### PR TITLE
Fix link for Quantitative Analysis

### DIFF
--- a/website/content/terminal/economy/_index.md
+++ b/website/content/terminal/economy/_index.md
@@ -13,7 +13,7 @@ Next to that, the databases of <a href="https://www.econdb.com/" target="_blank"
 can be accessed via <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/economy/macro/" target="_blank">macro</a>,
 <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/economy/fred/" target="_blank">fred</a> and
 <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/economy/index/" target="_blank">index</a> respectively.
-All of this can also be further analysed with <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/common/pred/" target="_blank">Prediction Techniques</a> (`pred`) and <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/common/quantitative_analysis/" target="_blank">Quantitative Techniques</a> (`qa`).
+All of this can also be further analysed with <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/common/pred/" target="_blank">Prediction Techniques</a> (`pred`) and <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/common/qa/" target="_blank">Quantitative Techniques</a> (`qa`).
 
 ## How to use
 


### PR DESCRIPTION
# Description

- Just replaced "https://openbb-finance.github.io/OpenBBTerminal/terminal/common/quantitative_analysis/" by "https://openbb-finance.github.io/OpenBBTerminal/terminal/common/qa/"