### PR TITLE
Fix TypeError in /stocks/quantitative_analysis/beta_model

### DIFF
--- a/openbb_terminal/stocks/quantitative_analysis/beta_model.py
+++ b/openbb_terminal/stocks/quantitative_analysis/beta_model.py
@@ -1,6 +1,6 @@
+from typing import Tuple
 import pandas as pd
 from scipy import stats
-from typing import Tuple
 from openbb_terminal.stocks import stocks_helper
 
 

--- a/openbb_terminal/stocks/quantitative_analysis/beta_model.py
+++ b/openbb_terminal/stocks/quantitative_analysis/beta_model.py
@@ -8,7 +8,7 @@ def beta_model(
     ref_ticker: str,
     stock: pd.DataFrame = None,
     ref: pd.DataFrame = None,
-) -> tuple[pd.Series, pd.Series, float, float]:
+) -> tuple([pd.Series, pd.Series, float, float]):
     """Calculate beta for a ticker and a reference ticker.
 
     Parameters

--- a/openbb_terminal/stocks/quantitative_analysis/beta_model.py
+++ b/openbb_terminal/stocks/quantitative_analysis/beta_model.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from scipy import stats
+from typing import Tuple
 from openbb_terminal.stocks import stocks_helper
 
 
@@ -8,7 +9,7 @@ def beta_model(
     ref_ticker: str,
     stock: pd.DataFrame = None,
     ref: pd.DataFrame = None,
-) -> tuple([pd.Series, pd.Series, float, float]):
+) -> Tuple[pd.Series, pd.Series, float, float]:
     """Calculate beta for a ticker and a reference ticker.
 
     Parameters


### PR DESCRIPTION
# Description

- Fixes TypeError when importing openbb in Python or trying to load qa module in terminal
- Solves #2189

# How has this been tested?

- Manually checking that no errors are raised for:

```python
from openbb_terminal import api as openbb
```

>  \>>

```bash
python terminal.py
stocks
load AAPL
qa
```
>  $

