### PR TITLE
Fix ETF screener #1704

### DIFF
--- a/openbb_terminal/etf/screener/screener_model.py
+++ b/openbb_terminal/etf/screener/screener_model.py
@@ -37,8 +37,10 @@ def etf_screener(preset: str):
     )
 
     cf = configparser.ConfigParser()
-    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "presets", preset + ".ini")
-    
+    path = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "presets", preset + ".ini"
+    )
+
     cf.read(path)
     cols = cf.sections()
 

--- a/openbb_terminal/etf/screener/screener_model.py
+++ b/openbb_terminal/etf/screener/screener_model.py
@@ -37,8 +37,9 @@ def etf_screener(preset: str):
     )
 
     cf = configparser.ConfigParser()
-    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "presets/")
-    cf.read(path + preset)
+    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "presets", preset + ".ini")
+    
+    cf.read(path)
     cols = cf.sections()
 
     for col in cols:


### PR DESCRIPTION
There was an issue in reading the `.ini` because the `.ini` was never added to the path this made it so that the results obtained where always the same and thus there was no filtering capability.

Fixes #1704. @deeleeramone 