### PR TITLE
crypto pred mc command number arg error fix

### DIFF
--- a/openbb_terminal/cryptocurrency/prediction_techniques/pred_controller.py
+++ b/openbb_terminal/cryptocurrency/prediction_techniques/pred_controller.py
@@ -682,6 +682,7 @@ class PredictionTechniquesController(CryptoBaseController):
             help="Number of simulations to perform",
             dest="n_sims",
             default=100,
+            type=check_positive,
         )
         parser.add_argument(
             "--dist",


### PR DESCRIPTION
#1756 issue fix
In case of stock pred mc command -n arg has type casting by check_positive, but crpto pred mc is not.
So I added it and confirmed issue's error is resolved.