### PR TITLE
Improved verbosity of dd rating failure, and add color to the chart

### DIFF
--- a/openbb_terminal/stocks/due_diligence/fmp_model.py
+++ b/openbb_terminal/stocks/due_diligence/fmp_model.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from openbb_terminal import config_terminal as cfg
 from openbb_terminal.decorators import log_start_end
+from openbb_terminal.rich_config import console
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ def get_rating(ticker: str) -> pd.DataFrame:
         try:
             df = fa.rating(ticker, cfg.API_KEY_FINANCIALMODELINGPREP)
         except ValueError as e:
+            console.print(f"[red]{e}[/red]\n")
             logger.exception(str(e))
             df = pd.DataFrame()
     else:

--- a/openbb_terminal/stocks/due_diligence/fmp_view.py
+++ b/openbb_terminal/stocks/due_diligence/fmp_view.py
@@ -25,6 +25,7 @@ def rating(ticker: str, num: int, export: str):
         Export dataframe data to csv,json,xlsx file
     """
     df = fmp_model.get_rating(ticker)
+    print(df)
 
     # TODO: This could be displayed in a nice rating plot over time
     # TODO: Add coloring to table

--- a/openbb_terminal/stocks/due_diligence/fmp_view.py
+++ b/openbb_terminal/stocks/due_diligence/fmp_view.py
@@ -11,6 +11,14 @@ from openbb_terminal.stocks.due_diligence import fmp_model
 logger = logging.getLogger(__name__)
 
 
+def add_color(value: str) -> str:
+    if "buy" in value.lower():
+        value = f"[green]{value}[/green]"
+    elif "sell" in value.lower():
+        value = f"[red]{value}[/red]"
+    return value
+
+
 @log_start_end(log=logger)
 def rating(ticker: str, num: int, export: str):
     """Display ratings for a given ticker. [Source: Financial Modeling Prep]
@@ -25,12 +33,11 @@ def rating(ticker: str, num: int, export: str):
         Export dataframe data to csv,json,xlsx file
     """
     df = fmp_model.get_rating(ticker)
-    print(df)
 
     # TODO: This could be displayed in a nice rating plot over time
-    # TODO: Add coloring to table
 
     if not df.empty:
+        df = df.astype(str).applymap(lambda x: add_color(x))
         l_recoms = [col for col in df.columns if "Recommendation" in col]
         l_recoms_show = [
             recom.replace("rating", "")

--- a/tests/openbb_terminal/stocks/due_diligence/txt/test_fmp_view/test_rating.txt
+++ b/tests/openbb_terminal/stocks/due_diligence/txt/test_fmp_view/test_rating.txt
@@ -1,8 +1,7 @@
-           ratingRecommendation ratingDetailsDCFRecommendation ratingDetailsROERecommendation ratingDetailsROARecommendation ratingDetailsDERecommendation ratingDetailsPERecommendation ratingDetailsPBRecommendation
-date                                                                                                                                                                                                                  
-2021-11-16           Strong Buy                     Strong Buy                        Neutral                        Neutral                           Buy                    Strong Buy                    Strong Buy
-2021-11-15           Strong Buy                     Strong Buy                        Neutral                        Neutral                           Buy                    Strong Buy                    Strong Buy
-2021-11-12           Strong Buy                     Strong Buy                        Neutral                        Neutral                           Buy                    Strong Buy                    Strong Buy
-2021-11-11           Strong Buy                     Strong Buy                        Neutral                        Neutral                           Buy                    Strong Buy                    Strong Buy
-2021-11-10           Strong Buy                     Strong Buy                        Neutral                        Neutral                           Buy                    Strong Buy                    Strong Buy
-
+                 ratingRecommendation ratingDetailsDCFRecommendation ratingDetailsROERecommendation ratingDetailsROARecommendation ratingDetailsDERecommendation ratingDetailsPERecommendation ratingDetailsPBRecommendation
+date                                                                                                                                                                                                                        
+2021-11-16  [green]Strong Buy[/green]      [green]Strong Buy[/green]                        Neutral                        Neutral            [green]Buy[/green]     [green]Strong Buy[/green]     [green]Strong Buy[/green]
+2021-11-15  [green]Strong Buy[/green]      [green]Strong Buy[/green]                        Neutral                        Neutral            [green]Buy[/green]     [green]Strong Buy[/green]     [green]Strong Buy[/green]
+2021-11-12  [green]Strong Buy[/green]      [green]Strong Buy[/green]                        Neutral                        Neutral            [green]Buy[/green]     [green]Strong Buy[/green]     [green]Strong Buy[/green]
+2021-11-11  [green]Strong Buy[/green]      [green]Strong Buy[/green]                        Neutral                        Neutral            [green]Buy[/green]     [green]Strong Buy[/green]     [green]Strong Buy[/green]
+2021-11-10  [green]Strong Buy[/green]      [green]Strong Buy[/green]                        Neutral                        Neutral            [green]Buy[/green]     [green]Strong Buy[/green]     [green]Strong Buy[/green]


### PR DESCRIPTION
# Description

Fixes #2195 by showing what the error received and makes the chart that is printed show in color (removed a TODO)


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
