### PR TITLE
Add yf for fa/earnings

### DIFF
--- a/data_sources_default.json
+++ b/data_sources_default.json
@@ -35,6 +35,10 @@
                 "polygon",
                 "av",
                 "fmp"
+            ],
+            "earnings": [
+                "yf",
+                "av"
             ]
         },
         "options": {

--- a/openbb_terminal/reports/equity.ipynb
+++ b/openbb_terminal/reports/equity.ipynb
@@ -344,7 +344,7 @@
    "outputs": [],
    "source": [
     "df = openbb.stocks.dd.models.business_insider.get_price_target_from_analysts(ticker)\n",
-    "avg_ratings_last_30_days= 0\n",
+    "avg_ratings_last_30_days = 0\n",
     "if not df.empty:\n",
     "    avg_ratings_last_30_days = round(\n",
     "        np.mean(\n",

--- a/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -150,7 +150,7 @@ class FundamentalAnalysisController(StockBaseController):
         mt.add_cmd("overview", "Alpha Vantage")
         mt.add_cmd("key", "Alpha Vantage")
         mt.add_cmd("cash", "Alpha Vantage / Yahoo Finance / FMP")
-        mt.add_cmd("earnings", "Alpha Vantage")
+        mt.add_cmd("earnings", "Alpha Vantage / Yahoo Finance")
         mt.add_cmd("fraud", "Alpha Vantage")
         mt.add_cmd("dupont", "Alpha Vantage")
         console.print(text=mt.menu_text, menu="Stocks - Fundamental Analysis")
@@ -1097,12 +1097,19 @@ class FundamentalAnalysisController(StockBaseController):
             EXPORT_ONLY_RAW_DATA_ALLOWED,
         )
         if ns_parser:
-            av_view.display_earnings(
-                symbol=self.ticker,
-                limit=ns_parser.limit,
-                quarterly=ns_parser.b_quarter,
-                export=ns_parser.export,
-            )
+            if ns_parser.source == "av":
+                av_view.display_earnings(
+                    symbol=self.ticker,
+                    limit=ns_parser.limit,
+                    quarterly=ns_parser.b_quarter,
+                    export=ns_parser.export,
+                )
+            elif ns_parser.source == "yf":
+                yahoo_finance_view.display_earnings(
+                    symbol=self.ticker, limit=ns_parser.limit, export=ns_parser.export
+                )
+            else:
+                pass
 
     @log_start_end(log=logger)
     def call_fraud(self, other_args: List[str]):

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
@@ -425,3 +425,21 @@ def get_financials(symbol: str, statement: str, ratios: bool = False) -> pd.Data
 
     df = df.dropna(how="all")
     return df
+
+
+@log_start_end(log=logger)
+def get_earnings_history(symbol: str) -> pd.DataFrame:
+    """Get earning reports
+
+    Parameters
+    ----------
+    symbol: str
+        Symbol to get earnings for
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe of historical earnings if present
+    """
+    earnings = yf.Ticker(symbol).earnings_history
+    return earnings

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -501,3 +501,32 @@ def display_fundamentals(
     export_data(
         export, os.path.dirname(os.path.abspath(__file__)), statement, fundamentals
     )
+
+
+@log_start_end(log=logger)
+def display_earnings(symbol: str, limit: int, export: str):
+    """
+
+    Parameters
+    ----------
+    symbol
+    limit
+    export
+
+    Returns
+    -------
+
+    """
+    earnings = yahoo_finance_model.get_earnings_history(symbol)
+    if not earnings:
+        console.print("")
+        return
+    earnings = earnings.drop(columns={"Symbol", "Company"})
+    print_rich_table(
+        earnings.head(limit),
+        headers=earnings.columns,
+        title=f"Historical Earnings for {symbol}",
+    )
+    export_data(
+        export, os.path.dirname(os.path.abspath(__file__)), "earnings_yf", earnings
+    )

--- a/tests/openbb_terminal/stocks/fundamental_analysis/test_fa_controller.py
+++ b/tests/openbb_terminal/stocks/fundamental_analysis/test_fa_controller.py
@@ -465,7 +465,7 @@ def test_call_func_expect_queue(expected_queue, queue, func):
         (
             "call_earnings",
             "av_view.display_earnings",
-            ["--limit=5", "--quarter", "--export=csv"],
+            ["--limit=5", "--quarter", "--export=csv", "--source=av"],
             dict(
                 symbol="TSLA",
                 limit=5,

--- a/tests/openbb_terminal/stocks/fundamental_analysis/txt/test_fa_controller/test_print_help.txt
+++ b/tests/openbb_terminal/stocks/fundamental_analysis/txt/test_fa_controller/test_print_help.txt
@@ -29,7 +29,7 @@ Ticker: TSLA
     overview           overview of the company                                         [Alpha Vantage]
     key                company key metrics                                             [Alpha Vantage]
     cash               cash flow of the company                                        [Alpha Vantage / Yahoo Finance / FMP]
-    earnings           earnings dates and reported EPS                                 [Alpha Vantage]
+    earnings           earnings dates and reported EPS                                 [Alpha Vantage / Yahoo Finance]
     fraud              key fraud ratios                                                [Alpha Vantage]
     dupont             detailed breakdown for return on equity                         [Alpha Vantage]
 


### PR DESCRIPTION
Here ya go dangle

#2485 


```
                    Historical Earnings for AAPL                     
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Earnings Date          ┃ EPS Estimate ┃ Reported EPS ┃ Surprise(%) ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ Oct 26, 2022, 4 PMEDT  │ 1.26         │ nan          │ nan         │
├────────────────────────┼──────────────┼──────────────┼─────────────┤
│ Jul 28, 2022, 12 PMEDT │ 1.16         │ 1.2          │ +3.27       │
├────────────────────────┼──────────────┼──────────────┼─────────────┤
│ Apr 28, 2022, 12 PMEDT │ 1.43         │ 1.52         │ +6.44       │
├────────────────────────┼──────────────┼──────────────┼─────────────┤
│ Jan 27, 2022, 11 AMEST │ 1.89         │ 2.1          │ +11.17      │
├────────────────────────┼──────────────┼──────────────┼─────────────┤
│ Oct 28, 2021, 12 PMEDT │ 1.24         │ 1.24         │ +0.32       │
└────────────────────────┴──────────────┴──────────────┴─────────────┘
```