### PR TITLE
Fix screenshot not finding images

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -1717,8 +1717,12 @@ def screenshot_to_canvas(shot, plot_exists: bool = False):
     BACKGROUND_WIDTH_SLACK = 150
     BACKGROUND_HEIGHT_SLACK = 150
 
-    background = Image.open(Path("images/background.png"))
-    logo = Image.open(Path("images/openbb_horizontal_logo.png"))
+    background = Image.open(
+        Path(os.path.abspath(__file__), "../../images/background.png")
+    )
+    logo = Image.open(
+        Path(os.path.abspath(__file__), "../../images/openbb_horizontal_logo.png")
+    )
 
     try:
         if plot_exists:


### PR DESCRIPTION
# Description

When running python through command line I get this error when trying to `screenshot` a plot:
![image](https://user-images.githubusercontent.com/79287829/195170882-cc588e39-d7eb-4488-a8c8-564e3692d813.png)

This PR fixes it by being explicit about the images locations. This do not occurs in VScode level.

*Open terminal on command line
*Create any random plot
*`screenshot`

![image](https://user-images.githubusercontent.com/79287829/195171514-50123e7a-3f9c-463b-b067-232a443ce745.png)


- [x] Summary of the change / bug fix.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context. 
