### PR TITLE
Fix crypto loading for Binance

### DIFF
--- a/openbb_terminal/cryptocurrency/cryptocurrency_helpers.py
+++ b/openbb_terminal/cryptocurrency/cryptocurrency_helpers.py
@@ -896,7 +896,7 @@ def load_ta_data(
 
         symbol_binance = coin_map_df["Binance"]
 
-        pair = symbol_binance + currency.upper()
+        pair = symbol_binance.upper() + currency.upper()
 
         if check_valid_binance_str(pair):
             # console.print(f"{symbol_binance} loaded vs {currency.upper()}")


### PR DESCRIPTION
# Description

In #1794, it is reported that trying to load cryptos with Binance using small caps letters (e.g. btc vs BTC) for the crypto name, generates an error. This is due to Binance not accepting small caps letters for crypto names. This PR fixes that.


# How has this been tested?

`$> crypto`
`$ crypto> load -c btc --source bin


# Checklist:

- [X] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [X] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [X] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [X] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [X] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
