### PR TITLE
fix: bug #2691

### DIFF
--- a/openbb_terminal/economy/econdb_model.py
+++ b/openbb_terminal/economy/econdb_model.py
@@ -418,6 +418,7 @@ TRANSFORM = {
 
 SCALES = {
     "Thousands": 1_000,
+    "Tens of thousands": 10_000,
     "Millions": 1_000_000,
     "Hundreds of millions": 100_000_000,
     "Billions": 1_000_000_000,


### PR DESCRIPTION
# Description
Scale of China's population given in Tens of thousands, which is missing in SCALES list. 

https://www.econdb.com/series/context/?tickers=popcn
