### PR TITLE
controller start set in datetime when load data from iex source

### DIFF
--- a/openbb_terminal/parent_classes.py
+++ b/openbb_terminal/parent_classes.py
@@ -545,7 +545,7 @@ class StockBaseController(BaseController, metaclass=ABCMeta):
                     self.suffix = ""
 
                 if ns_parser.source == "iex":
-                    self.start = self.stock.index[0].strftime("%Y-%m-%d")
+                    self.start = self.stock.index[0].to_pydatetime()
                 else:
                     self.start = ns_parser.start
                 self.interval = f"{ns_parser.interval}min"


### PR DESCRIPTION
#1729 fix
self.stock.index has pandas datetime and it can be changed to native datetime using to_pydatetime().
becuase of self.start.strftime('%Y-%m-%d'), controller.start must to be set in datetime not str. So I fixed it and confirmed issue's error is resolved.