### PR TITLE
Adding feedparser to spec file

### DIFF
--- a/build/pyinstaller/terminal.spec
+++ b/build/pyinstaller/terminal.spec
@@ -71,6 +71,7 @@ hidden_imports = [
     "textwrap3",
     "pyEX",
     "tensorflow",
+    "feedparser",
 ]
 
 analysis_kwargs = dict(


### PR DESCRIPTION
# Description

Fixes #2524. Seems like some modules can seemingly get lost in translation when using pyinstaller. Will have to look out for similar bugs like this in the future if they arise. 

# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
