### PR TITLE
Clarify values by re-ordering rows in enterprise value report

### DIFF
--- a/openbb_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_view.py
@@ -104,6 +104,19 @@ def display_enterprise(
     """
     df_fa = fmp_model.get_enterprise(ticker, number, quarterly)
     df_fa = df_fa[df_fa.columns[::-1]]
+
+    # Re-order the returned columns so they are in a more logical ordering
+    df_fa = df_fa.reindex(
+        [
+            "Symbol",
+            "Stock price",
+            "Number of shares",
+            "Market capitalization",
+            "Add total debt",
+            "Minus cash and cash equivalents",
+            "Enterprise value",
+        ]
+    )
     if df_fa.empty:
         console.print("[red]No data available[/red]\n")
     else:

--- a/tests/openbb_terminal/stocks/fundamental_analysis/financial_modeling_prep/txt/test_fmp_view/test_check_output[False-display_enterprise-kwargs_dict2].txt
+++ b/tests/openbb_terminal/stocks/fundamental_analysis/financial_modeling_prep/txt/test_fmp_view/test_check_output[False-display_enterprise-kwargs_dict2].txt
@@ -3,6 +3,6 @@ Symbol                                  PM         PM         PM         PM     
 Stock price                        107.940     74.480     84.330     79.650    103.520
 Number of shares                   1.552 B    1.555 B    1.555 B    1.557 B    1.557 B
 Market capitalization            167.523 B  115.816 B  131.133 B  124.015 B  161.181 B
-Minus cash and cash equivalents    8.447 B    6.593 B    6.861 B    7.280 B    4.496 B
 Add total debt                    34.339 B   31.759 B   31.045 B   31.536 B   27.806 B
+Minus cash and cash equivalents    8.447 B    6.593 B    6.861 B    7.280 B    4.496 B
 Enterprise value                 193.415 B  140.982 B  155.317 B  148.271 B  184.491 B

--- a/tests/openbb_terminal/stocks/fundamental_analysis/financial_modeling_prep/txt/test_fmp_view/test_check_output[True-display_enterprise-kwargs_dict2].txt
+++ b/tests/openbb_terminal/stocks/fundamental_analysis/financial_modeling_prep/txt/test_fmp_view/test_check_output[True-display_enterprise-kwargs_dict2].txt
@@ -3,6 +3,6 @@ Symbol                                  PM         PM         PM         PM     
 Stock price                        107.940     74.480     84.330     79.650    103.520
 Number of shares                   1.552 B    1.555 B    1.555 B    1.557 B    1.557 B
 Market capitalization            167.523 B  115.816 B  131.133 B  124.015 B  161.181 B
-Minus cash and cash equivalents    8.447 B    6.593 B    6.861 B    7.280 B    4.496 B
 Add total debt                    34.339 B   31.759 B   31.045 B   31.536 B   27.806 B
+Minus cash and cash equivalents    8.447 B    6.593 B    6.861 B    7.280 B    4.496 B
 Enterprise value                 193.415 B  140.982 B  155.317 B  148.271 B  184.491 B


### PR DESCRIPTION
# Description

This PR re-organizes the rows in the enterprise value report so that they are more logically presented. They previously were presented directly in the order as the data provider returned them, which wasn't great for human consumption. This meant that tickers were down at the bottom of the list and the values that sum to compute EV were not in any reasonable order and the EV itself was intermixed with other numbers, making it hard to identify.

This PR puts the stock ticker and price first, then it puts all the rows below it that sum to be the enterprise value, with the EV at the bottom.


![image](https://user-images.githubusercontent.com/69191/172158695-9a667329-34d2-4fc8-b81f-9b03117ed131.png)

The command is reached with `/stocks/fa/fmp/enterprise` while a ticker has been loaded.

# How has this been tested?

I've tested the change locally and ran it several time with different tickers. The `pre-commit` tests all passed as well.

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
