### PR TITLE
Allow for reports an easy exit when something fails and other fixes

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -612,7 +612,7 @@ def lambda_long_number_format(num, round_decimal=3) -> str:
         return f"{num_str} {' KMBTP'[magnitude]}".strip()
     if isinstance(num, int):
         num = str(num)
-    if num.lstrip("-").isdigit():
+    if isinstance(num, str) and num.lstrip("-").isdigit():
         num = int(num)
         num /= 1.0
         magnitude = 0

--- a/openbb_terminal/reports/equity.ipynb
+++ b/openbb_terminal/reports/equity.ipynb
@@ -26,7 +26,7 @@
     "import matplotlib_inline.backend_inline\n",
     "\n",
     "# import sys\n",
-    "# sys.path.append('../../../')\n",
+    "# sys.path.append('../../')\n",
     "\n",
     "from openbb_terminal import api as openbb\n",
     "from openbb_terminal.helper_classes import TerminalStyle\n",
@@ -79,6 +79,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a441ddbc-d75b-4a18-84d4-e01b677674d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \".\" in ticker:\n",
+    "    import sys\n",
+    "    sys.exit(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "1be26dae-cafe-4a22-80aa-eff296fc1a9b",
    "metadata": {},
    "outputs": [],
@@ -101,9 +113,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overview = openbb.stocks.fa.models.yahoo_finance.get_info(ticker=ticker).transpose()[\n",
-    "    \"Long business summary\"\n",
-    "][0]\n",
+    "info = openbb.stocks.fa.models.yahoo_finance.get_info(ticker=ticker).transpose()\n",
+    "\n",
+    "if info[\"Long business summary\"][0] != \"NA\":\n",
+    "    overview = info[\"Long business summary\"][0]\n",
+    "else:\n",
+    "    overview = info[\"Long name\"][0]\n",
     "overview"
    ]
   },

--- a/openbb_terminal/reports/reports_controller.py
+++ b/openbb_terminal/reports/reports_controller.py
@@ -203,26 +203,29 @@ class ReportController(BaseController):
 
             d_report_params["report_name"] = notebook_output
 
-            pm.execute_notebook(
+            result = pm.execute_notebook(
                 notebook_template + ".ipynb",
                 notebook_output + ".ipynb",
                 parameters=d_report_params,
                 kernel_name="python3",
             )
 
-            if obbff.OPEN_REPORT_AS_HTML:
-                report_output_path = os.path.join(
-                    os.path.abspath(os.path.join(".")), notebook_output + ".html"
-                )
-                print(report_output_path)
-                webbrowser.open(f"file://{report_output_path}")
+            if not result["metadata"]["papermill"]["exception"]:
+                if obbff.OPEN_REPORT_AS_HTML:
+                    report_output_path = os.path.join(
+                        os.path.abspath(os.path.join(".")), notebook_output + ".html"
+                    )
+                    print(report_output_path)
+                    webbrowser.open(f"file://{report_output_path}")
 
-            console.print("")
-            console.print(
-                "Exported: ",
-                os.path.join(
-                    os.path.abspath(os.path.join(".")), notebook_output + ".html"
-                ),
-                "\n",
-            )
+                console.print("")
+                console.print(
+                    "Exported: ",
+                    os.path.join(
+                        os.path.abspath(os.path.join(".")), notebook_output + ".html"
+                    ),
+                    "\n",
+                )
+            else:
+                console.print("[red]\nParameter provided is not valid.\n[/red]")
         return self.queue

--- a/openbb_terminal/stocks/due_diligence/marketwatch_model.py
+++ b/openbb_terminal/stocks/due_diligence/marketwatch_model.py
@@ -51,20 +51,22 @@ def get_sec_filings(ticker: str) -> pd.DataFrame:
 
         # If header has been processed and dataframe created ready to populate the SEC information
         if b_ready_to_process_info:
-            l_financials_info = [a_financials[2]]
-            l_financials_info.extend(a_financials[5:-1])
-            l_financials_info.append(financials_info.a["href"])
-            # Append data values to financials
-            df_financials.loc[len(df_financials.index)] = l_financials_info  # type: ignore
+            if len(a_financials) > 1:
+                l_financials_info = [a_financials[2]]
+                l_financials_info.extend(a_financials[5:-1])
+                l_financials_info.append(financials_info.a["href"])
+                # Append data values to financials
+                df_financials.loc[len(df_financials.index)] = l_financials_info  # type: ignore
 
         if "Filing Date" in a_financials:
-            l_financials_header = [a_financials[2]]
-            l_financials_header.extend(a_financials[5:-1])
-            l_financials_header.append("Link")
+            if len(a_financials) > 1:
+                l_financials_header = [a_financials[2]]
+                l_financials_header.extend(a_financials[5:-1])
+                l_financials_header.append("Link")
 
-            df_financials = pd.DataFrame(columns=l_financials_header)
-            df_financials.set_index("Filing Date")
-            b_ready_to_process_info = True
+                df_financials = pd.DataFrame(columns=l_financials_header)
+                df_financials.set_index("Filing Date")
+                b_ready_to_process_info = True
 
     # Set Filing Date as index
     df_financials = df_financials.set_index("Filing Date")  # type: ignore


### PR DESCRIPTION
We can now early exit a notebook report when an input is not valid. And this logic can all be handled within terminal.
<img width="1304" alt="Screenshot 2022-05-27 at 01 10 06" src="https://user-images.githubusercontent.com/25267873/170603803-0034ba81-9013-4482-be3f-85c4fcf4a9a7.png">

This is how we can do it.
<img width="690" alt="Screenshot 2022-05-27 at 01 13 52" src="https://user-images.githubusercontent.com/25267873/170603826-1a001926-ed53-48ad-abb8-166bfb3b36c5.png">

Extra: Fixes `stocks/dd/sec` command and also `openbb.stocks.fa.models.yahoo_finance.get_info`.