### PR TITLE
fix coindix api call error

### DIFF
--- a/openbb_terminal/cryptocurrency/defi/coindix_model.py
+++ b/openbb_terminal/cryptocurrency/defi/coindix_model.py
@@ -8,6 +8,7 @@ import pandas as pd
 import requests
 
 from openbb_terminal.decorators import log_start_end
+from openbb_terminal.helper_funcs import get_user_agent
 
 logger = logging.getLogger(__name__)
 
@@ -142,8 +143,9 @@ def get_defi_vaults(
         Top 100 DeFi Vaults for given chain/protocol sorted by APY.
     """
 
+    headers={"User-Agent":get_user_agent()}
     params = _prepare_params(chain=chain, protocol=protocol, kind=kind)
-    response = requests.get("https://apiv2.coindix.com/search", params=params)
+    response = requests.get("https://apiv2.coindix.com/search", params=params, headers=headers, verify=False)
     if not 200 <= response.status_code < 300:
         raise Exception(f"Coindix api exception: {response.text}")
 

--- a/openbb_terminal/cryptocurrency/defi/coindix_model.py
+++ b/openbb_terminal/cryptocurrency/defi/coindix_model.py
@@ -143,9 +143,11 @@ def get_defi_vaults(
         Top 100 DeFi Vaults for given chain/protocol sorted by APY.
     """
 
-    headers={"User-Agent":get_user_agent()}
+    headers = {"User-Agent": get_user_agent()}
     params = _prepare_params(chain=chain, protocol=protocol, kind=kind)
-    response = requests.get("https://apiv2.coindix.com/search", params=params, headers=headers, verify=False)
+    response = requests.get(
+        "https://apiv2.coindix.com/search", headers=headers, params=params, verify=False
+    )
     if not 200 <= response.status_code < 300:
         raise Exception(f"Coindix api exception: {response.text}")
 


### PR DESCRIPTION
#1784 fix
Coindix api call has 2 errors. first is SSL error in the issue's screenshot and second is Coindix check user-agent to block python requests(with 403 Forbidden code).
So I changed SSL verify option and user-agent in headers.
SSL error occurred by coindix ssl certificate that only certified api.coindix.com not apiv2.coindix.com. you can check it in your browser.