### PR TITLE
Add demark indicator to stocks/ta

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -430,6 +430,7 @@ en:
   stocks/ta/fisher: fisher transform
   stocks/ta/cg: centre of gravity
   stocks/ta/clenow: clenow volatility adjusted momentum
+  stocks/ta/demark: Tom Demark's sequential indicator
   stocks/ta/_trend_: Trend
   stocks/ta/adx: average directional movement index
   stocks/ta/aroon: aroon indicator

--- a/openbb_terminal/common/technical_analysis/momentum_model.py
+++ b/openbb_terminal/common/technical_analysis/momentum_model.py
@@ -184,7 +184,7 @@ def cg(values: pd.Series, window: int) -> pd.DataFrame:
         Length for indicator window
     Returns
     ----------
-    d.DataFrame
+    pd.DataFrame
         Dataframe of technical indicator
     """
     return pd.DataFrame(ta.cg(close=values, length=window).dropna())
@@ -232,3 +232,20 @@ def clenow_momentum(
     annualized_coef = (np.exp(coef) ** 252) - 1
 
     return r2, annualized_coef, pd.Series(lr.predict(X))
+
+
+@log_start_end(log=logger)
+def demark_seq(values: pd.Series) -> pd.DataFrame:
+    """Get the integer value for demark sequential indicator
+
+    Parameters
+    ----------
+    values: pd.Series
+        Series of close values
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe of UP and DOWN sequential indicators
+    """
+    return ta.td_seq(values, asint=True)

--- a/openbb_terminal/common/technical_analysis/momentum_view.py
+++ b/openbb_terminal/common/technical_analysis/momentum_view.py
@@ -701,7 +701,7 @@ def display_demark(
         candle_chart_kwargs["figsize"] = plot_autoscale()
         candle_chart_kwargs["warn_too_much_data"] = 100_000
 
-        fig, ax = mpf.plot(stock_data, **candle_chart_kwargs)
+        fig, _ = mpf.plot(stock_data, **candle_chart_kwargs)
         fig.suptitle(
             f"{symbol} Demark Sequential",
             x=0.055,
@@ -714,7 +714,6 @@ def display_demark(
         if len(external_axes) != 1:
             logger.error("Expected list of one axis item.")
             console.print("[red]Expected list of 1 axis items.\n[/red]")
-            return pd.DataFrame()
         ax1 = external_axes
         candle_chart_kwargs["ax"] = ax1
         mpf.plot(stock_data, **candle_chart_kwargs)

--- a/openbb_terminal/common/technical_analysis/momentum_view.py
+++ b/openbb_terminal/common/technical_analysis/momentum_view.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from pandas.plotting import register_matplotlib_converters
+import mplfinance as mpf
 
 from openbb_terminal.config_terminal import theme
 from openbb_terminal.common.technical_analysis import momentum_model
@@ -21,6 +22,7 @@ from openbb_terminal.helper_funcs import (
     is_valid_axes_count,
     print_rich_table,
 )
+from openbb_terminal.rich_config import console
 
 logger = logging.getLogger(__name__)
 
@@ -611,4 +613,115 @@ def display_clenow_momentum(
         export,
         os.path.dirname(os.path.abspath(__file__)).replace("common", "stocks"),
         "clenow",
+    )
+
+
+def display_demark(
+    data: pd.DataFrame,
+    symbol: str = "",
+    min_to_show: int = 5,
+    export: str = "",
+    external_axes: Optional[List[plt.Axes]] = None,
+):
+    """Display demark squential indicator
+
+    Parameters
+    ----------
+    data : pd.Series
+        Series of values
+    symbol : str
+        Symbol that the data corresponds to
+    min_to_show: int
+        Minimum value to show
+    export : str
+        Format to export data
+    external_axes : Optional[List[plt.Axes]], optional
+        External axes (1 axes are expected in the list), by default None
+
+    Returns
+    -------
+
+    """
+    demark_df = momentum_model.demark_seq(data["Adj Close"])
+    demark_df.index = data.index
+
+    stock_data = data.copy()
+    stock_data["up"] = demark_df.TD_SEQ_UPa
+    stock_data["down"] = demark_df.TD_SEQ_DNa
+
+    # MPLfinance can do series of markers :)
+    markersUP = (
+        stock_data["up"]
+        .apply(lambda x: f"${x}$" if x > min_to_show else None)
+        .to_list()
+    )
+    markersDOWN = (
+        stock_data["down"]
+        .apply(lambda x: f"${x}$" if x > min_to_show else None)
+        .to_list()
+    )
+
+    adp = [
+        mpf.make_addplot(
+            0.98 * stock_data["Low"],
+            type="scatter",
+            markersize=30,
+            marker=markersDOWN,
+            color="r",
+        ),
+        mpf.make_addplot(
+            1.012 * stock_data["High"],
+            type="scatter",
+            markersize=30,
+            marker=markersUP,
+            color="b",
+        ),
+    ]
+
+    # Stuff for mplfinance
+    candle_chart_kwargs = {
+        "type": "ohlc",
+        "style": theme.mpf_style,
+        "volume": False,
+        "addplot": adp,
+        "xrotation": theme.xticks_rotation,
+        "scale_padding": {"left": 0.3, "right": 1, "top": 0.8, "bottom": 0.8},
+        "update_width_config": {
+            "candle_linewidth": 0.6,
+            "candle_width": 0.8,
+            "volume_linewidth": 0.8,
+            "volume_width": 0.8,
+        },
+        "warn_too_much_data": 10000,
+    }
+    if external_axes is None:
+        candle_chart_kwargs["returnfig"] = True
+        candle_chart_kwargs["figratio"] = (10, 7)
+        candle_chart_kwargs["figscale"] = 1.10
+        candle_chart_kwargs["figsize"] = plot_autoscale()
+        candle_chart_kwargs["warn_too_much_data"] = 100_000
+
+        fig, ax = mpf.plot(stock_data, **candle_chart_kwargs)
+        fig.suptitle(
+            f"{symbol} Demark Sequential",
+            x=0.055,
+            y=0.965,
+            horizontalalignment="left",
+        )
+        theme.visualize_output(force_tight_layout=False)
+
+    else:
+        if len(external_axes) != 1:
+            logger.error("Expected list of one axis item.")
+            console.print("[red]Expected list of 1 axis items.\n[/red]")
+            return pd.DataFrame()
+        ax1 = external_axes
+        candle_chart_kwargs["ax"] = ax1
+        mpf.plot(stock_data, **candle_chart_kwargs)
+
+    export_data(
+        export,
+        os.path.dirname(os.path.abspath(__file__)).replace("common", "stocks"),
+        "demark",
+        stock_data,
     )

--- a/openbb_terminal/stocks/technical_analysis/ta_controller.py
+++ b/openbb_terminal/stocks/technical_analysis/ta_controller.py
@@ -78,6 +78,7 @@ class TechnicalAnalysisController(StockBaseController):
         "fib",
         "tv",
         "clenow",
+        "demark",
     ]
     PATH = "/stocks/ta/"
 
@@ -140,6 +141,7 @@ class TechnicalAnalysisController(StockBaseController):
         mt.add_cmd("fisher")
         mt.add_cmd("cg")
         mt.add_cmd("clenow")
+        mt.add_cmd("demark")
         mt.add_info("_trend_")
         mt.add_cmd("adx")
         mt.add_cmd("aroon")
@@ -1419,4 +1421,33 @@ class TechnicalAnalysisController(StockBaseController):
                 self.ticker.upper(),
                 ns_parser.period,
                 ns_parser.export,
+            )
+
+    @log_start_end(log=logger)
+    def call_demark(self, other_args: List[str]):
+        """Process demark command"""
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            prog="demark",
+            description="Calculates the Demark sequential indicator.",
+        )
+        parser.add_argument(
+            "-m",
+            "--min",
+            help="Minimum value of indicator to show (declutters plot).",
+            dest="min_to_show",
+            type=check_positive,
+            default=5,
+        )
+
+        ns_parser = self.parse_known_args_and_warn(
+            parser, other_args, EXPORT_ONLY_FIGURES_ALLOWED
+        )
+        if ns_parser:
+            momentum_view.display_demark(
+                self.stock,
+                self.ticker.upper(),
+                min_to_show=ns_parser.min_to_show,
+                export=ns_parser.export,
             )

--- a/tests/openbb_terminal/stocks/technical_analysis/txt/test_ta_controller/test_print_help[None].txt
+++ b/tests/openbb_terminal/stocks/technical_analysis/txt/test_ta_controller/test_print_help[None].txt
@@ -21,6 +21,7 @@ Momentum:
     fisher             fisher transform
     cg                 centre of gravity
     clenow             clenow volatility adjusted momentum
+    demark             Tom Demark's sequential indicator
 Trend:
     adx                average directional movement index
     aroon              aroon indicator

--- a/tests/openbb_terminal/stocks/technical_analysis/txt/test_ta_controller/test_print_help[start0].txt
+++ b/tests/openbb_terminal/stocks/technical_analysis/txt/test_ta_controller/test_print_help[start0].txt
@@ -21,6 +21,7 @@ Momentum:
     fisher             fisher transform
     cg                 centre of gravity
     clenow             clenow volatility adjusted momentum
+    demark             Tom Demark's sequential indicator
 Trend:
     adx                average directional movement index
     aroon              aroon indicator

--- a/website/content/terminal/common/ta/demark/_index.md
+++ b/website/content/terminal/common/ta/demark/_index.md
@@ -1,0 +1,12 @@
+```
+usage: demark [-m MIN_TO_SHOW] [-h] [--export EXPORT]
+```
+Calculates the Demark sequential indicator.
+```
+optional arguments:
+  -m MIN_TO_SHOW, --min MIN_TO_SHOW
+                        Minimum value of indicator to show (declutters plot). (default: 5)
+  -h, --help            show this help message (default: False)
+  --export EXPORT       Export figure into png, jpg, pdf, svg (default: )
+```
+For more information and examples, use 'about demark' to access the related guide.

--- a/website/data/menu/main.yml
+++ b/website/data/menu/main.yml
@@ -146,6 +146,8 @@ main:
               ref: /terminal/common/ta/cci
             - name: cg
               ref: /terminal/common/ta/cg
+            - name: demark
+              ref: /terminal/common/ta/demark
             - name: donchian
               ref: /terminal/common/ta/donchian
             - name: ema


### PR DESCRIPTION
This will fix #2249 and by fix, I mean this will implement the demark indicator.

This plot is pretty busy and I chose to use the ohlc instead of candle in mpf intentionally.  This results in a less busy plot as mentioned in the discussion in that thread.

<img width="917" alt="Screen Shot 2022-10-10 at 9 02 06 PM" src="https://user-images.githubusercontent.com/18151143/194975195-f1ff6bf7-e16d-4045-89ac-b3ec45759de2.png">
