### PR TITLE
Fixing future warnings bug by switching from append to concat.

### DIFF
--- a/openbb_terminal/stocks/dark_pool_shorts/finra_model.py
+++ b/openbb_terminal/stocks/dark_pool_shorts/finra_model.py
@@ -251,7 +251,8 @@ def getATSdata(num_tickers_to_filter: int, tier_ats: str) -> Tuple[pd.DataFrame,
             df_ats_week["weekStartDate"] = d_week["weekStartDate"]
 
             if not df_ats_week.empty:
-                df_ats = df_ats.append(df_ats_week, ignore_index=True)
+                # df_ats = df_ats.append(df_ats_week, ignore_index=True)
+                df_ats = pd.concat([df_ats, df_ats_week], ignore_index=True)
 
     df_ats = df_ats.sort_values("weekStartDate")
     df_ats["weekStartDateInt"] = pd.to_datetime(df_ats["weekStartDate"]).apply(
@@ -282,7 +283,7 @@ def getATSdata(num_tickers_to_filter: int, tier_ats: str) -> Tuple[pd.DataFrame,
                 ].values,
             )[0]
             d_ats_reg[symbol] = slope
-        except Exception:
+        except Exception:  # nosec B110
             pass
 
     return df_ats, d_ats_reg


### PR DESCRIPTION
# Description
Fixed #1886 by changing from append to concat to get rid of future warnings. Tested with:
`pytest tests/openbb_terminal/stocks/dark_pool_shorts/test_finra_model.py --rewrite-expected` 
This did not rewrite any files, so only modifying one file: finra_model.py

<img width="461" alt="Screen Shot 2022-06-13 at 6 55 38 PM" src="https://user-images.githubusercontent.com/53658028/173465999-510d6ee5-2495-4ed4-921f-b17d2c1a4294.png">

- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context. 
- [x] List any dependencies that are required for this change.

# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
