### PR TITLE
Deprecate stocks/dps/volexch

### DIFF
--- a/openbb_terminal/stocks/dark_pool_shorts/dps_controller.py
+++ b/openbb_terminal/stocks/dark_pool_shorts/dps_controller.py
@@ -51,7 +51,7 @@ class DarkPoolShortsController(StockBaseController):
         "dpotc",
         "ftd",
         "spos",
-        "volexch",
+        # "volexch",
     ]
     PATH = "/stocks/dps/"
 
@@ -103,10 +103,11 @@ class DarkPoolShortsController(StockBaseController):
 [src][Stockgrid][/src]
     spos           net short vs position
 [src][Quandl/Stockgrid][/src]
-    psi            price vs short interest volume
-[src][NYSE][/src]
-    volexch        short volume for ARCA,Amex,Chicago,NYSE and national exchanges[/cmds]
+    psi            price vs short interest volume[/cmds]
 {has_ticker_end}"""
+        # Commented out from docstring 5/19:
+        # [src][NYSE][/src]
+        #     volexch        short volume for ARCA,Amex,Chicago,NYSE and national exchanges
         console.print(text=help_text, menu="Stocks - Dark Pool and Short data")
 
     @log_start_end(log=logger)
@@ -515,59 +516,60 @@ class DarkPoolShortsController(StockBaseController):
             else:
                 console.print("No ticker loaded.\n")
 
-    @log_start_end(log=logger)
-    def call_volexch(self, other_args: List[str]):
-        """Process volexch command"""
-        parser = argparse.ArgumentParser(
-            prog="volexch",
-            add_help=False,
-            description="Displays short volume based on exchange.",
-        )
-        parser.add_argument(
-            "-r",
-            "--raw",
-            help="Display raw data",
-            dest="raw",
-            action="store_true",
-            default=False,
-        )
-        parser.add_argument(
-            "-s",
-            "--sort",
-            help="Column to sort by",
-            dest="sort",
-            type=str,
-            default="",
-            choices=["", "NetShort", "Date", "TotalVolume", "PctShort"],
-        )
-        parser.add_argument(
-            "-a",
-            "--asc",
-            help="Sort in ascending order",
-            dest="asc",
-            action="store_true",
-            default=False,
-        )
-        parser.add_argument(
-            "-p",
-            "--plotly",
-            help="Display plot using interactive plotly.",
-            dest="plotly",
-            action="store_false",
-            default=True,
-        )
-        ns_parser = parse_known_args_and_warn(
-            parser, other_args, export_allowed=EXPORT_BOTH_RAW_DATA_AND_FIGURES
-        )
-        if ns_parser:
-            if self.ticker:
-                nyse_view.display_short_by_exchange(
-                    ticker=self.ticker,
-                    raw=ns_parser.raw,
-                    sort=ns_parser.sort,
-                    asc=ns_parser.asc,
-                    mpl=ns_parser.plotly,
-                    export=ns_parser.export,
-                )
-            else:
-                console.print("No ticker loaded.  Use `load ticker` first.")
+    # TODO: Load back in once data is properly stored
+    # @log_start_end(log=logger)
+    # def call_volexch(self, other_args: List[str]):
+    #     """Process volexch command"""
+    #     parser = argparse.ArgumentParser(
+    #         prog="volexch",
+    #         add_help=False,
+    #         description="Displays short volume based on exchange.",
+    #     )
+    #     parser.add_argument(
+    #         "-r",
+    #         "--raw",
+    #         help="Display raw data",
+    #         dest="raw",
+    #         action="store_true",
+    #         default=False,
+    #     )
+    #     parser.add_argument(
+    #         "-s",
+    #         "--sort",
+    #         help="Column to sort by",
+    #         dest="sort",
+    #         type=str,
+    #         default="",
+    #         choices=["", "NetShort", "Date", "TotalVolume", "PctShort"],
+    #     )
+    #     parser.add_argument(
+    #         "-a",
+    #         "--asc",
+    #         help="Sort in ascending order",
+    #         dest="asc",
+    #         action="store_true",
+    #         default=False,
+    #     )
+    #     parser.add_argument(
+    #         "-p",
+    #         "--plotly",
+    #         help="Display plot using interactive plotly.",
+    #         dest="plotly",
+    #         action="store_false",
+    #         default=True,
+    #     )
+    #     ns_parser = parse_known_args_and_warn(
+    #         parser, other_args, export_allowed=EXPORT_BOTH_RAW_DATA_AND_FIGURES
+    #     )
+    #     if ns_parser:
+    #         if self.ticker:
+    #             nyse_view.display_short_by_exchange(
+    #                 ticker=self.ticker,
+    #                 raw=ns_parser.raw,
+    #                 sort=ns_parser.sort,
+    #                 asc=ns_parser.asc,
+    #                 mpl=ns_parser.plotly,
+    #                 export=ns_parser.export,
+    #             )
+    #         else:
+    #             console.print("No ticker loaded.  Use `load ticker` first.")

--- a/openbb_terminal/stocks/dark_pool_shorts/dps_controller.py
+++ b/openbb_terminal/stocks/dark_pool_shorts/dps_controller.py
@@ -24,7 +24,6 @@ from openbb_terminal.parent_classes import StockBaseController
 from openbb_terminal.rich_config import console
 from openbb_terminal.stocks.dark_pool_shorts import (
     finra_view,
-    nyse_view,
     quandl_view,
     sec_view,
     shortinterest_view,

--- a/tests/openbb_terminal/stocks/dark_pool_shorts/test_dps_controller.py
+++ b/tests/openbb_terminal/stocks/dark_pool_shorts/test_dps_controller.py
@@ -389,25 +389,25 @@ def test_call_func_expect_queue(expected_queue, queue, func):
                 export="csv",
             ),
         ),
-        (
-            "call_volexch",
-            "nyse_view.display_short_by_exchange",
-            [
-                "--raw",
-                "--sort=Date",
-                "--asc",
-                "--mpl",
-                "--export=csv",
-            ],
-            dict(
-                ticker="MOCK_TICKER",
-                raw=True,
-                sort="Date",
-                asc=True,
-                mpl=True,
-                export="csv",
-            ),
-        ),
+        # (
+        #     "call_volexch",
+        #     "nyse_view.display_short_by_exchange",
+        #     [
+        #         "--raw",
+        #         "--sort=Date",
+        #         "--asc",
+        #         "--mpl",
+        #         "--export=csv",
+        #     ],
+        #     dict(
+        #         ticker="MOCK_TICKER",
+        #         raw=True,
+        #         sort="Date",
+        #         asc=True,
+        #         mpl=True,
+        #         export="csv",
+        #     ),
+        #),
     ],
 )
 def test_call_func(tested_func, mocked_func, other_args, called_with, mocker):
@@ -445,7 +445,7 @@ def test_call_func(tested_func, mocked_func, other_args, called_with, mocker):
         "call_dpotc",
         "call_ftd",
         "call_spos",
-        "call_volexch",
+#        "call_volexch",
     ],
 )
 def test_call_func_no_parser(func, mocker):
@@ -473,7 +473,7 @@ def test_call_func_no_parser(func, mocker):
         "call_ftd",
         "call_spos",
         "call_psi",
-        "call_volexch",
+#        "call_volexch",
     ],
 )
 def test_call_func_no_ticker(func, mocker):

--- a/tests/openbb_terminal/stocks/dark_pool_shorts/test_dps_controller.py
+++ b/tests/openbb_terminal/stocks/dark_pool_shorts/test_dps_controller.py
@@ -407,7 +407,7 @@ def test_call_func_expect_queue(expected_queue, queue, func):
         #         mpl=True,
         #         export="csv",
         #     ),
-        #),
+        # ),
     ],
 )
 def test_call_func(tested_func, mocked_func, other_args, called_with, mocker):
@@ -445,7 +445,7 @@ def test_call_func(tested_func, mocked_func, other_args, called_with, mocker):
         "call_dpotc",
         "call_ftd",
         "call_spos",
-#        "call_volexch",
+        #        "call_volexch",
     ],
 )
 def test_call_func_no_parser(func, mocker):
@@ -473,7 +473,7 @@ def test_call_func_no_parser(func, mocker):
         "call_ftd",
         "call_spos",
         "call_psi",
-#        "call_volexch",
+        #        "call_volexch",
     ],
 )
 def test_call_func_no_ticker(func, mocker):

--- a/tests/openbb_terminal/stocks/dark_pool_shorts/txt/test_dps_controller/test_print_help.txt
+++ b/tests/openbb_terminal/stocks/dark_pool_shorts/txt/test_dps_controller/test_print_help.txt
@@ -23,6 +23,4 @@ Ticker: TSLA
     spos           net short vs position
 [Quandl/Stockgrid]
     psi            price vs short interest volume
-[NYSE]
-    volexch        short volume for ARCA,Amex,Chicago,NYSE and national exchanges
 

--- a/website/data/menu/main.yml
+++ b/website/data/menu/main.yml
@@ -121,8 +121,6 @@ main:
                 ref: "/terminal/stocks/dark_pool_shorts/spos"
               - name: psi
                 ref: "/terminal/stocks/dark_pool_shorts/psi"
-              - name: volexch
-                ref: "/terminal/stocks/dark_pool_shorts/volexch"
           - name: screener
             ref: "/terminal/stocks/screener"
             sub:


### PR DESCRIPTION
As pointed out in #1836, the volexch function is broken.

The reason for the breaking is that the data was stored on my personal mongodb account which has limited free tier storage.  I have simply run out of storage to keep updating it.

This PR deprecates that function by commenting it out.  This can be added back when a better storage option is found.