### PR TITLE
The prediction menu installation instructions are not correct and should not be used

### DIFF
--- a/openbb_terminal/README.md
+++ b/openbb_terminal/README.md
@@ -143,18 +143,9 @@ issues.
 
    To enable the `prediction` menu install additional dependencies after installing main dependencies:
 
-   - On M1 macs
-
-     ```bash
-     conda install -c apple tensorflow-deps
-     poetry install -E prediction-m1-mac
-     ```
-
-   - On all other systems
-
-     ```bash
-     poetry install -E prediction
-     ```
+ ```bash
+ conda install -c conda-forge tensorflow
+ ```
 
    If you are having trouble with Poetry (e.g. on a non-conda python), simply install requirements.txt with pip
 


### PR DESCRIPTION

Tensorflow *cannot* be installed via Poetry. `tensorflow-macOS` and `tensorflow-metal` perform terribly and should not be used. Installing tensorflow via `conda install -c conda-forge tensorflow` is the only way tensorflow should be installed.

This PR updates the Anaconda installation instructions to reflect this reality. 