### PR TITLE
Make documentation link front and center in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   </a>
 
   <h3 align="center">OpenBB Terminal 🚀</h3>
+  <h4 align="center">Documentation can be found at: https://openbb-finance.github.io/OpenBBTerminal/ </h4>
   <p align="center">Click on the GIF below for a DEMO of the terminal.</p>
 
 <p align="center">


### PR DESCRIPTION
I think we should make the Hugo documentation link more clear in the README

This could also be a hyperlink, but I just did this as an idea.

<img width="688" alt="Screen Shot 2022-06-03 at 11 37 18 AM" src="https://user-images.githubusercontent.com/18151143/171893606-21cf1e56-96ea-463a-abea-7c5eafc1d67d.png">