### PR TITLE
Data Sources Default Installer Bug Fix

### DIFF
--- a/openbb_terminal/core/config/paths_helper.py
+++ b/openbb_terminal/core/config/paths_helper.py
@@ -1,4 +1,6 @@
 # IMPORTATION STANDARD
+import os
+import shutil
 from typing import List
 
 from openbb_terminal.core.config.paths import (
@@ -12,6 +14,7 @@ from openbb_terminal.core.config.paths import (
     PRESETS_DIRECTORY,
     ROUTINES_DIRECTORY,
     DATA_SOURCES_DEFAULT_FILE,
+    REPOSITORY_DIRECTORY,
 )
 
 # pylint: disable=W0603
@@ -36,7 +39,13 @@ def create_files(list_files: List):
     for filename in list_files:
         if not filename.is_file():
             with open(str(filename), "w"):
-                pass
+                if filename == DATA_SOURCES_DEFAULT_FILE:
+                    filesize = os.path.getsize(filename)
+                    if filesize == 0:
+                        shutil.copyfile(
+                            REPOSITORY_DIRECTORY / "data_sources_default.json",
+                            filename,
+                        )
 
 
 dirs_list = [

--- a/openbb_terminal/feature_flags.py
+++ b/openbb_terminal/feature_flags.py
@@ -9,7 +9,11 @@ from dotenv import load_dotenv
 import i18n
 
 # IMPORTATION INTERNAL
-from openbb_terminal.core.config.paths import USER_ENV_FILE, REPOSITORY_ENV_FILE, DATA_SOURCES_DEFAULT_FILE
+from openbb_terminal.core.config.paths import (
+    USER_ENV_FILE,
+    REPOSITORY_ENV_FILE,
+    DATA_SOURCES_DEFAULT_FILE,
+)
 from openbb_terminal.core.config import paths_helper
 
 paths_helper.init_userdata()

--- a/terminal.py
+++ b/terminal.py
@@ -17,6 +17,7 @@ from prompt_toolkit.completion import NestedCompleter
 from prompt_toolkit.styles import Style
 from prompt_toolkit.formatted_text import HTML
 
+from openbb_terminal import feature_flags as obbff
 
 from openbb_terminal.core.config.paths import (
     REPOSITORY_DIRECTORY,
@@ -28,7 +29,7 @@ from openbb_terminal.core.config.paths import (
 from openbb_terminal.core.log.generation.path_tracking_file_handler import (
     PathTrackingFileHandler,
 )
-from openbb_terminal import feature_flags as obbff
+
 from openbb_terminal.helper_funcs import (
     check_positive,
     get_flair,


### PR DESCRIPTION
# Description
Fixes bug where installer cannot utilize the `data_sources_dafeault.json` within `OpenBBUserData` because it is empty. This solution copies either the git repositories data sources file or installer data sources file into `OpenBBUserData`. This means users can keep their data sources when they update the repo or the installer.

To recreate the issue, remove the `OpenBBUserData` folder and try to run a previous installer.


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
