### PR TITLE
Allow home access "/" from anywhere

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -134,6 +134,13 @@ def parse_and_split_input(an_input: str, custom_filters: List) -> List[str]:
     List[str]
         Command queue as list
     """
+    # Make sure that the user can go back to the root when doing "/"
+    if an_input:
+        if an_input == "/":
+            an_input = "home"
+        elif an_input[0] == "/":
+            an_input = "home" + an_input
+
     # everything from ` -f ` to the next known extension
     file_flag = r"(\ -f |\ --file )"
     up_to = r".*?"
@@ -175,7 +182,6 @@ def parse_and_split_input(an_input: str, custom_filters: List) -> List[str]:
         if len(matching_placeholders) > 0:
             for tag in matching_placeholders:
                 commands[command_num] = command.replace(tag, placeholders[tag])
-
     return commands
 
 

--- a/openbb_terminal/parent_classes.py
+++ b/openbb_terminal/parent_classes.py
@@ -102,7 +102,6 @@ class BaseController(metaclass=ABCMeta):
         """
         self.check_path()
         self.path = [x for x in self.PATH.split("/") if x != ""]
-
         self.queue = (
             self.parse_input(an_input="/".join(queue))
             if (queue and self.PATH != "/")
@@ -648,6 +647,10 @@ class BaseController(metaclass=ABCMeta):
                     an_input = "exit"
 
             try:
+                # Allow user to go back to root
+                if an_input == "/":
+                    an_input = "home"
+
                 # Process the input command
                 self.queue = self.switch(an_input)
 


### PR DESCRIPTION
With the forward slash fix (@piiq), the access to the root directly using "/" was lost, and also to fast switching menus, e.g. "/crypto/load btc/dd". This PR fixes that.