### PR TITLE
Corrected wording

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -971,7 +971,7 @@ en:
   econometrics/granger: Granger causality tests on two columns
   econometrics/coint: co-integration test on a multitude of columns
   portfolio/bro: brokers holdings,   supports robinhood, ally, degiro, coinbase
-  portfolio/po: portfolio optimization,  optimal your portfolio weights efficiently
+  portfolio/po: portfolio optimization,  optimize your portfolio weights efficiently
   portfolio/load: load data into the portfolio
   portfolio/_loaded: Loaded orderbook
   portfolio/_riskfreerate: Risk Free Rate

--- a/openbb_terminal/portfolio/portfolio_controller.py
+++ b/openbb_terminal/portfolio/portfolio_controller.py
@@ -197,7 +197,7 @@ class PortfolioController(BaseController):
 
         help_text = f"""[menu]
 >   bro              brokers holdings, \t\t supports: robinhood, ally, degiro, coinbase
->   po               portfolio optimization, \t optimal your portfolio weights efficiently[/menu]
+>   po               portfolio optimization, \t optimize your portfolio weights efficiently[/menu]
 [cmds]
     load             load data into the portfolio[/cmds]
 

--- a/tests/openbb_terminal/portfolio/txt/test_portfolio_controller/test_print_help.txt
+++ b/tests/openbb_terminal/portfolio/txt/test_portfolio_controller/test_print_help.txt
@@ -1,7 +1,7 @@
 Could not preprocess orderbook.
 
 >   bro              brokers holdings, 		 supports: robinhood, ally, degiro, coinbase
->   po               portfolio optimization, 	 optimal your portfolio weights efficiently
+>   po               portfolio optimization, 	 optimize your portfolio weights efficiently
 
     load             load data into the portfolio
 


### PR DESCRIPTION
# Description 

In the 'portfolio' context for the 'po' category it read "optimal your portfolio weights efficiently". It would be better/more clear to say "optimize your portfolio weights efficiently". There is no issue or bug related to this as it is purely a wording update.


# How has this been tested?

* All three locations/files where this wording occurred have been checked and confirmed to be correct and matching.
* Ran tests/portfolio/test_portfolio_controller.py and all tests (most importantly test_print_help) passed


# Checklist:

* No features were added. Only text change. 


# Others

* None
