### PR TITLE
Handle errors when tickers can't be loaded

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -115,7 +115,7 @@ def check_path(path: str) -> str:
     return ""
 
 
-def log_and_raise(error: Union[argparse.ArgumentTypeError, ValueError]) -> None:
+def log_and_raise(error: Union[argparse.ArgumentTypeError, ValueError, RuntimeError]) -> None:
     logger.error(str(error))
     raise error
 

--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -115,9 +115,7 @@ def check_path(path: str) -> str:
     return ""
 
 
-def log_and_raise(
-    error: Union[argparse.ArgumentTypeError, ValueError]
-) -> None:
+def log_and_raise(error: Union[argparse.ArgumentTypeError, ValueError]) -> None:
     logger.error(str(error))
     raise error
 

--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -115,7 +115,9 @@ def check_path(path: str) -> str:
     return ""
 
 
-def log_and_raise(error: Union[argparse.ArgumentTypeError, ValueError, RuntimeError]) -> None:
+def log_and_raise(
+    error: Union[argparse.ArgumentTypeError, ValueError, RuntimeError]
+) -> None:
     logger.error(str(error))
     raise error
 

--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -116,7 +116,7 @@ def check_path(path: str) -> str:
 
 
 def log_and_raise(
-    error: Union[argparse.ArgumentTypeError, ValueError, RuntimeError]
+    error: Union[argparse.ArgumentTypeError, ValueError]
 ) -> None:
     logger.error(str(error))
     raise error

