### PR TITLE
[docs] removed -s flag from documentation

### DIFF
--- a/website/content/terminal/stocks/options/_index.md
+++ b/website/content/terminal/stocks/options/_index.md
@@ -16,7 +16,7 @@ At the bottom of the menu, and near the top, there are items prefaced with `>`. 
 
   - `screen` is a dedicated options screener that uses `.ini` files from the local installation folder `/OpenBBTerminal/openbb_terminal/stocks/options/presets/`. Refer to the Options Screener Guide <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/stocks/options/screen/" target="_blank">here</a>.
 
-  - `pricing` is another method for calculating options prices. See the guide for this submenu <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/stocks/options/pricing/" target="_blank">here</a>. 
+  - `pricing` is another method for calculating options prices. See the guide for this submenu <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/stocks/options/pricing/" target="_blank">here</a>.
 
   - `hedge` is a group of features for calculating a delta-neutral position. The guide for this submenu is located <a href="https://openbb-finance.github.io/OpenBBTerminal/terminal/stocks/options/hedge/" target="_blank">here</a>.
 
@@ -29,17 +29,17 @@ Navigate to the menu by typing `options`, from the `Stocks` menu, and then press
 <h3>Market Coverage and Data Sources</h3>
 
 At the time of writing, OpenBB is able to provide coverage only for US-listed equity and ETF options. While not officially supported, some additional markets and index options may be accessible with yFinance as the source. Coverage will be added as the product grows to incorporate more community contributions but, for now, it is safe to generalize equity options as referring to US-listed companies on a major exchange and are priced in $USD.<br></br>
-By default, the Terminal loads a ticker using <a href="https://developer.tradier.com/" target="_blank">Tradier</a> as the source. It's not perfect but the price is right. Sign up for a free developer account and then enter that token using the <a href="https://openbb-finance.github.io/OpenBBTerminal/#accessing-other-sources-of-data-via-api-keys" target="_blank">`keys`</a> function. Alternatively, there is a choice to use yFinance data sets by attaching the argument as shown below. Help dialogues are displayed for any command by adding `-h` to the string. It is worth noting that this load command is different than the load command elsewhere. 
+By default, the Terminal loads a ticker using <a href="https://developer.tradier.com/" target="_blank">Tradier</a> as the source. It's not perfect but the price is right. Sign up for a free developer account and then enter that token using the <a href="https://openbb-finance.github.io/OpenBBTerminal/#accessing-other-sources-of-data-via-api-keys" target="_blank">`keys`</a> function. Alternatively, there is a choice to use yFinance data sets by attaching the argument as shown below. Help dialogues are displayed for any command by adding `-h` to the string. It is worth noting that this load command is different than the load command elsewhere.
 ````
 (🦋) /stocks/options/ $ load -h
-usage: load [-t TICKER] [-s {tr,yf}] [-h]
+usage: load [-t TICKER] [--source {tradier,yf}] [-h]
 
 Load a ticker into option menu
 
 optional arguments:
   -t TICKER, --ticker TICKER
                         Stock ticker (default: None)
-  -s {tr,yf}, --source {tr,yf}
+  --source  {tradier ,yf}    Tradier or Yahoo Finance (default: tr)
                         Source to get option expirations from (default: None)
   -h, --help            show this help message (default: False)
 ````
@@ -54,7 +54,7 @@ To begin, a ticker must be loaded with an expiration date selected. Enter these 
 
 (🦋) /stocks/options/ $ exp
 
-   Available expiry dates   
+   Available expiry dates
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Identifier ┃ Date       ┃
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━┩
@@ -101,7 +101,7 @@ Choose an expiration date with the corresponding Identifier value on the left.
 
 ````
 (🦋) /stocks/options/ $ exp 16
-Expiration set to 2023-09-15 
+Expiration set to 2023-09-15
 ````
 Setting the chain for analysis will change the text colour at the bottom of the Options menu. These commands require loaded data.
 
@@ -111,7 +111,7 @@ The `info` command displays a table of notable statistics.
 ````
 (🦋) /stocks/options/ $ info
 
-                Options Information                
+                Options Information
 ┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Info                  ┃ Value                   ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩

