### PR TITLE
Fix: issue #2372

### DIFF
--- a/openbb_terminal/portfolio/portfolio_optimization/optimizer_view.py
+++ b/openbb_terminal/portfolio/portfolio_optimization/optimizer_view.py
@@ -2178,6 +2178,11 @@ def display_ef(
         ax = external_axes[0]
 
     frontier = pd.concat([frontier, random_weights], axis=1)
+    # to delete stocks with corrupted data
+    frontier.drop(
+        frontier.tail(len(random_weights.index) - len(stock_returns.columns)).index,
+        inplace=True,
+    )
     ax = rp.plot_frontier(
         w_frontier=frontier,
         mu=mu,


### PR DESCRIPTION
# Description

Fixes #2372. The issue was with stocks with corrupted data also being added to the frontier df causing a mismatch in sizes between returns and frontier dfs
ef of SP500 portfolio
![image](https://user-images.githubusercontent.com/85685255/187092566-7d3bbbbb-bd87-46f5-b6b0-eff6e8c61efc.png)

