### PR TITLE
Update data sources json to allow submenu loading

### DIFF
--- a/data_sources_default.json
+++ b/data_sources_default.json
@@ -2,7 +2,7 @@
   "stocks": {
     "load": "yf",
     "dps": {
-      "psi": "quandl"
+      "psi": "stockgrid"
     },
     "fa": {
       "income": "av",

--- a/data_sources_default.json
+++ b/data_sources_default.json
@@ -14,6 +14,45 @@
       "vol": "tradier",
       "voi": "tradier",
       "oi": "tradier"
+    },
+    "disc": {
+      "load": "yf"
+    },
+    "sia": {
+      "load": "yf"
+    },
+    "scr": {
+      "load": "yf"
+    },
+    "ins": {
+      "load": "yf"
+    },
+    "gov": {
+      "load": "yf"
+    },
+    "ba": {
+      "load": "yf"
+    },
+    "ca": {
+      "load": "yf"
+    },
+    "res": {
+      "load": "yf"
+    },
+    "dd": {
+      "load": "yf"
+    },
+    "bt": {
+      "load": "yf"
+    },
+    "ta": {
+      "load": "yf"
+    },
+    "qa": {
+      "load": "yf"
+    },
+    "pred": {
+      "load": "yf"
     }
   },
   "crypto": {

--- a/tests/openbb_terminal/stocks/dark_pool_shorts/test_dps_controller.py
+++ b/tests/openbb_terminal/stocks/dark_pool_shorts/test_dps_controller.py
@@ -315,6 +315,7 @@ def test_call_func_expect_queue(expected_queue, queue, func):
             [
                 "quandl",
                 "--nyse",
+                "--source=quandl",
                 "--limit=1",
                 "--raw",
                 "--export=csv",


### PR DESCRIPTION
#2052

Updates stocks submenus to have a default source in the json.

Ran load in all submenus.  Crypto submenus were working though....