### PR TITLE
Fix ycrv to allow raw display and export when source is FRED

### DIFF
--- a/openbb_terminal/economy/economy_controller.py
+++ b/openbb_terminal/economy/economy_controller.py
@@ -1008,15 +1008,21 @@ class EconomyController(BaseController):
             if isinstance(ns_parser.country, list):
                 ns_parser.country = " ".join(ns_parser.country)
 
-            investingcom_model.check_correct_country(ns_parser.country)
-
             if ns_parser.source == "FRED":
-                fred_view.display_yield_curve(
-                    ns_parser.date,
-                    raw=ns_parser.raw,
-                    export=ns_parser.export,
-                )
+
+                if ns_parser.country == "united states":
+                    fred_view.display_yield_curve(
+                        ns_parser.date,
+                        raw=ns_parser.raw,
+                        export=ns_parser.export,
+                    )
+                else:
+                    console.print("Source FRED is only available for united states.\n")
+
             elif ns_parser.source == "investpy":
+
+                investingcom_model.check_correct_country(ns_parser.country)
+
                 investingcom_view.display_yieldcurve(
                     country=ns_parser.country,
                     raw=ns_parser.raw,

--- a/openbb_terminal/economy/economy_controller.py
+++ b/openbb_terminal/economy/economy_controller.py
@@ -1011,7 +1011,11 @@ class EconomyController(BaseController):
             investingcom_model.check_correct_country(ns_parser.country)
 
             if ns_parser.source == "FRED":
-                fred_view.display_yield_curve(ns_parser.date)
+                fred_view.display_yield_curve(
+                    ns_parser.date,
+                    raw=ns_parser.raw,
+                    export=ns_parser.export,
+                )
             elif ns_parser.source == "investpy":
                 investingcom_view.display_yieldcurve(
                     country=ns_parser.country,

--- a/openbb_terminal/economy/fred_model.py
+++ b/openbb_terminal/economy/fred_model.py
@@ -257,5 +257,9 @@ def get_yield_curve(date: Optional[datetime]) -> Tuple[pd.DataFrame, str]:
             return pd.DataFrame(), date.strftime("%Y-%m-%d")
         rates = pd.DataFrame(series.values.T, columns=["Rate"])
 
-    rates["Maturity"] = [1 / 12, 1 / 4, 1 / 2, 1, 2, 3, 5, 7, 10, 20, 30]
+    rates.insert(
+        0,
+        "Maturity",
+        ["1M", "3M", "6M", "1Y", "2Y", "3Y", "5Y", "7Y", "10Y", "20Y", "30Y"],
+    )
     return rates, date_of_yield

--- a/openbb_terminal/economy/fred_view.py
+++ b/openbb_terminal/economy/fred_view.py
@@ -230,7 +230,7 @@ def display_yield_curve(
             rates,
             headers=list(rates.columns),
             show_index=False,
-            title=f"US Yield Curve for {date_of_yield.strftime('%Y-%m-%d')}",
+            title=f"United States Yield Curve for {date_of_yield.strftime('%Y-%m-%d')}",
             floatfmt=".3f",
         )
 


### PR DESCRIPTION
# Description

This PR fixes the --raw and --export outputs when `ycrv --source FRED --raw --export csv` is used. Currently, those flags only work for the default source `investpy`. If user picks FRED he cannot display raw data or export it to csv. 

![image](https://user-images.githubusercontent.com/79287829/180327919-b9105b8b-cf6d-4348-b0c0-59532f2590a4.png)


- [x] Summary of the change / bug fix.
- [x] Relevant motivation and context. 


Test:
ycrv --source FRED -d 2021-01-04  --raw --export csv


# Others
- [x] I have performed a self-review of my own code.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
