### PR TITLE
Fix a broken link to the load page

### DIFF
--- a/website/content/terminal/stocks/quote/_index.md
+++ b/website/content/terminal/stocks/quote/_index.md
@@ -2,7 +2,7 @@
 usage: quote [-t S_TICKER] [-p] [-h]
 ```
 
-Retrieves a current quote from the currently [loaded ticker](https://openbb-finance.github.io/OpenBBTerminal/stocks/load/). To view a quote from a different symbol than what is currently loaded, add the '-t' argument to the command string.
+Retrieves a current quote from the currently [loaded ticker](https://openbb-finance.github.io/OpenBBTerminal/terminal/stocks/load/). To view a quote from a different symbol than what is currently loaded, add the '-t' argument to the command string.
 
 ```
 optional arguments:


### PR DESCRIPTION
# Description

The current link for the loaded stocks page is invalid and goes to a 404 page. This is because the URL is incorrect.

# How has this been tested?

I have visited the URL https://openbb-finance.github.io/OpenBBTerminal/terminal/stocks/load/ and confirmed it does not 404.

# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
