### PR TITLE
Fixes #2018 and updates default dates in dd_controller.py

### DIFF
--- a/openbb_terminal/cryptocurrency/due_diligence/dd_controller.py
+++ b/openbb_terminal/cryptocurrency/due_diligence/dd_controller.py
@@ -242,6 +242,7 @@ class DueDiligenceController(CryptoBaseController):
                 description="""
                     Display addresses with nonzero assets in a certain blockchain
                     [Source: https://glassnode.org]
+                    Note that free api keys only allow fetching data with a 1y lag
                 """,
             )
 
@@ -255,13 +256,12 @@ class DueDiligenceController(CryptoBaseController):
                 choices=glassnode_model.INTERVALS_NON_ZERO_ADDRESSES,
             )
 
-            # TODO: tell users that free api key only data with 1y lag
             parser.add_argument(
                 "-s",
                 "--since",
                 dest="since",
                 type=valid_date,
-                help="Initial date. Default: 2020-01-01",
+                help="Initial date. Default: 2 years ago",
                 default=(datetime.now() - timedelta(days=365 * 2)).strftime("%Y-%m-%d"),
             )
 
@@ -270,7 +270,7 @@ class DueDiligenceController(CryptoBaseController):
                 "--until",
                 dest="until",
                 type=valid_date,
-                help="Final date. Default: 2021-01-01",
+                help="Final date. Default: 1 year ago",
                 default=(datetime.now() - timedelta(days=367)).strftime("%Y-%m-%d"),
             )
 
@@ -320,7 +320,7 @@ class DueDiligenceController(CryptoBaseController):
                 "--since",
                 dest="since",
                 type=valid_date,
-                help="Initial date. Default: 2020-01-01",
+                help="Initial date. Default: 1 year ago",
                 default=(datetime.now() - timedelta(days=365)).strftime("%Y-%m-%d"),
             )
 
@@ -329,7 +329,7 @@ class DueDiligenceController(CryptoBaseController):
                 "--until",
                 dest="until",
                 type=valid_date,
-                help="Final date. Default: 2021-01-01",
+                help="Final date. Default: Today",
                 default=(datetime.now()).strftime("%Y-%m-%d"),
             )
 
@@ -361,6 +361,7 @@ class DueDiligenceController(CryptoBaseController):
                 description="""
                     Display active blockchain addresses over time
                     [Source: https://glassnode.org]
+                    Note that free api keys only allow fetching data with a 1y lag
                 """,
             )
 
@@ -389,8 +390,8 @@ class DueDiligenceController(CryptoBaseController):
                 "--since",
                 dest="since",
                 type=valid_date,
-                help="Initial date. Default: 2019-01-01",
-                default="2019-01-01",
+                help="Initial date. Default: 2 years ago",
+                default=(datetime.now() - timedelta(days=365 * 2)).strftime("%Y-%m-%d"),
             )
 
             parser.add_argument(
@@ -398,8 +399,8 @@ class DueDiligenceController(CryptoBaseController):
                 "--until",
                 dest="until",
                 type=valid_date,
-                help="Final date. Default: 2020-01-01",
-                default="2020-01-01",
+                help="Final date. Default: 1 year ago",
+                default=(datetime.now() - timedelta(days=367)).strftime("%Y-%m-%d"),
             )
 
             if other_args:
@@ -434,6 +435,7 @@ class DueDiligenceController(CryptoBaseController):
                 description="""
                     Display active blockchain addresses over time
                     [Source: https://glassnode.org]
+                    Note that free api keys only allow fetching data with a 1y lag
                 """,
             )
 
@@ -470,8 +472,8 @@ class DueDiligenceController(CryptoBaseController):
                 "--since",
                 dest="since",
                 type=valid_date,
-                help="Initial date. Default: 2019-01-01",
-                default="2019-01-01",
+                help="Initial date. Default: 2 years ago",
+                default=(datetime.now() - timedelta(days=365 * 2)).strftime("%Y-%m-%d"),
             )
 
             parser.add_argument(
@@ -479,8 +481,8 @@ class DueDiligenceController(CryptoBaseController):
                 "--until",
                 dest="until",
                 type=valid_date,
-                help="Final date. Default: 2020-01-01",
-                default="2020-01-01",
+                help="Final date. Default: 1 year ago",
+                default=(datetime.now() - timedelta(days=367)).strftime("%Y-%m-%d"),
             )
 
             if other_args and not other_args[0][0] == "-":

--- a/openbb_terminal/cryptocurrency/due_diligence/glassnode_view.py
+++ b/openbb_terminal/cryptocurrency/due_diligence/glassnode_view.py
@@ -401,12 +401,12 @@ def display_exchange_balances(
         f"{asset}: Total Balance in {'all exchanges' if exchange == 'aggregated' else exchange}"
     )
     ax1.tick_params(axis="x", labelrotation=10)
-    ax1.legend(["{} Unit".format(asset)], loc="upper right")
+    ax1.legend([f"{asset} Unit"], loc="upper right")
 
     ax2.grid(visible=False)
     ax2.plot(df_balance.index, df_balance["price"], color="orange")
     ax2.set_ylabel(f"{asset} price [$]")
-    ax2.legend(["{} Price".format(asset)], loc="upper left")
+    ax2.legend([f"{asset} Price"], loc="upper left")
 
     if not external_axes:
         theme.visualize_output()

--- a/openbb_terminal/cryptocurrency/due_diligence/glassnode_view.py
+++ b/openbb_terminal/cryptocurrency/due_diligence/glassnode_view.py
@@ -401,12 +401,12 @@ def display_exchange_balances(
         f"{asset}: Total Balance in {'all exchanges' if exchange == 'aggregated' else exchange}"
     )
     ax1.tick_params(axis="x", labelrotation=10)
-    ax1.legend(["ETH Unit"], loc="best")
+    ax1.legend(["{} Unit".format(asset)], loc="upper right")
 
     ax2.grid(visible=False)
     ax2.plot(df_balance.index, df_balance["price"], color="orange")
     ax2.set_ylabel(f"{asset} price [$]")
-    ax2.legend(["ETH Price"], loc="best")
+    ax2.legend(["{} Price".format(asset)], loc="upper left")
 
     if not external_axes:
         theme.visualize_output()


### PR DESCRIPTION
# Description
Fixes labels in #2018 and updates default dates for plots to from 2 years ago to 1 year ago (wherever the free glassnode api only allows fetching data with a 1y lag)

Before:
![image](https://user-images.githubusercontent.com/85685255/176911368-2bde2eed-5495-4f31-b016-1b0efbadaea9.png)

After:
![image](https://user-images.githubusercontent.com/85685255/176911420-baf6c785-7305-4885-a9a5-651d75f46867.png)


- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
