### PR TITLE
Fix light terminal stylesheet that would prevent using it in notebooks

### DIFF
--- a/openbb_terminal/config_terminal.py
+++ b/openbb_terminal/config_terminal.py
@@ -14,9 +14,9 @@ if env_files:
 
 # Terminal UX section
 theme = _TerminalStyle(
-    os.getenv("OPENBB_MPLSTYLE") or "boring",
-    os.getenv("OPENBB_MPFSTYLE") or "boring",
-    os.getenv("OPENBB_RICHSTYLE") or "boring",
+    os.getenv("OPENBB_MPLSTYLE") or "light",
+    os.getenv("OPENBB_MPFSTYLE") or "light",
+    os.getenv("OPENBB_RICHSTYLE") or "light",
 )
 
 # Set to True to see full stack traces for debugging/error reporting

--- a/styles/default/light.mplrc.json
+++ b/styles/default/light.mplrc.json
@@ -2,5 +2,6 @@
     "xticks_rotation": 10,
     "tight_layout_padding": 2,
     "pie_wedgeprops": {"linewidth": 0.5, "edgecolor": "#000000"},
-    "pie_startangle": 90
+    "pie_startangle": 90,
+    "volume_bar_width": 0.5
 }


### PR DESCRIPTION
This 👆

To validate you can run the following in a notebook:
<img width="542" alt="image" src="https://user-images.githubusercontent.com/11668535/187682898-beef081b-b73c-4e65-a35d-de2f02a02e45.png">
