### PR TITLE
Enable single day forcast with all models

### DIFF
--- a/openbb_terminal/forecast/forecast_controller.py
+++ b/openbb_terminal/forecast/forecast_controller.py
@@ -442,7 +442,7 @@ class ForecastController(BaseController):
                 "--n-days",
                 action="store",
                 dest="n_days",
-                type=check_greater_than_one,
+                type=check_positive,
                 default=5,
                 help="prediction days.",
             )

--- a/openbb_terminal/forecast/helpers.py
+++ b/openbb_terminal/forecast/helpers.py
@@ -509,7 +509,7 @@ def plot_forecast(
     pred_label = f"{name} Forecast"
     if past_covariates:
         pred_label += " w/ past covs"
-    predicted_values.plot(label=pred_label, ax=ax, **quant_kwargs, color="#00AAFF")
+    predicted_values.plot(label=pred_label, **quant_kwargs, color="#00AAFF")
     ax.set_title(
         f"{name} for ${ticker_name} for next [{n_predict}] days (MAPE={precision:.2f}%)"
     )


### PR DESCRIPTION
# Description

Plots would break when plotting single day forecast. We were limited to at least 2 days in the future.
With the new changes to the base layer Darts, we can now plot single points.

`regr AAPL -n 1 --forecast-only`
![image](https://user-images.githubusercontent.com/105685594/194777227-354e721c-7e92-40ed-af63-5917c89bbd46.png)



For probabilistic models it will show a potential "range" of where the point could lie. 
`expo AAPL -n 1 --forecast-only`
![image](https://user-images.githubusercontent.com/105685594/194777236-55dd2cb9-ef09-4a49-9e76-f9549d2c1d41.png)


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.
- [x] Make sure affected commands still run in terminal
- [x] Ensure the api still works
- [x] Check any related reports


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
