### PR TITLE
Economy/treasury: No data found for any secondary market treasuries. Displays a blank chart.

### DIFF
--- a/openbb_terminal/economy/econdb_model.py
+++ b/openbb_terminal/economy/econdb_model.py
@@ -708,7 +708,10 @@ def get_treasuries(
 
                     for column in df.columns:
                         # check if type inside the name and maturity inside the maturity string
-                        if type_string in column[2] and maturity_string in column[3]:
+                        if (
+                            type_string.lower() in column[2].lower()
+                            and maturity_string in column[3]
+                        ):
                             treasury_data[type_string][maturity_string] = df[
                                 column
                             ].dropna()


### PR DESCRIPTION
# Description

Fixes #1946 which failed to display chart with secondary market treasuries data. I believe it was a detail on the name secondary data has in the source dataframe. Code looks for first capital first letter 'Secondary' or 'Nominal' type of treasuries, which is not in this format for the secondary type. Just lowercased both the column name and the type_string to be searched to work for both cases. Seems to have worked.

![image](https://user-images.githubusercontent.com/79287829/174329304-814f7e26-0c1f-4c4e-8621-606b5c62f419.png)

![image](https://user-images.githubusercontent.com/79287829/174328790-b1022262-341f-40f6-a561-cf03d27eec4e.png)




- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?
treasury -m 3m -f daily -t secondary
treasury -m 3m -f weekly -t secondary
treasury -m 3m -t secondary
pytest tests/openbb_terminal/economy/test_econdb_model.py
pytest tests/openbb_terminal/economy/test_econdb_view.py


# Others
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
