### PR TITLE
Makes running exe files more robust 

### DIFF
--- a/routines/fa_demo.openbb
+++ b/routines/fa_demo.openbb
@@ -1,4 +1,5 @@
 # Demonstration of the Fundamental Analysis features, with a user-defined ticker.
+# This can be done on the home menu through 'exe fa_demo.openbb -i AAPL'
 
 # Enter stocks menu, load $ARGV[0], enter the Fundamental Analysis submenu and show a quote and overview statistics.
 stocks

--- a/terminal.py
+++ b/terminal.py
@@ -46,7 +46,7 @@ from openbb_terminal.terminal_helper import (
 )
 from openbb_terminal.helper_funcs import parse_and_split_input
 
-# pylint: disable=too-many-public-methods,import-outside-toplevel,too-many-branches,no-member
+# pylint: disable=too-many-public-methods,import-outside-toplevel,too-many-branches,no-member,C0302
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
I believe #2399 has been fixed, but I realised that if the user run a script that expected parameters this was not flagging as an issue, neither if the number of parameters was under the number of params required by the script. 

So I added this.