### PR TITLE
fix: typo in tradinghours_controller.py

### DIFF
--- a/openbb_terminal/stocks/tradinghours/tradinghours_controller.py
+++ b/openbb_terminal/stocks/tradinghours/tradinghours_controller.py
@@ -65,7 +65,7 @@ class TradingHoursController(BaseController):
                 else:
                     self.symbol_market_open = False
             else:
-                console.print(f"The ticker {ticker} was not find in the database.")
+                console.print(f"The ticker {ticker} was not found in the database.")
 
         self.source = "yf"
         self.data = pd.DataFrame()


### PR DESCRIPTION
Fix minor typo in the message shown when ticker is not found in equities list