### PR TITLE
Fixed warnings bug which does not display data if there is an inf value data point

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -31,6 +31,7 @@ import pandas.io.formats.format
 import requests
 from screeninfo import get_monitors
 import yfinance as yf
+import numpy as np
 
 from openbb_terminal.rich_config import console
 from openbb_terminal import feature_flags as obbff
@@ -673,6 +674,10 @@ def lambda_clean_data_values_to_float(val: str) -> float:
 
 def lambda_int_or_round_float(x) -> str:
     """Format int or round float"""
+    # If the data is inf, -inf, or NaN then simply return '~' because it is either too
+    # large, too small, or we do not have data to display for it
+    if x in (np.inf, -np.inf, np.nan):
+        return " " + "~"
     if (x - int(x) < -sys.float_info.epsilon) or (x - int(x) > sys.float_info.epsilon):
         return " " + str(round(x, 2))
 


### PR DESCRIPTION
Fixes #1906
This bug stems from trying to calculate the Interest Coverage Ratio but the calculation return inf if it does not have the variables needed for the calculation, which  occurs if the website we are scraping the data from does not have certain data points. This PR addresses this by adding functionality to the `lambda_int_or_round_float` function by identifying if there is an 'inf' and denoting it as '~' when viewing table.

Due to the function being within the `helper_funcs.py` file there was no testing run.

<img width="755" alt="Screen Shot 2022-06-15 at 12 01 19 AM" src="https://user-images.githubusercontent.com/53658028/173740990-8b09e110-6817-4e5d-87cf-2370253b8665.png">


- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context. 
- [x] List any dependencies that are required for this change.

# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
