### PR TITLE
better match for econ param parse to dict

### DIFF
--- a/openbb_terminal/economy/econdb_model.py
+++ b/openbb_terminal/economy/econdb_model.py
@@ -497,7 +497,8 @@ def get_macro_data(
     units
         The units of the macro data, e.g. 'Bbl/day" for oil.
     """
-    country = country[0].upper()+country[1:]
+    country = country.replace(" ", "_")
+    country[0] = country[0].upper() + country[1:]
     parameter = parameter.upper()
 
     if country not in COUNTRY_CODES:

--- a/openbb_terminal/economy/econdb_model.py
+++ b/openbb_terminal/economy/econdb_model.py
@@ -497,7 +497,8 @@ def get_macro_data(
     units
         The units of the macro data, e.g. 'Bbl/day" for oil.
     """
-    country = country.replace(" ", "_")
+    country = country[0].upper()+country[1:]
+    parameter = parameter.upper()
 
     if country not in COUNTRY_CODES:
         console.print(f"No data available for the country {country}.")

--- a/openbb_terminal/economy/econdb_model.py
+++ b/openbb_terminal/economy/econdb_model.py
@@ -498,7 +498,7 @@ def get_macro_data(
         The units of the macro data, e.g. 'Bbl/day" for oil.
     """
     country = country.replace(" ", "_")
-    country[0] = country[0].upper() + country[1:]
+    country = country[0].upper() + country[1:]
     parameter = parameter.upper()
 
     if country not in COUNTRY_CODES:


### PR DESCRIPTION
rm line 500 because spaces cannot be parsed from the command line anyway.
now it's able to match for keywords like "denmark" instead of "Denmark" to the dictionary.
same as "parameter". parsing "ppi" now will be "PPI", matching the dictionary.
