### PR TITLE
Fixes stock price and metrics in #1993

### DIFF
--- a/openbb_terminal/cryptocurrency/cryptocurrency_helpers.py
+++ b/openbb_terminal/cryptocurrency/cryptocurrency_helpers.py
@@ -299,7 +299,7 @@ def load(
         start=start_date,
         progress=False,
         interval="1d",
-    ).sort_index(ascending=False)
+    ).sort_index(ascending=True)
 
     if df.empty:
         return pd.DataFrame()


### PR DESCRIPTION
# Description
Fixes stock price and metrics by reversing the dataframe being loaded from #1993 . Note that candle has already been fixed
Before:
![image](https://user-images.githubusercontent.com/85685255/175956050-cef1656b-574c-4d6a-8f43-ff6a74af00da.png)

After:
![image](https://user-images.githubusercontent.com/85685255/175956128-b8866b1e-b562-497d-bbe8-d5319d4298cd.png)

- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
