### PR TITLE
Changing menu dialogue for keys menu to be more apparent on how to add an api key

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -35,7 +35,7 @@ en:
   keys: set API keys and check their validity
   _configure_: Configure your own terminal
   _main_menu_: Main menu
-  keys/_keys_: Set API keys through environment variables
+  keys/_keys_: Set API keys through environment variables. Type <API> -h for usage details
   defined, test passed: defined, test passed
   defined, test failed: defined, test failed
   not defined: not defined

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -35,7 +35,7 @@ en:
   keys: set API keys and check their validity
   _configure_: Configure your own terminal
   _main_menu_: Main menu
-  keys/_keys_: Set API keys through environment variables. Type <API> -h for usage details
+  keys/_keys_: Set API keys. Type <API> -h for usage details
   defined, test passed: defined, test passed
   defined, test failed: defined, test failed
   not defined: not defined


### PR DESCRIPTION
# Description
Changed menu so that users know what command to use to add a new api key. Specifically told users to see the help dialogue for each key because some keys need optional arguments such as the reddit api which needs client id, client secret, etc.

<img width="909" alt="Screen Shot 2022-06-20 at 6 26 13 PM" src="https://user-images.githubusercontent.com/53658028/174688633-f34fef22-415e-45f5-9ed4-d36c08f36362.png">

- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