--- a/openbb_terminal/stocks/comparison_analysis/marketwatch_model.py
+++ b/openbb_terminal/stocks/comparison_analysis/marketwatch_model.py
@@ -88,8 +88,6 @@ def prepare_df_financials(
     ------
     ValueError
         If statement is not income, balance or cashflow
-    RuntimeError
-        If the financial statements could not be parsed correctly
     """
     financial_urls = {
         "income": {

--- a/openbb_terminal/stocks/comparison_analysis/marketwatch_model.py
+++ b/openbb_terminal/stocks/comparison_analysis/marketwatch_model.py
@@ -202,7 +202,6 @@ def prepare_comparison_financials(
         similar.copy()
     ):  # We need a copy since we are modifying the original potentially
         try:
-            console.print("Symbol " + symbol)
             financials[symbol] = prepare_df_financials(
                 symbol, statement, quarter
             ).set_index("Item")

--- a/openbb_terminal/stocks/comparison_analysis/marketwatch_model.py
+++ b/openbb_terminal/stocks/comparison_analysis/marketwatch_model.py
@@ -129,11 +129,14 @@ def prepare_df_financials(
     s_header_end_trend = ("5-year trend", "5- qtr trend")[quarter]
     if s_header_end_trend in a_financials_header:
         df_financials = pd.DataFrame(
-            columns=a_financials_header[0 : a_financials_header.index(s_header_end_trend)]
+            columns=a_financials_header[
+                0 : a_financials_header.index(s_header_end_trend)
+            ]
         )
     else:
-        log_and_raise(RuntimeError("Couldn't parse financial statement for ticker " + ticker))
-
+        log_and_raise(
+            RuntimeError("Couldn't parse financial statement for ticker " + ticker)
+        )
 
     find_table = text_soup_financials.findAll(
         "div", {"class": "element element--table table--fixed financials"}
@@ -193,10 +196,16 @@ def prepare_comparison_financials(
     """
 
     financials = {}
-    for symbol in similar.copy(): # We need a copy since we are modifying the original potentially
+    for (
+        symbol
+    ) in (
+        similar.copy()
+    ):  # We need a copy since we are modifying the original potentially
         try:
             console.print("Symbol " + symbol)
-            financials[symbol] = prepare_df_financials(symbol, statement, quarter).set_index("Item")
+            financials[symbol] = prepare_df_financials(
+                symbol, statement, quarter
+            ).set_index("Item")
         except RuntimeError as e:
             console.print(e)
             console.print("Removing ticker " + symbol + " from further processing")

--- a/openbb_terminal/stocks/comparison_analysis/marketwatch_view.py
+++ b/openbb_terminal/stocks/comparison_analysis/marketwatch_view.py
@@ -41,6 +41,10 @@ def display_income_comparison(
     df_financials_compared = marketwatch_model.get_financial_comparisons(
         similar, "income", timeframe, quarter
     )
+
+    if df_financials_compared == None or df_financials_compared.empty:
+        return
+
     # Export data before the color
     export_data(
         export,
@@ -89,6 +93,10 @@ def display_balance_comparison(
     df_financials_compared = marketwatch_model.get_financial_comparisons(
         similar, "balance", timeframe, quarter
     )
+
+    if len(df_financials_compared) == 0 or df_financials_compared.empty:
+        return
+
     # Export data before the color
     export_data(
         export,
@@ -139,6 +147,9 @@ def display_cashflow_comparison(
     df_financials_compared = marketwatch_model.get_financial_comparisons(
         similar, "cashflow", timeframe, quarter
     )
+
+    if df_financials_compared == None or df_financials_compared.empty:
+        return
 
     # Export data before the color
     export_data(

--- a/openbb_terminal/stocks/comparison_analysis/marketwatch_view.py
+++ b/openbb_terminal/stocks/comparison_analysis/marketwatch_view.py
@@ -42,7 +42,7 @@ def display_income_comparison(
         similar, "income", timeframe, quarter
     )
 
-    if df_financials_compared == None or df_financials_compared.empty:
+    if len(df_financials_compared) == 0 or df_financials_compared.empty:
         return
 
     # Export data before the color
@@ -148,7 +148,7 @@ def display_cashflow_comparison(
         similar, "cashflow", timeframe, quarter
     )
 
-    if df_financials_compared == None or df_financials_compared.empty:
+    if len(df_financials_compared) == 0 or df_financials_compared.empty:
         return
 
     # Export data before the color

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
@@ -89,9 +89,12 @@ def prepare_df_financials(
     if s_header_end_trend not in a_financials_header:
         return pd.DataFrame()
 
-    df_financials = pd.DataFrame(
-        columns=a_financials_header[0 : a_financials_header.index(s_header_end_trend)]
-    )
+    if s_header_end_trend in a_financials_header:
+        df_financials = pd.DataFrame(
+            columns=a_financials_header[0 : a_financials_header.index(s_header_end_trend)]
+        )
+    else:
+        log_and_raise(RuntimeError("Couldn't parse financial statement for ticker " + ticker))
 
     find_table = text_soup_financials.findAll(
         "div", {"class": "element element--table table--fixed financials"}

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
@@ -15,6 +15,7 @@ from openbb_terminal.helper_funcs import (
     lambda_clean_data_values_to_float,
     get_user_agent,
     lambda_int_or_round_float,
+    log_and_raise,
 )
 from openbb_terminal.rich_config import console
 
@@ -91,10 +92,14 @@ def prepare_df_financials(
 
     if s_header_end_trend in a_financials_header:
         df_financials = pd.DataFrame(
-            columns=a_financials_header[0 : a_financials_header.index(s_header_end_trend)]
+            columns=a_financials_header[
+                0 : a_financials_header.index(s_header_end_trend)
+            ]
         )
     else:
-        log_and_raise(RuntimeError("Couldn't parse financial statement for ticker " + ticker))
+        log_and_raise(
+            RuntimeError("Couldn't parse financial statement for ticker " + ticker)
+        )
 
     find_table = text_soup_financials.findAll(
         "div", {"class": "element element--table table--fixed financials"}

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
@@ -100,6 +100,7 @@ def prepare_df_financials(
         log_and_raise(
             RuntimeError("Couldn't parse financial statement for ticker " + ticker)
         )
+        return []
 
     find_table = text_soup_financials.findAll(
         "div", {"class": "element element--table table--fixed financials"}

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_model.py
@@ -15,7 +15,6 @@ from openbb_terminal.helper_funcs import (
     lambda_clean_data_values_to_float,
     get_user_agent,
     lambda_int_or_round_float,
-    log_and_raise,
 )
 from openbb_terminal.rich_config import console
 
@@ -97,10 +96,7 @@ def prepare_df_financials(
             ]
         )
     else:
-        log_and_raise(
-            RuntimeError("Couldn't parse financial statement for ticker " + ticker)
-        )
-        return []
+        return pd.DataFrame()
 
     find_table = text_soup_financials.findAll(
         "div", {"class": "element element--table table--fixed financials"}

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
@@ -79,6 +79,7 @@ def income(other_args: List[str], ticker: str):
 
     df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
     if len(df_financials) == 0 or df_financials.empty:
+        console.print("Marketwatch does not yet provide financials for this ticker")
         return
 
     if rich_config.USE_COLOR:
@@ -158,6 +159,7 @@ def balance(other_args: List[str], ticker: str):
 
     df_financials = mwm.prepare_df_financials(ticker, "balance", ns_parser.b_quarter)
     if len(df_financials) == 0 or df_financials.empty:
+        console.print("Marketwatch does not yet provide financials for this ticker")
         return
 
     if rich_config.USE_COLOR:
@@ -233,6 +235,7 @@ def cash(other_args: List[str], ticker: str):
 
     df_financials = mwm.prepare_df_financials(ticker, "cashflow", ns_parser.b_quarter)
     if len(df_financials) == 0 or df_financials.empty:
+        console.print("Marketwatch does not yet provide financials for this ticker")
         return
 
     if rich_config.USE_COLOR:

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
@@ -78,7 +78,7 @@ def income(other_args: List[str], ticker: str):
         return
 
     df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
-    if df_financials == []:
+    if len(df_financials) == 0 or df_financials.empty:
         return
 
     if rich_config.USE_COLOR:
@@ -157,7 +157,7 @@ def balance(other_args: List[str], ticker: str):
         return
 
     df_financials = mwm.prepare_df_financials(ticker, "balance", ns_parser.b_quarter)
-    if df_financials == []:
+    if len(df_financials) == 0 or df_financials.empty:
         return
 
     if rich_config.USE_COLOR:
@@ -232,7 +232,7 @@ def cash(other_args: List[str], ticker: str):
         return
 
     df_financials = mwm.prepare_df_financials(ticker, "cashflow", ns_parser.b_quarter)
-    if df_financials == []:
+    if len(df_financials) == 0 or df_financials.empty:
         return
 
     if rich_config.USE_COLOR:

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
@@ -159,7 +159,9 @@ def balance(other_args: List[str], ticker: str):
         return
 
     try:
-        df_financials = mwm.prepare_df_financials(ticker, "balance", ns_parser.b_quarter)
+        df_financials = mwm.prepare_df_financials(
+            ticker, "balance", ns_parser.b_quarter
+        )
     except RuntimeError as e:
         console.print(e)
         return
@@ -236,7 +238,9 @@ def cash(other_args: List[str], ticker: str):
         return
 
     try:
-        df_financials = mwm.prepare_df_financials(ticker, "cashflow", ns_parser.b_quarter)
+        df_financials = mwm.prepare_df_financials(
+            ticker, "cashflow", ns_parser.b_quarter
+        )
     except RuntimeError as e:
         console.print(e)
         return

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
@@ -77,10 +77,8 @@ def income(other_args: List[str], ticker: str):
     if not ns_parser:
         return
 
-    try:
-        df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
-    except RuntimeError as e:
-        console.print(e)
+    df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
+    if df_financials == []:
         return
 
     if rich_config.USE_COLOR:
@@ -158,12 +156,8 @@ def balance(other_args: List[str], ticker: str):
     if not ns_parser:
         return
 
-    try:
-        df_financials = mwm.prepare_df_financials(
-            ticker, "balance", ns_parser.b_quarter
-        )
-    except RuntimeError as e:
-        console.print(e)
+    df_financials = mwm.prepare_df_financials(ticker, "balance", ns_parser.b_quarter)
+    if df_financials == []:
         return
 
     if rich_config.USE_COLOR:
@@ -237,12 +231,8 @@ def cash(other_args: List[str], ticker: str):
     if not ns_parser:
         return
 
-    try:
-        df_financials = mwm.prepare_df_financials(
-            ticker, "cashflow", ns_parser.b_quarter
-        )
-    except RuntimeError as e:
-        console.print(e)
+    df_financials = mwm.prepare_df_financials(ticker, "cashflow", ns_parser.b_quarter)
+    if df_financials == []:
         return
 
     if rich_config.USE_COLOR:

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
@@ -159,7 +159,7 @@ def balance(other_args: List[str], ticker: str):
         return
 
     try:
-        df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
+        df_financials = mwm.prepare_df_financials(ticker, "balance", ns_parser.b_quarter)
     except RuntimeError as e:
         console.print(e)
         return
@@ -236,7 +236,7 @@ def cash(other_args: List[str], ticker: str):
         return
 
     try:
-        df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
+        df_financials = mwm.prepare_df_financials(ticker, "cashflow", ns_parser.b_quarter)
     except RuntimeError as e:
         console.print(e)
         return

--- a/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/market_watch_view.py
@@ -77,7 +77,11 @@ def income(other_args: List[str], ticker: str):
     if not ns_parser:
         return
 
-    df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
+    try:
+        df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
+    except RuntimeError as e:
+        console.print(e)
+        return
 
     if rich_config.USE_COLOR:
         df_financials = df_financials.applymap(lambda_financials_colored_values)
@@ -154,7 +158,11 @@ def balance(other_args: List[str], ticker: str):
     if not ns_parser:
         return
 
-    df_financials = mwm.prepare_df_financials(ticker, "balance", ns_parser.b_quarter)
+    try:
+        df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
+    except RuntimeError as e:
+        console.print(e)
+        return
 
     if rich_config.USE_COLOR:
         df_financials = df_financials.applymap(lambda_financials_colored_values)
@@ -227,7 +235,11 @@ def cash(other_args: List[str], ticker: str):
     if not ns_parser:
         return
 
-    df_financials = mwm.prepare_df_financials(ticker, "cashflow", ns_parser.b_quarter)
+    try:
+        df_financials = mwm.prepare_df_financials(ticker, "income", ns_parser.b_quarter)
+    except RuntimeError as e:
+        console.print(e)
+        return
 
     if rich_config.USE_COLOR:
         df_financials = df_financials.applymap(lambda_financials_colored_values)


### PR DESCRIPTION
# Description

This PR gracefully handles errors when certain tickers can't be loaded as part of `/stocks/ca` commands. This can happen for certain tickers like SPY. When a ticker can't be loaded, it is removed from the comparison set and the command continues if possible. An example of what happens is in the screenshot below.

![image](https://user-images.githubusercontent.com/69191/175776525-83189c7c-1238-431b-aee3-7f95c3007daf.png)


# How has this been tested?

Manual testing and pytest

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
