### PR TITLE
[Bugfix/Stocks/KeyMetricsExport] Add export call to FA key metrics controller

### DIFF
--- a/openbb_terminal/stocks/fundamental_analysis/av_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/av_view.py
@@ -50,7 +50,7 @@ def display_overview(ticker: str):
 
 @log_start_end(log=logger)
 @check_api_key(["API_KEY_ALPHAVANTAGE"])
-def display_key(ticker: str):
+def display_key(ticker: str, export: str = ""):
     """Alpha Vantage key metrics
 
     Parameters
@@ -66,6 +66,8 @@ def display_key(ticker: str):
     print_rich_table(
         df_key, headers=[""], title=f"{ticker} Key Metrics", show_index=True
     )
+
+    export_data(export, os.path.dirname(os.path.abspath(__file__)), "key", df_key)
 
 
 @log_start_end(log=logger)

--- a/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -764,7 +764,7 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
-            av_view.display_key(self.ticker)
+            av_view.display_key(ticker=self.ticker, export=ns_parser.export)
 
     @log_start_end(log=logger)
     def call_income(self, other_args: List[str]):

--- a/tests/openbb_terminal/stocks/fundamental_analysis/test_fa_controller.py
+++ b/tests/openbb_terminal/stocks/fundamental_analysis/test_fa_controller.py
@@ -301,6 +301,12 @@ def test_call_func_expect_queue(expected_queue, queue, func):
             {"TSLA"},
         ),
         (
+            "call_key",
+            "av_view.display_key",
+            ["--export=xlsx"],
+            dict(ticker="TSLA", export="xlsx"),
+        ),
+        (
             "call_income",
             "av_view.display_income_statement",
             ["--source=av", "--export=csv", "--limit=5"],


### PR DESCRIPTION
# Description

- [x] Summary of the change / bug fix.
The stocks/fa/key call does not handle the `--export` parameter even though it is documented.
- [x] Link # issue, if applicable: #2181
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
**Before**
<img width="1900" alt="image" src="https://user-images.githubusercontent.com/20739674/181089342-1310647a-3cf1-4117-bb19-dcc2e5312bd5.png">
**After**
<img width="1900" alt="image" src="https://user-images.githubusercontent.com/20739674/181089610-afdeb60f-a1a0-4650-9446-f4a295c8cafd.png">

- [x] Relevant motivation and context: Prior to this change, user can not export key metrics of a stock.
- [x] List any dependencies that are required for this change: **N/A**


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
Running `stocks` >> `load goog` >> `fa` >> `key --export xlsx` after the change saves an export file which does not get exported without this change.

* Provide instructions so we can reproduce. 
Running `stocks` >> `load goog` >> `fa` >> `key --export xlsx`, no file is exported.

* Please also list any relevant details for your test configuration.
N/a

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
