### PR TITLE
Get into oanda submenu

### DIFF
--- a/openbb_terminal/forex/forex_controller.py
+++ b/openbb_terminal/forex/forex_controller.py
@@ -287,14 +287,14 @@ class ForexController(BaseController):
         """Enter Oanda menu."""
         from openbb_terminal.forex.oanda.oanda_controller import OandaController
 
-        if self.to_symbol and self.from_symbol:
+        # if self.to_symbol and self.from_symbol:
 
-            self.queue = self.load_class(
-                OandaController,
-                queue=self.queue,
-            )
-        else:
-            console.print("No currency pair data is loaded. Use 'load' to load data.\n")
+        self.queue = self.load_class(
+            OandaController,
+            queue=self.queue,
+        )
+        # else:
+        #     console.print("No currency pair data is loaded. Use 'load' to load data.\n")
 
     @log_start_end(log=logger)
     def call_ta(self, _):

--- a/openbb_terminal/forex/forex_helper.py
+++ b/openbb_terminal/forex/forex_helper.py
@@ -19,6 +19,7 @@ from openbb_terminal.config_terminal import theme
 FOREX_SOURCES: Dict = {
     "yf": "YahooFinance",
     "av": "AlphaAdvantage",
+    "oanda": "Oanda",
 }
 
 SOURCES_INTERVALS: Dict = {

--- a/openbb_terminal/forex/oanda/oanda_controller.py
+++ b/openbb_terminal/forex/oanda/oanda_controller.py
@@ -56,7 +56,7 @@ class OandaController(BaseController):
 
         self.from_symbol = ""
         self.to_symbol = ""
-        self.source = "Oanda"
+        self.source = "oanda"
         self.instrument: Union[str, None] = None
 
         if session and obbff.USE_PROMPT_TOOLKIT:

--- a/openbb_terminal/keys_controller.py
+++ b/openbb_terminal/keys_controller.py
@@ -1260,7 +1260,7 @@ class KeysController(BaseController):
             help="token",
         )
         parser.add_argument(
-            "-t",
+            "-at",
             "--account_type",
             type=str,
             dest="account_type",


### PR DESCRIPTION
# Description

- [ ] Summary of the change / bug fix.

Comment-out not needed checks for `to` and `from` currency.
Add `oanda` forex source in dictionary.

- [ ] Link # issue, if applicable.

Fix #1608

- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 

Can not login using Oanda valid info.

- [ ] List any dependencies that are required for this change.

None.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 

Insert proper environment variables, run terminal in debug mode, and use forex/oanda menu

* Provide instructions so we can reproduce.

Try set the account type using `-t`. Now it's renamed to `-at` that stands for account type

* Please also list any relevant details for your test configuration.

Working Oanda account.


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).

No tests, as this is very simple fix, and I'm not sure, if you follow with my reasoning.

- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).

Again, it's basic. Enables only login.


# Others
- [ ] I have performed a self-review of my own code.

No.
- [ ] I have commented my code, particularly in hard-to-understand areas.

No. I have commented out, in my opinion, not needed part of checking for valid currency pair **before** entering Oanda submenu

- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.

Overkill for simple fix, but I'm taking this into consideration ;)

- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
