### PR TITLE
Add option to calculate correlation based on returns

### DIFF
--- a/openbb_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/openbb_terminal/stocks/comparison_analysis/ca_controller.py
@@ -566,9 +566,9 @@ class ComparisonAnalysisController(BaseController):
             action="store",
             dest="type_candle",
             type=str,
-            choices=["o", "h", "l", "c", "a"],
+            choices=["o", "h", "l", "c", "a", "r"],
             default="a",  # in case it's adjusted close
-            help="Candle data to use: o-open, h-high, l-low, c-close, a-adjusted close.",
+            help="Candle data to use: o-open, h-high, l-low, c-close, a-adjusted close, r-returns.",
         )
         parser.add_argument(
             "-s",

--- a/openbb_terminal/stocks/comparison_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/comparison_analysis/yahoo_finance_model.py
@@ -54,17 +54,16 @@ def get_historical(
     use_returns = False
     if candle_type.lower() == "r":
         use_returns = True
-        candle_type = "C"
+        candle_type = "c"
 
     from openbb_terminal.rich_config import console
     from openbb_terminal.helper_funcs import (
-    export_data,
-    plot_autoscale,
-    is_valid_axes_count,
-    print_rich_table,
-)
+        export_data,
+        plot_autoscale,
+        is_valid_axes_count,
+        print_rich_table,
+    )
 
-    console.print(d_candle_types)
     # To avoid having to recursively append, just do a single yfinance call.  This will give dataframe
     # where all tickers are columns.
     similar_tickers_dataframe = yf.download(
@@ -77,20 +76,23 @@ def get_historical(
         else similar_tickers_dataframe[similar_tickers]
     )
 
-    print_rich_table(
-            returnable,
-            headers=[x.title().upper() for x in returnable.columns],
-            show_index=True,
-    )
+    if use_returns:
+        console.print("Using returns")
+        print_rich_table(
+                returnable,
+                headers=[x.title().upper() for x in returnable.columns],
+                show_index=True,
+        )
 
-    shifted = returnable.shift(1)[1:]
-    returnable = returnable.div(shifted)-1
+        shifted = returnable.shift(1)[1:]
+        returnable = returnable.div(shifted)-1
 
-    print_rich_table(
-            returnable,
-            headers=[x.title().upper() for x in returnable.columns],
-            show_index=True,
-    )
+        print_rich_table(
+                returnable,
+                headers=[x.title().upper() for x in returnable.columns],
+                show_index=True,
+        )
+
     return returnable
 
 

--- a/openbb_terminal/stocks/comparison_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/comparison_analysis/yahoo_finance_model.py
@@ -50,16 +50,48 @@ def get_historical(
     pd.DataFrame
         Dataframe containing candle type variable for each ticker
     """
+    
+    use_returns = False
+    if candle_type.lower() == "r":
+        use_returns = True
+        candle_type = "C"
+
+    from openbb_terminal.rich_config import console
+    from openbb_terminal.helper_funcs import (
+    export_data,
+    plot_autoscale,
+    is_valid_axes_count,
+    print_rich_table,
+)
+
+    console.print(d_candle_types)
     # To avoid having to recursively append, just do a single yfinance call.  This will give dataframe
     # where all tickers are columns.
     similar_tickers_dataframe = yf.download(
         similar_tickers, start=start, progress=False, threads=False
     )[d_candle_types[candle_type]]
-    return (
+
+    returnable = (
         similar_tickers_dataframe
         if similar_tickers_dataframe.empty
         else similar_tickers_dataframe[similar_tickers]
     )
+
+    print_rich_table(
+            returnable,
+            headers=[x.title().upper() for x in returnable.columns],
+            show_index=True,
+    )
+
+    shifted = returnable.shift(1)[1:]
+    returnable = returnable.div(shifted)-1
+
+    print_rich_table(
+            returnable,
+            headers=[x.title().upper() for x in returnable.columns],
+            show_index=True,
+    )
+    return returnable
 
 
 @log_start_end(log=logger)

--- a/openbb_terminal/stocks/comparison_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/comparison_analysis/yahoo_finance_view.py
@@ -200,9 +200,6 @@ def display_correlation(
 
     df_similar = df_similar.dropna(axis=1, how="all")
 
-    mask = np.zeros((df_similar.shape[1], df_similar.shape[1]), dtype=bool)
-    mask[np.triu_indices(len(mask))] = True
-
     # This plot has 1 axis
     if not external_axes:
         _, ax = plt.subplots(figsize=plot_autoscale(), dpi=PLOT_DPI)
@@ -211,8 +208,10 @@ def display_correlation(
     else:
         return
 
+    correlations = df_similar.corr()
+    console.print("Correlations: %s" % correlations)
     sns.heatmap(
-        df_similar.corr(),
+        correlations,
         cbar_kws={"ticks": [-1.0, -0.5, 0.0, 0.5, 1.0]},
         cmap="RdYlGn",
         linewidths=1,
@@ -220,7 +219,6 @@ def display_correlation(
         annot_kws={"fontsize": 10},
         vmin=-1,
         vmax=1,
-        mask=mask,
         ax=ax,
     )
     ax.set_title(f"Correlation Heatmap of similar companies from {start}")

--- a/openbb_terminal/stocks/comparison_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/comparison_analysis/yahoo_finance_view.py
@@ -181,13 +181,14 @@ def display_correlation(
     start : str, optional
         Start date of comparison, by default 1 year ago
     candle_type : str, optional
-        OHLCA column to use, by default "a" for Adjusted Close
+        OHLCA column to use for candles or R for returns, by default "a" for Adjusted Close
     external_axes : Optional[List[plt.Axes]], optional
         External axes (1 axis is expected in the list), by default None
     export : str, optional
         Format to export correlation prices, by default ""
 
     """
+    
     df_similar = yahoo_finance_model.get_historical(similar_tickers, start, candle_type)
     df_similar = df_similar[similar_tickers]
 

--- a/openbb_terminal/stocks/comparison_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/comparison_analysis/yahoo_finance_view.py
@@ -35,6 +35,7 @@ d_candle_types = {
     "c": "Close",
     "a": "Adj Close",
     "v": "Volume",
+    "r": "Returns"
 }
 
 
@@ -56,7 +57,7 @@ def display_historical(
     start : str, optional
         Start date of comparison, by default 1 year ago
     candle_type : str, optional
-        OHLCA column to use, by default "a" for Adjusted Close
+        OHLCA column to use or R to use daily returns calculated from Adjusted Close, by default "a" for Adjusted Close
     normalize : bool, optional
         Boolean to normalize all stock prices using MinMax defaults True
     export : str, optional
@@ -65,6 +66,7 @@ def display_historical(
         External axes (1 axis is expected in the list), by default None
 
     """
+    console.print(candle_type)
     df_similar = yahoo_finance_model.get_historical(similar_tickers, start, candle_type)
     df_similar = df_similar[similar_tickers]
 


### PR DESCRIPTION
# Description

- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
