### PR TITLE
Fix yf FA quarterly issue

### DIFF
--- a/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -543,6 +543,9 @@ class FundamentalAnalysisController(StockBaseController):
             limit=5,
         )
         if ns_parser:
+            if ns_parser.source == "yf" and ns_parser.b_quarter:
+                text = "Quarterly data currently unavailable for yfinance"
+                console.print(f"[red]{text}, showing yearly.[/red]\n")
             if ns_parser.source == "av":
                 av_view.display_income_statement(
                     ticker=self.ticker,
@@ -612,6 +615,9 @@ class FundamentalAnalysisController(StockBaseController):
             limit=5,
         )
         if ns_parser:
+            if ns_parser.source == "yf" and ns_parser.b_quarter:
+                text = "Quarterly data currently unavailable for yfinance"
+                console.print(f"[red]{text}, showing yearly.[/red]\n")
             if ns_parser.source == "av":
                 av_view.display_balance_sheet(
                     ticker=self.ticker,
@@ -687,6 +693,9 @@ class FundamentalAnalysisController(StockBaseController):
             export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED,
         )
         if ns_parser:
+            if ns_parser.source == "yf" and ns_parser.b_quarter:
+                text = "Quarterly data currently unavailable for yfinance"
+                console.print(f"[red]{text}, showing yearly.[/red]\n")
             if ns_parser.source == "av":
                 av_view.display_cash_flow(
                     ticker=self.ticker,

--- a/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -543,6 +543,7 @@ class FundamentalAnalysisController(StockBaseController):
             limit=5,
         )
         if ns_parser:
+            # TODO: Switch to actually getting data
             if ns_parser.source == "yf" and ns_parser.b_quarter:
                 text = "Quarterly data currently unavailable for yfinance"
                 console.print(f"[red]{text}, showing yearly.[/red]\n")
@@ -615,6 +616,7 @@ class FundamentalAnalysisController(StockBaseController):
             limit=5,
         )
         if ns_parser:
+            # TODO: Switch to actually getting data
             if ns_parser.source == "yf" and ns_parser.b_quarter:
                 text = "Quarterly data currently unavailable for yfinance"
                 console.print(f"[red]{text}, showing yearly.[/red]\n")
@@ -693,6 +695,7 @@ class FundamentalAnalysisController(StockBaseController):
             export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED,
         )
         if ns_parser:
+            # TODO: Switch to actually getting data
             if ns_parser.source == "yf" and ns_parser.b_quarter:
                 text = "Quarterly data currently unavailable for yfinance"
                 console.print(f"[red]{text}, showing yearly.[/red]\n")


### PR DESCRIPTION
# Description

Adds a warning telling users we do not get quarterly data with yfinance.


# How has this been tested?

Made sure message was displayed.


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
