### PR TITLE
fixing crypto nft integration bug

### DIFF
--- a/openbb_terminal/cryptocurrency/nft/opensea_model.py
+++ b/openbb_terminal/cryptocurrency/nft/opensea_model.py
@@ -52,6 +52,9 @@ def get_collection_stats(slug: str) -> pd.DataFrame:
             "Creation Date",
             "URL",
         ]
+        # T his variable is here because sometimes the created dates also have
+        # milliseconds in the string and we dont it, so this just gets the m,d,y,h,m,s
+        created_date = collection["created_date"][0:19]
         values = [
             collection["name"],
             "-" if not stats["floor_price"] else float(stats["floor_price"]),
@@ -69,9 +72,7 @@ def get_collection_stats(slug: str) -> pd.DataFrame:
             round(float(stats["total_supply"]), 2),
             round(float(stats["total_sales"]), 2),
             round(float(stats["total_volume"]), 2),
-            datetime.strptime(
-                collection["created_date"], "%Y-%m-%dT%H:%M:%S.%f"
-            ).strftime("%b %d, %Y"),
+            datetime.strptime(created_date, "%Y-%m-%dT%H:%M:%S").strftime("%b %d, %Y"),
             "-" if not collection["external_url"] else collection["external_url"],
         ]
         df = pd.DataFrame({"Metric": metrics, "Value": values})


### PR DESCRIPTION
# Description
Fixes the crypto nft portion #2612 by truncating the created_date string to fit the criteria for the `datetime` function `strptime` since some nft data doesn't have milliseconds.

<img width="872" alt="Screen Shot 2022-09-26 at 10 57 37 PM" src="https://user-images.githubusercontent.com/53658028/192428559-386f8a8e-744c-42bd-ace2-78d4dd27c4fb.png">

# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
