### PR TITLE
Fixed several errors in trading hours

### DIFF
--- a/openbb_terminal/stocks/tradinghours/tradinghours_controller.py
+++ b/openbb_terminal/stocks/tradinghours/tradinghours_controller.py
@@ -195,7 +195,7 @@ class TradingHoursController(BaseController):
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             bursa_view.display_open()
-
+        else:
             logger.error("No open exchanges right now.")
             console.print("[red]No open exchanges right now.[/red]\n")
 

--- a/tests/openbb_terminal/stocks/tradinghours/csv/test_bursa_model/trading_hours_df.csv
+++ b/tests/openbb_terminal/stocks/tradinghours/csv/test_bursa_model/trading_hours_df.csv
@@ -1,0 +1,3 @@
+,name,short_name,timezone,market_open,market_close,lunchbreak_start,lunchbreak_end
+AAA,Exchange With Lunch Hours,AAA,Europe/London,09:30:00,17:30:00,12:15:00,13:30:00
+BBB,Exchange Without Lunch Hours,BBB,Europe/London,09:30:00,17:30:00,,

--- a/tests/openbb_terminal/stocks/tradinghours/test_bursa_model.py
+++ b/tests/openbb_terminal/stocks/tradinghours/test_bursa_model.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from openbb_terminal.stocks.tradinghours import bursa_model
+
+TRADING_HOURS_DF = pd.read_csv(
+    "tests/openbb_terminal/stocks/tradinghours/csv/test_bursa_model/trading_hours_df.csv",
+    index_col=0,
+)
+
+DAYS_TILL_NEXT_MONDAY = (0 - datetime.utcnow().date().weekday()) % 7
+NEXT_MONDAY = datetime.utcnow() + timedelta(days=DAYS_TILL_NEXT_MONDAY)
+DAYS_TILL_NEXT_SUNDAY = (6 - datetime.utcnow().date().weekday()) % 7
+NEXT_SUNDAY = datetime.utcnow() + timedelta(days=DAYS_TILL_NEXT_SUNDAY)
+
+
+@pytest.mark.parametrize(
+    "current_time, exchange, expected",
+    [
+        (NEXT_MONDAY.replace(hour=8, minute=0, second=0), "AAA", False),
+        (NEXT_MONDAY.replace(hour=9, minute=0, second=0), "AAA", False),
+        (NEXT_MONDAY.replace(hour=12, minute=30, second=0), "AAA", False),
+        (NEXT_MONDAY.replace(hour=13, minute=15, second=0), "AAA", False),
+        (NEXT_MONDAY.replace(hour=17, minute=45, second=0), "AAA", False),
+        (NEXT_MONDAY.replace(hour=20, minute=0, second=0), "AAA", False),
+        (NEXT_MONDAY.replace(hour=9, minute=30, second=0), "AAA", True),
+        (NEXT_MONDAY.replace(hour=9, minute=45, second=0), "AAA", True),
+        (NEXT_MONDAY.replace(hour=11, minute=0, second=0), "AAA", True),
+        (NEXT_MONDAY.replace(hour=12, minute=10, second=0), "AAA", True),
+        (NEXT_MONDAY.replace(hour=13, minute=45, second=0), "AAA", True),
+        (NEXT_MONDAY.replace(hour=14, minute=0, second=0), "AAA", True),
+        (NEXT_MONDAY.replace(hour=17, minute=0, second=0), "AAA", True),
+        (NEXT_MONDAY.replace(hour=12, minute=30, second=0), "BBB", True),
+        (NEXT_SUNDAY.replace(hour=14, minute=0, second=0), "AAA", False),
+        (NEXT_SUNDAY.replace(hour=14, minute=0, second=0), "BBB", False),
+    ],
+)
+def test_check_if_open(current_time, exchange, expected, mocker):
+    path_model = "openbb_terminal.stocks.tradinghours.bursa_model"
+
+    mocked_datetime = mocker.patch(target=f"{path_model}.datetime")
+
+    mocked_datetime.utcnow().replace().astimezone.return_value = current_time
+    mocked_datetime.strptime = datetime.strptime
+
+    is_open = bursa_model.check_if_open(TRADING_HOURS_DF, exchange)
+
+    assert is_open == expected


### PR DESCRIPTION
# Description

- Fixes #2762 
- Simplified the whole conditional tree checking if the user's local datetime is inside the trading hours of an exchange.
- Fixed an error found while testing that caused `No open exchanges right now.` to always appear.
- Added unit tests.


# How has this been tested?

Tested manually and with unit tests testing multiple different scenarios.

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
