### PR TITLE
Shorten CI Time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,17 +253,6 @@ jobs:
           conda list
           pip list
 
-      - name: Run linter (Bash)
-        shell: bash -l {0}
-        run: |
-          pip install pylint==2.12.2
-          pylint discordbot openbb_terminal terminal.py tests
-
-      - name: Run MyPy (Bash)
-        if: runner.os != 'Windows'
-        shell: bash -l {0}
-        run: mypy --ignore-missing-imports --exclude '/setup\.py$' .
-
       - name: Run tests (Bash)
         shell: bash -l {0}
         run: pytest tests/ -m "not bots and not linux"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
           pylint terminal.py openbb_terminal bots tests
   test:
     name: Base Tests - Ubuntu-latest - Python 3.9
-    needs: linting
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:


### PR DESCRIPTION
# Description

- Remove second lintings in further tests to shorten run time.
- Run general linting concurrently with base tests


# How has this been tested?

Ran tests with new setup.


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