--- a/website/content/terminal/stocks/options/hist/_index.md
+++ b/website/content/terminal/stocks/options/hist/_index.md
@@ -1,21 +1,18 @@
 ```
-usage: hist -s STRIKE [-p] [-c CHAIN_ID] [-r] [--source {td,ce}] [-l LIMIT] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
+usage: hist -s STRIKE [-p] [-c CHAIN_ID] [-r] [--source {tradier,chartexchange}] [-l LIMIT] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
 ```
 
 The price history for a specified strike price from the loaded options chain.
 
 ```
 optional arguments:
-  -s STRIKE, --strike STRIKE
-                        Strike price to look at (default: None)
-  -p, --put             Flag for showing put option (default: False)
-  -c CHAIN_ID, --chain CHAIN_ID
-                        OCC option symbol (default: None)
-  -r, --raw             Display raw data (default: False)
-  --source {td,ce}      Choose Tradier(TD) or ChartExchange (CE), only affects raw data (default: ce)
-  -l LIMIT, --limit LIMIT
-                        Limit of data rows to display (default: None)
-  -h, --help            show this help message (default: False)
+  -s STRIKE, --strike STRIKE         Strike price to look at (default: None)
+  -p, --put                          Flag for showing put option (default: False)
+  -c CHAIN_ID, --chain CHAIN_ID      OCC option symbol (default: None)
+  -r, --raw                          Display raw data (default: False)
+  --source {tradier,chartexchange}   Choose Tradier or ChartExchange, only affects raw data (default: chartexchange)
+  -l LIMIT, --limit LIMIT            Limit of data rows to display (default: None)
+  -h, --help                         show this help message (default: False)
   --export {csv,json,xlsx,png,jpg,pdf,svg}
                         Export raw data into csv, json, xlsx and figure into png, jpg, pdf, svg (default: )
 ```

--- a/website/content/terminal/stocks/options/load/_index.md
+++ b/website/content/terminal/stocks/options/load/_index.md
@@ -1,5 +1,5 @@
 ```
-usage: load [-t TICKER] [-s {tr,yf}] [-h]
+usage: load [-t TICKER] [--source {tradier,yf}] [-h]
 ```
 
 Load a ticker into the Options menu
@@ -8,7 +8,7 @@ Load a ticker into the Options menu
 optional arguments:
   -t TICKER, --ticker TICKER
                         Stock ticker (default: None)
-  -s {tr,yf}, --source {tr,yf}
+  --source  {tradier ,yf}    Tradier or Yahoo Finance (default: tradier)
                         Source to get option expirations from (default: None)
   -h, --help            show this help message (default: False)
 ```

--- a/website/content/terminal/stocks/options/oi/_index.md
+++ b/website/content/terminal/stocks/options/oi/_index.md
@@ -1,18 +1,18 @@
 ```
-usage: oi [-m MIN] [-M MAX] [-c] [-p] [-s {tr,yf}] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
+usage: oi [-m MIN] [-M MAX] [-c] [-p] [--source {tradier,yf}] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
 ```
 
-Plot open interest. Open interest is the number of outstanding contracts, which typically represent one hundred shares. 
+Plot open interest. Open interest is the number of outstanding contracts, which typically represent one hundred shares.
 
 ```
 optional arguments:
-  -m MIN, --min MIN     Min strike to plot (default: -1)
-  -M MAX, --max MAX     Max strike to plot (default: -1)
-  -c, --calls           Flag to plot call options only (default: False)
-  -p, --puts            Flag to plot put options only (default: False)
-  -s {tr,yf}, --source {tr,yf}
-                        Source to get data from (default: tr)
-  -h, --help            show this help message (default: False)
+  -m MIN, --min MIN           Min strike to plot (default: -1)
+  -M MAX, --max MAX           Max strike to plot (default: -1)
+  -c, --calls                 Flag to plot call options only (default: False)
+  -p, --puts                  Flag to plot put options only (default: False)
+  --source  {tradier ,yf}     Source to get data from (default: tradier)
+
+  -h, --help                  show this help message (default: False)
   --export {csv,json,xlsx,png,jpg,pdf,svg}
                         Export raw data into csv, json, xlsx and figure into png, jpg, pdf, svg (default: )
 ```

--- a/website/content/terminal/stocks/options/voi/_index.md
+++ b/website/content/terminal/stocks/options/voi/_index.md
@@ -1,19 +1,15 @@
 ```
