### PR TITLE
Bug: Fix same-day error for portfolio historical trades.

### DIFF
--- a/openbb_terminal/portfolio/portfolio_model.py
+++ b/openbb_terminal/portfolio/portfolio_model.py
@@ -1165,14 +1165,19 @@ class PortfolioModel:
         # Set current price of benchmark
         self.benchmark_trades["Last price"] = self.benchmark_historical_prices[-1]
         self.benchmark_trades[["Benchmark Quantity", "Trade price"]] = float(0)
-
         # Iterate over orderbook to replicate trades on benchmark
         for index, trade in self.__orderbook.iterrows():
             # Select date to search (if not in historical prices, get closest value)
             if trade["Date"] not in self.benchmark_historical_prices.index:
-                date = self.benchmark_historical_prices.index.searchsorted(
+                found_date = self.benchmark_historical_prices.index.searchsorted(
                     trade["Date"]
                 )
+                # Fix error if trade was today and there are no historical price data rows
+                if self.benchmark_historical_prices.index.isin([found_date]).any():
+                    date = found_date
+                else:
+                    # If no historical price data, use last row
+                    date = self.benchmark_historical_prices.index[-1]
             else:
                 date = trade["Date"]
 


### PR DESCRIPTION
# Description

During portfolio loading, adds last traded date in historical prices if last date isn't available. This is a very odd time dependent off by 1 error, so testing this might be difficult.

# Issue
#2450 

- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [ ] ~Screenshot of the feature or the bug before/after fix, if applicable.~
- [x] Relevant motivation and context. 
- [ ] ~List any dependencies that are required for this change.~


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] ~Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).~
- [ ] ~Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).~
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] ~If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).~


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
