### PR TITLE
Fix failing exit

### DIFF
--- a/openbb_terminal/portfolio/portfolio_optimization/po_controller.py
+++ b/openbb_terminal/portfolio/portfolio_optimization/po_controller.py
@@ -12,7 +12,6 @@ from typing import List, Dict
 from prompt_toolkit.completion import NestedCompleter
 
 from openbb_terminal import feature_flags as obbff
-from openbb_terminal import parent_classes
 from openbb_terminal.decorators import log_start_end
 from openbb_terminal.helper_funcs import (
     check_non_negative,
@@ -530,13 +529,6 @@ class PortfolioOptimizationController(BaseController):
             self.params,
             self.current_model,
         )
-        self.current_file = parent_classes.controllers[
-            "/portfolio/po/params/"
-        ].current_file
-        self.current_model = parent_classes.controllers[
-            "/portfolio/po/params/"
-        ].current_model
-        self.params = parent_classes.controllers["/portfolio/po/params/"].params
 
     @log_start_end(log=logger)
     def call_show(self, other_args: List[str]):

--- a/tests/openbb_terminal/portfolio/csv/test_portfolio_model/test_common_sense_ratio.csv
+++ b/tests/openbb_terminal/portfolio/csv/test_portfolio_model/test_common_sense_ratio.csv
@@ -11,14 +11,14 @@ dtype: float64"
 3m,"TotalHoldings    0.68
 dtype: float64","Adj Close    0.613
 dtype: float64"
-6m,"TotalHoldings    0.731
-dtype: float64","Adj Close    0.699
+6m,"TotalHoldings    0.733
+dtype: float64","Adj Close    0.693
 dtype: float64"
-1y,"TotalHoldings    0.571
-dtype: float64","Adj Close    0.452
+1y,"TotalHoldings    0.59
+dtype: float64","Adj Close    0.489
 dtype: float64"
-3y,"TotalHoldings   -1.17
-dtype: float64","Adj Close   -0.791
+3y,"TotalHoldings   -1.128
+dtype: float64","Adj Close   -0.773
 dtype: float64"
 5y,"TotalHoldings   -1.308
 dtype: float64","Adj Close   -1.483

--- a/tests/openbb_terminal/portfolio/csv/test_portfolio_model/test_tail_ratio.csv
+++ b/tests/openbb_terminal/portfolio/csv/test_portfolio_model/test_tail_ratio.csv
@@ -11,14 +11,14 @@ dtype: float64"
 3m,"TotalHoldings    0.758
 dtype: float64","Adj Close    0.703
 dtype: float64"
-6m,"TotalHoldings    0.847
-dtype: float64","Adj Close    0.83
+6m,"TotalHoldings    0.849
+dtype: float64","Adj Close    0.827
 dtype: float64"
 1y,"TotalHoldings    0.923
-dtype: float64","Adj Close    0.927
+dtype: float64","Adj Close    0.926
 dtype: float64"
-3y,"TotalHoldings    0.91
-dtype: float64","Adj Close    0.798
+3y,"TotalHoldings    0.908
+dtype: float64","Adj Close    0.799
 dtype: float64"
 5y,"TotalHoldings    0.882
 dtype: float64","Adj Close    0.81


### PR DESCRIPTION
# Description

There is no need to manually set the attributes of the class. The dictionary remembers them. Fixes #2053.


# How has this been tested?

Reran `r` and did not get an error.


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
