### PR TITLE
Fast Merge - Updating README.md from top folder, CONTRIBUTING.md wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
     Investment research for everyone.
     <br />
     <a href="https://github.com/OpenBB-finance/OpenBBTerminal/tree/master/openbb_terminal/README.md"><strong>≪  GETTING STARTED</strong></a>
-    &nbsp · &nbsp <a href="https://github.com/OpenBB-finance/OpenBBTerminal/tree/master/openbb_terminal/CONTRIBUTING.md"><strong>CONTRIBUTING</strong></a> &nbsp · &nbsp
+    &nbsp · &nbsp <a href="https://github.com/OpenBB-finance/OpenBBTerminal/tree/master/CONTRIBUTING.md"><strong>CONTRIBUTING</strong></a> &nbsp · &nbsp
     <a href="https://openbb-finance.github.io/OpenBBTerminal/">
     <strong>SEE FEATURES »</strong></a>
     <br />


### PR DESCRIPTION
The 'OpenBB-finance/OpenBBTerminal' repository doesn't contain the 'openbb_terminal/CONTRIBUTING.md' path in 'main'.

CONTRIBUTING.md link was pointed to openbb_terminal folder, when it was supposed to be pointed to the main folder
Also both are pointing to master folder, and they are being redirected via "Branch not found, redirected to default branch." :
        Maybe update to https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md ?
but either way https://github.com/OpenBB-finance/OpenBBTerminal/tree/master/CONTRIBUTING.md would still redirect correctly

# How has this been tested?

At least for me clicking the link in the current repo goes to the wrong link

Current link
https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/openbb_terminal/CONTRIBUTING.md
            -> wrong path

New link Options
https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md
            -> link to the correct repo branch "main"
https://github.com/OpenBB-finance/OpenBBTerminal/tree/master/CONTRIBUTING.md
            -> link to master, the same as was being used but for wrong folder, and same as used for Getting started link which is working, but being redirect to /blob/main