### PR TITLE
Add on feature flag for 'smart' loading

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -43,6 +43,7 @@ en:
   defined, test unsuccessful: defined, test unsuccessful
   featflags/_info_: Feature flags through environment variables
   featflags/logcollection: allow logs to be sent to help OpenBB team
+  featflags/retryload: retry misspelled commands with load first
   featflags/tab: use tabulate to print dataframes
   featflags/cls: clear console after each command
   featflags/color: use coloring features

--- a/openbb_terminal/featflags_controller.py
+++ b/openbb_terminal/featflags_controller.py
@@ -27,6 +27,7 @@ class FeatureFlagsController(BaseController):
 
     CHOICES_COMMANDS: List[str] = [
         "logcollection",
+        "retryload",
         "tab",
         "cls",
         "color",
@@ -59,6 +60,7 @@ class FeatureFlagsController(BaseController):
         mt.add_info("_info_")
         mt.add_raw("\n")
         mt.add_setting("logcollection", obbff.LOG_COLLECTION)
+        mt.add_setting("retryload", obbff.RETRY_WITH_LOAD)
         mt.add_setting("tab", obbff.USE_TABULATE_DF)
         mt.add_setting("cls", obbff.USE_CLEAR_AFTER_CMD)
         mt.add_setting("color", obbff.USE_COLOR)
@@ -82,6 +84,12 @@ class FeatureFlagsController(BaseController):
         """Process logcollection command"""
         obbff.LOG_COLLECTION = not obbff.LOG_COLLECTION
         set_key(obbff.ENV_FILE, "OPENBB_LOG_COLLECTION", str(obbff.LOG_COLLECTION))
+        console.print("")
+
+    def call_retryload(self, _):
+        """Process retryload command"""
+        obbff.RETRY_WITH_LOAD = not obbff.RETRY_WITH_LOAD
+        set_key(obbff.ENV_FILE, "OPENBB_RETRY_WITH_LOAD", str(obbff.RETRY_WITH_LOAD))
         console.print("")
 
     @log_start_end(log=logger)

--- a/openbb_terminal/feature_flags.py
+++ b/openbb_terminal/feature_flags.py
@@ -20,6 +20,9 @@ i18n.set("filename_format", "{locale}.{format}")
 if ENV_FILE.is_file():
     load_dotenv(dotenv_path=ENV_FILE, override=True)
 
+# Retry unknown commands with `load`
+RETRY_WITH_LOAD = strtobool(os.getenv("OPENBB_RETRY_WITH_LOAD", "False"))
+
 # Use tabulate to print dataframes
 USE_TABULATE_DF = strtobool(os.getenv("OPENBB_USE_TABULATE_DF", "True"))
 

--- a/openbb_terminal/parent_classes.py
+++ b/openbb_terminal/parent_classes.py
@@ -484,7 +484,7 @@ class BaseController(metaclass=ABCMeta):
                     console.print(f" Replacing by '{an_input}'.")
                     self.queue.insert(0, an_input)
                 else:
-                    if self.TRY_RELOAD:
+                    if self.TRY_RELOAD and obbff.RETRY_WITH_LOAD:
                         console.print(f"Trying `load {an_input}`")
                         self.queue.insert(0, "load " + an_input)
                     console.print("")


### PR DESCRIPTION
As per a request on discord, I am hiding the attempt at smart loading (ie user can do `/stocks/aapl` instead of `/stocks/load aapl)  behind a new feature flag.

This allows users to not have to see `trying load canlde` when they mistype candle if they want.