### PR TITLE
Stop consuming first element of list

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -434,9 +434,6 @@ def terminal(jobs_cmds: List[str] = None, appName: str = "gst"):
                 print_goodbye()
                 break
 
-            if obbff.ENABLE_EXIT_AUTO_HELP and len(t_controller.queue) > 1:
-                t_controller.queue = t_controller.queue[1:]
-
             # Consume 1 element from the queue
             an_input = t_controller.queue[0]
             t_controller.queue = t_controller.queue[1:]


### PR DESCRIPTION
#2054

This code served no purpose but to mess with us
```
 if obbff.ENABLE_EXIT_AUTO_HELP and len(t_controller.queue) > 1:
       t_controller.queue = t_controller.queue[1:]
```

Also:
<img width="374" alt="Screen Shot 2022-07-07 at 2 54 53 PM" src="https://user-images.githubusercontent.com/18151143/177852182-4b032be3-c73a-4f8a-91e5-da8511146288.png">

