### PR TITLE
Minor fixes in API usage

### DIFF
--- a/openbb_terminal/api.py
+++ b/openbb_terminal/api.py
@@ -953,8 +953,14 @@ functions = {
         "model": "openbb_terminal.economy.fred_model.get_yield_curve",
         "view": "openbb_terminal.economy.fred_view.display_yield_curve",
     },
+    "economy.get_events_countries": {
+        "model": "openbb_terminal.economy.investingcom_model.get_events_countries"
+    },    
     "economy.events": {
         "model": "openbb_terminal.economy.investingcom_model.get_economic_calendar"
+    },
+    "economy.get_ycrv_countries": {
+        "model": "openbb_terminal.economy.investingcom_model.get_ycrv_countries"
     },
     "economy.ycrv": {
         "model": "openbb_terminal.economy.investingcom_model.get_yieldcurve",

--- a/openbb_terminal/api.py
+++ b/openbb_terminal/api.py
@@ -955,7 +955,7 @@ functions = {
     },
     "economy.get_events_countries": {
         "model": "openbb_terminal.economy.investingcom_model.get_events_countries"
-    },    
+    },
     "economy.events": {
         "model": "openbb_terminal.economy.investingcom_model.get_economic_calendar"
     },

--- a/openbb_terminal/config_terminal.py
+++ b/openbb_terminal/config_terminal.py
@@ -17,9 +17,9 @@ dotenv.load_dotenv(REPOSITORY_ENV_FILE, override=True)
 
 # Terminal UX section
 theme = _TerminalStyle(
-    os.getenv("OPENBB_MPLSTYLE") or "light",
-    os.getenv("OPENBB_MPFSTYLE") or "light",
-    os.getenv("OPENBB_RICHSTYLE") or "light",
+    os.getenv("OPENBB_MPLSTYLE") or "boring",
+    os.getenv("OPENBB_MPFSTYLE") or "boring",
+    os.getenv("OPENBB_RICHSTYLE") or "boring",
 )
 
 # Set to True to see full stack traces for debugging/error reporting

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -391,7 +391,10 @@ def display_fundamentals(
     symbol: str
         Stock ticker symbol
     statement: str
-        Either balance or financials for income or cash-flow
+        can be:
+            cash-flow
+            financials for Income
+            balance-sheet
     limit: int
     ratios: bool
         Shows percentage change

--- a/openbb_terminal/stocks/stocks_helper.py
+++ b/openbb_terminal/stocks/stocks_helper.py
@@ -1072,6 +1072,7 @@ def display_candle(
             weekly,
             monthly,
         )
+        data = process_candle(data)
 
     if add_trend:
         if (data.index[1] - data.index[0]).total_seconds() >= 86400:

--- a/openbb_terminal/stocks/stocks_helper.py
+++ b/openbb_terminal/stocks/stocks_helper.py
@@ -1011,7 +1011,7 @@ def display_candle(
     interval: int = 1440,
     end_date: datetime = datetime.now(),
     prepost: bool = False,
-    source: str = "yf",
+    source: str = "YahooFinance",
     iexrange: str = "ytd",
     weekly: bool = False,
     monthly: bool = False,


### PR DESCRIPTION
# Description

This PR fixes some small details on the api and reverts default plot style to boring

openbb.economy.get_ycrv_countries()
openbb.economy.get_events_countries()

import datetime
openbb.stocks.candle("GME", add_trend=True, ma=[20, 50, 100], start_date=datetime.datetime(2020, 10, 18), asset_type="This is")