### PR TITLE
fix typo - change 'seaarch' to 'search'

### DIFF
--- a/openbb_terminal/economy/economy_controller.py
+++ b/openbb_terminal/economy/economy_controller.py
@@ -616,7 +616,7 @@ class EconomyController(BaseController):
             nargs="+",
             action="store",
             dest="query",
-            help="Query the FRED database to obtain Series IDs given the query seaarch term.",
+            help="Query the FRED database to obtain Series IDs given the query search term.",
         )
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-p")

--- a/website/content/terminal/economy/fred/_index.md
+++ b/website/content/terminal/economy/fred/_index.md
@@ -13,7 +13,7 @@ optional arguments:
   -e END_DATE, --end_date END_DATE
                         Ending date (YYYY-MM-DD) of data (default: None)
   -q QUERY [QUERY ...], --query QUERY [QUERY ...]
-                        Query the FRED database to obtain Series IDs given the query seaarch term. (default: None)
+                        Query the FRED database to obtain Series IDs given the query search term. (default: None)
   -st, --store          Store the data to be used for plotting with the 'plot' command. (default: False)
   -h, --help            show this help message (default: False)
   --export {csv,json,xlsx,png,jpg,pdf,svg}


### PR DESCRIPTION
# Description

changed 'seaarch' to 'search' in two places for the economy help message. because this seemed like a typo to me.



<img width="1057" alt="Screen Shot 2022-07-19 at 16 12 17" src="https://user-images.githubusercontent.com/29739201/179840659-dab756b8-0c04-4580-8d64-1010cef942a9.png">

<img width="1057" alt="Screen Shot 2022-07-19 at 16 12 30" src="https://user-images.githubusercontent.com/29739201/179840684-5af3f89c-1059-476a-b010-b0c381ea26ba.png">


<img width="888" alt="Screen Shot 2022-07-19 at 16 12 49" src="https://user-images.githubusercontent.com/29739201/179840721-830a76c2-013f-41df-9e91-d1072597f5df.png">

<img width="888" alt="Screen Shot 2022-07-19 at 16 12 57" src="https://user-images.githubusercontent.com/29739201/179840737-b8a58b47-27f0-42c4-bed6-eee15f69c730.png">

