### PR TITLE
redact inception date from investpy when incorrect

### DIFF
--- a/openbb_terminal/mutual_funds/investpy_view.py
+++ b/openbb_terminal/mutual_funds/investpy_view.py
@@ -118,8 +118,8 @@ def display_fund_info(name: str, country: str = "united states"):
 
     # redact inception date if it appears castable to a float
     try:
-        float(info[0].loc[info['index'] == 'Inception Date'].values[0])
-        info.loc[info['index']=='Inception Date', 0] = np.nan
+        float(info[0].loc[info["index"] == "Inception Date"].values[0])
+        info.loc[info["index"] == "Inception Date", 0] = np.nan
     except ValueError:
         pass
 

--- a/openbb_terminal/mutual_funds/investpy_view.py
+++ b/openbb_terminal/mutual_funds/investpy_view.py
@@ -115,6 +115,14 @@ def display_fund_info(name: str, country: str = "united states"):
         .applymap(lambda x: np.nan if not x else x)
         .dropna()
     )
+
+    # redact inception date if it appears castable to a float
+    try:
+        float(info[0].loc[info['index'] == 'Inception Date'].values[0])
+        info.loc[info['index']=='Inception Date', 0] = np.nan
+    except ValueError:
+        pass
+
     print_rich_table(
         info,
         title=f"[bold]{name.title()} Information[/bold]",


### PR DESCRIPTION
# Description

- [ ] Summary of the change / bug fix.
Redact Inception Date from Investpy and replace it with NA in instances where the result appears as a decimal instead of date type.
- [ ] Link # issue, if applicable.
[Bug] Funds/info - Inception Date field does not return a date for some funds, instead displays an unknown integer. #2469
https://github.com/OpenBB-finance/OpenBBTerminal/issues/2469

- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.
None


# How has this been tested?
Locally on my machine

* Please describe the tests that you ran to verify your changes. 
Replicated original bug report steps with different funds. 
* Provide instructions so we can reproduce. 

funds
load gtapx
info

* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
