### PR TITLE
Fixed cntrld issue

### DIFF
--- a/openbb_terminal/parent_classes.py
+++ b/openbb_terminal/parent_classes.py
@@ -553,7 +553,7 @@ class BaseController(metaclass=ABCMeta):
                     # Get input from user without auto-completion
                     else:
                         an_input = input(f"{get_flair()} {self.PATH} $ ")
-                except KeyboardInterrupt:
+                except (KeyboardInterrupt, EOFError):
                     # Exit in case of keyboard interrupt
                     an_input = "exit"
 

--- a/terminal.py
+++ b/terminal.py
@@ -489,7 +489,7 @@ def terminal(jobs_cmds: List[str] = None, appName: str = "gst"):
                             completer=t_controller.completer,
                             search_ignore_case=True,
                         )
-                except KeyboardInterrupt:
+                except (KeyboardInterrupt, EOFError):
                     print_goodbye()
                     break
             # Get input from user without auto-completion


### PR DESCRIPTION
# Description

Fixes #1945. cntrl+d now exits in an appealing way.

# How has this been tested?

Pressing cntrl+d inside the terminal.

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
