### PR TITLE
Improves the forex menu to include the `forecast` command

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -796,6 +796,7 @@ en:
   forex/ta: technical analysis,          ema, macd, rsi, adx, bbands, obv
   forex/qa: quantitative analysis,       decompose, cusum, residuals analysis
   forex/forex: Forex brokerages
+  forex/forecast: forecast techniques
   forex/oanda: Oanda menu
   forex/ta/_currency: Currency pair loaded
   forex/ta/_source: Source

--- a/openbb_terminal/forex/forex_controller.py
+++ b/openbb_terminal/forex/forex_controller.py
@@ -45,7 +45,7 @@ FX_TICKERS = pd.read_csv(forex_data_path).iloc[:, 0].to_list()
 class ForexController(BaseController):
     """Forex Controller class."""
 
-    CHOICES_COMMANDS = ["load", "quote", "candle", "resources", "fwd"]
+    CHOICES_COMMANDS = ["load", "quote", "candle", "resources", "fwd", "forecast"]
     CHOICES_MENUS = ["ta", "qa", "Oanda"]
     RESOLUTION = ["i", "d", "w", "m"]
 
@@ -102,6 +102,7 @@ class ForexController(BaseController):
         mt.add_raw("\n")
         mt.add_info("forex")
         mt.add_menu("oanda")
+        mt.add_menu("forecast")
         console.print(text=mt.menu_text, menu="Forex")
 
     def custom_reset(self):
@@ -315,14 +316,7 @@ class ForexController(BaseController):
         """Enter Oanda menu."""
         from openbb_terminal.forex.oanda.oanda_controller import OandaController
 
-        # if self.to_symbol and self.from_symbol:
-
-        self.queue = self.load_class(
-            OandaController,
-            queue=self.queue,
-        )
-        # else:
-        #     console.print("No currency pair data is loaded. Use 'load' to load data.\n")
+        self.queue = self.load_class(OandaController, queue=self.queue)
 
     @log_start_end(log=logger)
     def call_ta(self, _):
@@ -367,10 +361,14 @@ class ForexController(BaseController):
         else:
             console.print("No pair selected.\n")
 
-    # HELP WANTED!
-    # TODO: Add news and reddit commands back
-    # behavioural analysis and exploratory data analysis would be useful in the
-    # forex menu. The examples of integration of the common ba and eda components
-    # into the stocks context can provide an insight on how this can be done.
-    # The earlier implementation did not work and was deleted in commit
-    # d0e51033f7d5d4da6386b9e0b787892979924dce
+    @log_start_end(log=logger)
+    def call_forecast(self, _):
+        """Process forecast command"""
+        from openbb_terminal.forecast import forecast_controller
+
+        self.queue = self.load_class(
+            forecast_controller.ForecastController,
+            self.fx_pair,
+            self.data,
+            self.queue,
+        )

--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -167,10 +167,9 @@ class StocksController(StockBaseController):
             s_intraday = (f"Intraday {self.interval}", "Daily")[
                 self.interval == "1440min"
             ]
+            stock_text += f"{s_intraday} {self.ticker}"
             if self.start:
-                stock_text = f"{s_intraday} {self.ticker} (from {self.start.strftime('%Y-%m-%d')})"
-            else:
-                stock_text = f"{s_intraday} {self.ticker}"
+                stock_text += f" (from {self.start.strftime('%Y-%m-%d')})"
 
         mt = MenuText("stocks/", 100)
         mt.add_cmd("search")
@@ -743,8 +742,6 @@ class StocksController(StockBaseController):
                 self.stock,
                 self.queue,
             )
-        # TODO: This menu should work regardless of data being daily or not!
-        # James: 5/27 I think it does now
         else:
             console.print("Use 'load <ticker>' prior to this command!", "\n")
 

--- a/tests/openbb_terminal/forex/txt/test_forex_controller/test_print_help.txt
+++ b/tests/openbb_terminal/forex/txt/test_forex_controller/test_print_help.txt
@@ -1,16 +1,16 @@
-    load               forex/load                                  [YahooFinance, AlphaVantage, Polygon, Oanda]
+    load               get historical data                         [YahooFinance, AlphaVantage, Polygon, Oanda]
 
-forex/_ticker: 
-forex/_source: YahooFinance
+Ticker: 
+Source: YahooFinance
 
-[unvl]    quote              forex/quote[/unvl]                                 [YahooFinance, AlphaVantage]
-[unvl]    candle             forex/candle[/unvl]
-[unvl]    fwd                forex/fwd[/unvl]                                   [FXEmpire]
+[unvl]    quote              get last quote[/unvl]                              [YahooFinance, AlphaVantage]
+[unvl]    candle             show candle plot for loaded pair[/unvl]
+[unvl]    fwd                get forward rates for loaded pair[/unvl]           [FXEmpire]
 
-[unvl]>   ta                 forex/ta[/unvl]
-[unvl]>   qa                 forex/qa[/unvl]
+[unvl]>   ta                 technical analysis,          ema, macd, rsi, adx, bbands, obv[/unvl]
+[unvl]>   qa                 quantitative analysis,       decompose, cusum, residuals analysis[/unvl]
 
-forex/forex:
->   oanda              forex/oanda
->   forecast           forex/forecast
+Forex brokerages:
+>   oanda              Oanda menu
+>   forecast           forecast techniques
 

--- a/tests/openbb_terminal/forex/txt/test_forex_controller/test_print_help.txt
+++ b/tests/openbb_terminal/forex/txt/test_forex_controller/test_print_help.txt
@@ -1,15 +1,16 @@
-    load               get historical data                         [YahooFinance, AlphaVantage, Polygon, Oanda]
+    load               forex/load                                  [YahooFinance, AlphaVantage, Polygon, Oanda]
 
-Ticker: 
-Source: YahooFinance
+forex/_ticker: 
+forex/_source: YahooFinance
 
-[unvl]    quote              get last quote[/unvl]                              [YahooFinance, AlphaVantage]
-[unvl]    candle             show candle plot for loaded pair[/unvl]
-[unvl]    fwd                get forward rates for loaded pair[/unvl]           [FXEmpire]
+[unvl]    quote              forex/quote[/unvl]                                 [YahooFinance, AlphaVantage]
+[unvl]    candle             forex/candle[/unvl]
+[unvl]    fwd                forex/fwd[/unvl]                                   [FXEmpire]
 
-[unvl]>   ta                 technical analysis,          ema, macd, rsi, adx, bbands, obv[/unvl]
-[unvl]>   qa                 quantitative analysis,       decompose, cusum, residuals analysis[/unvl]
+[unvl]>   ta                 forex/ta[/unvl]
+[unvl]>   qa                 forex/qa[/unvl]
 
-Forex brokerages:
->   oanda              Oanda menu
+forex/forex:
+>   oanda              forex/oanda
+>   forecast           forex/forecast
 


### PR DESCRIPTION
# Description

As request by @DidierRLopes, people can now load forex data right into the forecast menu. Also did some minor refactoring.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the api still works
- [ ] Check any related reports


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
