### PR TITLE
Match to USA if no exchange suffix is present

### DIFF
--- a/openbb_terminal/stocks/stocks_helper.py
+++ b/openbb_terminal/stocks/stocks_helper.py
@@ -43,7 +43,7 @@ INTERVALS = [1, 5, 15, 30, 60]
 SOURCES = ["yf", "av", "iex"]
 
 market_coverage_suffix = {
-    "USA": ["CBT", "CME", "NYB", "CMX", "NYM"],
+    "USA": ["CBT", "CME", "NYB", "CMX", "NYM", ""],
     "Argentina": ["BA"],
     "Austria": ["VI"],
     "Australia": ["AX"],


### PR DESCRIPTION
# Description

This PR enables filtering stock searches by US based exchanges.

The logic on line 213 defaults to USA if there is no exchange symbol present, so the market coverage suffix should use the same logic. This enables filtering by exchange to work correctly.

Without this PR:
![image](https://user-images.githubusercontent.com/69191/173376032-e92d8585-d83a-4be6-b7e2-9c54573b5928.png)


With this PR:
![image](https://user-images.githubusercontent.com/69191/173375882-29be4c29-cd33-418e-adbf-1faf84bb5b5a.png)


# How has this been tested?

I tried several `stocks search <ticker> -e USA` commands.

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
