### PR TITLE
Adding integration tests to intel mac workflow

### DIFF
--- a/.github/workflows/intel_macos_build.yml
+++ b/.github/workflows/intel_macos_build.yml
@@ -6,10 +6,7 @@ env:
   OPENBB_USE_PROMPT_TOOLKIT: false
   PIP_DEFAULT_TIMEOUT: 100
   PYTHONNOUSERSITE: 1
-on:
-  push:
-    branches:
-      - 'build_workflow_test'
+on: workflow_dispatch
 jobs:
   Build:
     name: Intel MacOS Build
@@ -57,3 +54,6 @@ jobs:
           path: |
                 DMG/OpenBB\ Terminal/.openbb
                 DMG/OpenBB\ Terminal/OpenBB\ Terminal
+      - name: Run Integration Tests
+        shell: bash -l {0}
+        run: DMG/OpenBB\ Terminal/.OpenBB/OpenBBTerminal ~/work/OpenBBTerminal/OpenBBTerminal/scripts/*.openbb -t


### PR DESCRIPTION
# Description

Changed workflow to be `workflow_dispatch` and added integration tests.

# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