-usage: voi [-v MIN_VOL] [-m MIN_SP] [-M MAX_SP] [-s {tr,yf}] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
+usage: voi [-v MIN_VOL] [-m MIN_SP] [-M MAX_SP] [--source {tradier,yf}] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
 ```
 
 Plots volume and open interest of calls vs puts for the selected expiration date.
 
 ```
 optional arguments:
-  -v MIN_VOL, --minv MIN_VOL
-                        minimum volume (considering open interest) threshold of the plot. (default: -1)
-  -m MIN_SP, --min MIN_SP
-                        minimum strike price to consider in the plot. (default: -1)
-  -M MAX_SP, --max MAX_SP
-                        maximum strike price to consider in the plot. (default: -1)
-  -s {tr,yf}, --source {tr,yf}
-                        Source to get data from (default: tr)
+  -v MIN_VOL, --minv MIN_VOL minimum volume (considering open interest) threshold of the plot. (default: -1)
+  -m MIN_SP, --min MIN_SP    minimum strike price to consider in the plot. (default: -1)
+  -M MAX_SP, --max MAX_SP    maximum strike price to consider in the plot. (default: -1)
+  --source  {tradier ,yf}    Source to get data from (default: tradier)
   -h, --help            show this help message (default: False)
   --export {csv,json,xlsx,png,jpg,pdf,svg}
                         Export raw data into csv, json, xlsx and figure into png, jpg, pdf, svg (default: )

--- a/website/content/terminal/stocks/options/vol/_index.md
+++ b/website/content/terminal/stocks/options/vol/_index.md
@@ -1,18 +1,17 @@
 ```
-usage: vol [-m MIN] [-M MAX] [-c] [-p] [-s {tr,yf}] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
+usage: vol [-m MIN] [-M MAX] [-c] [-p] [--source {tradier,yf}] [-h] [--export {csv,json,xlsx,png,jpg,pdf,svg}]
 ```
 
 Plot volume. Volume refers to the number of contracts traded today.
 
 ```
 optional arguments:
-  -m MIN, --min MIN     Min strike to plot (default: -1)
-  -M MAX, --max MAX     Max strike to plot (default: -1)
-  -c, --calls           Flag to plot call options only (default: False)
-  -p, --puts            Flag to plot put options only (default: False)
-  -s {tr,yf}, --source {tr,yf}
-                        Source to get data from (default: tr)
-  -h, --help            show this help message (default: False)
+  -m MIN, --min MIN          Min strike to plot (default: -1)
+  -M MAX, --max MAX          Max strike to plot (default: -1)
+  -c, --calls                Flag to plot call options only (default: False)
+  -p, --puts                 Flag to plot put options only (default: False)
+  --source  {tradier ,yf}    Source to get data from (default: tradier)
+  -h, --help                 show this help message (default: False)
   --export {csv,json,xlsx,png,jpg,pdf,svg}
                         Export raw data into csv, json, xlsx and figure into png, jpg, pdf, svg (default: )
 ```


### PR DESCRIPTION
Website documentation fixes:

1. `-s` does not exist for stocks/options, must use --source

2. per _data_sources_default.json_, fixed incorrect references to sources in the options module:
-`tr`  must be full name: `tradier`
-`ce` must be full name: `chartexchange`

3. Whitespace removal (end of line, etc.)

Functions and `--help` information are already correct, we just needed to correct the website docs

# Description

- [X] Summary of the change / bug fix.
- [X] Link # issue, if applicable. #2378 
- [X] Screenshot of the feature or the bug before/after fix, if applicable.
- [X] Relevant motivation and context. 
     - docs don't match actual behavior (difficult for new users)
     - Tradier no longer offers developer-only licenses, brokerage accounts are required, so Yahoo finance may be a preference
- [X] List any dependencies that are required for this change.
     - none

# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
     * viewed the relevant markdown files in github after pushing to my fork
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [X] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [X] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [X] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [X] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [X] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
