### PR TITLE
Adding draft release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+name-template: 'OpenBB Terminal v$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+
+template: |
+  ## Thank you and welcome to our new contributors 🔥
+  $CONTRIBUTORS
+
+  ## What's changed 🚀
+  $CHANGES
+
+  We are proud of our community contributors and staunch supporters of open-source ecosystems.
+  Help us promote our community by tagging `@openbb_finance` on Twitter with a link to your pull request,
+  and join our Discord server to chat about your contribution! We want to hear about your experience!
+
+  ### Links 🦋
+  [Website](https://openbb.co/), [Twitter](https://twitter.com/openbb_finance),
+  [Linkedin](https://www.linkedin.com/company/openbb-finance), [Instagram](https://www.instagram.com/openbb.finance/),
+  [Reddit](https://www.reddit.com/r/openbb/), [Discord](https://discord.com/invite/xPHTuHCmuV)

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,4 @@ template: |
   and join our Discord server to chat about your contribution! We want to hear about your experience!
 
   ### Links 🦋
-  [Website](https://openbb.co/), [Twitter](https://twitter.com/openbb_finance),
-  [Linkedin](https://www.linkedin.com/company/openbb-finance), [Instagram](https://www.instagram.com/openbb.finance/),
-  [Reddit](https://www.reddit.com/r/openbb/), [Discord](https://discord.com/invite/xPHTuHCmuV)
+  [Website](https://openbb.co/), [Twitter](https://twitter.com/openbb_finance), [Linkedin](https://www.linkedin.com/company/openbb-finance), [Instagram](https://www.instagram.com/openbb.finance/), [Reddit](https://www.reddit.com/r/openbb/), [Discord](https://discord.com/invite/xPHTuHCmuV)

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,11 @@
+name: Release Drafter
+
+on: workflow_dispatch
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
Creates a draft release on demand. To run, navigate 'Release Drafter' in Github Actions and click 'Run Workflow'. The draft release includes:
- Title with new version
- New version tag
- List of contributors
- List of commits/changes
- Links to socials/website/etc

Individuals completing the release process simply need to attach the correct release files and proof-read the draft.

# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
