### PR TITLE
Fixes error message on portfolio menu help

### DIFF
--- a/openbb_terminal/portfolio/portfolio_model.py
+++ b/openbb_terminal/portfolio/portfolio_model.py
@@ -836,8 +836,7 @@ class PortfolioModel:
         self.empty = False
 
     def get_orderbook(self):
-        if not self.empty:
-            return self.__orderbook
+        return self.__orderbook
 
     @staticmethod
     def read_orderbook(path: str) -> pd.DataFrame:

--- a/openbb_terminal/portfolio/portfolio_model.py
+++ b/openbb_terminal/portfolio/portfolio_model.py
@@ -811,9 +811,9 @@ class PortfolioModel:
         self.portfolio_assets_allocation = pd.DataFrame()
         self.portfolio_regional_allocation = pd.DataFrame()
         self.portfolio_country_allocation = pd.DataFrame()
-
-        # Prices
         self.portfolio_historical_prices = pd.DataFrame()
+        self.empty = True
+
         self.risk_free_rate = float(0)
 
         # Benchmark
@@ -822,20 +822,22 @@ class PortfolioModel:
         self.benchmark_historical_prices = pd.DataFrame()
         self.benchmark_returns = pd.DataFrame()
         self.benchmark_trades = pd.DataFrame()
-
         self.benchmark_assets_allocation = pd.DataFrame()
         self.benchmark_regional_allocation = pd.DataFrame()
         self.benchmark_country_allocation = pd.DataFrame()
 
         # Set and preprocess orderbook
-        self.__set_orderbook(orderbook)
+        if not orderbook.empty:
+            self.__set_orderbook(orderbook)
 
     def __set_orderbook(self, orderbook):
         self.__orderbook = orderbook
         self.preprocess_orderbook()
+        self.empty = False
 
     def get_orderbook(self):
-        return self.__orderbook
+        if not self.empty:
+            return self.__orderbook
 
     @staticmethod
     def read_orderbook(path: str) -> pd.DataFrame:

--- a/openbb_terminal/portfolio/portfolio_view.py
+++ b/openbb_terminal/portfolio/portfolio_view.py
@@ -76,7 +76,7 @@ def display_orderbook(portfolio=None, show_index=False):
         Defaults to False.
     """
 
-    if portfolio is None:
+    if portfolio.empty:
         logger.warning("No orderbook loaded")
         console.print("[red]No orderbook loaded.[/red]\n")
     else:

--- a/tests/openbb_terminal/portfolio/txt/test_portfolio_controller/test_print_help.txt
+++ b/tests/openbb_terminal/portfolio/txt/test_portfolio_controller/test_print_help.txt
@@ -1,4 +1,3 @@
-Could not preprocess orderbook.
 
 >   bro              brokers holdings, 		 supports: robinhood, ally, degiro, coinbase
 >   po               portfolio optimization, 	 optimize your portfolio weights efficiently


### PR DESCRIPTION
# Description

Fixes the "Could not preprocess orderbook." message on portfolio help menu being displayed by default.

![image](https://user-images.githubusercontent.com/79287829/179053783-ed345eb6-d0b3-4713-ae81-d49cad247ba5.png)


- [x] Summary of the change / bug fix.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context. 

# Others
- [x] I have performed a self-review of my own code.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
