### PR TITLE
Fix fund bug and add forecast menu command

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -873,6 +873,7 @@ en:
   funds/equity: equity holdings
   funds/al_swe: display fund allocation (sector, country, holdings)
   funds/info_swe: get fund information
+  funds/forecast: forecasting techniques
   alternative/covid: COVID menu,                 cases, deaths, rates
   alternative/oss: Open Source menu,           star history, repos information
   alternative/covid/slopes: get countries with highest slope in cases

--- a/openbb_terminal/mutual_funds/investpy_model.py
+++ b/openbb_terminal/mutual_funds/investpy_model.py
@@ -181,28 +181,19 @@ def get_fund_historical(
             logger.exception(str(e))
             return pd.DataFrame(), "", name, country
 
-    # Note that dates for investpy need to be in the format dd/mm/yyyy
-    from_date = start_date.strftime("%d/%m/%Y")
-    to_date = end_date.strftime("%d/%m/%Y")
+    # Note that dates for investpy need to be in the format mm/dd/yyyy
+    from_date = start_date.strftime("%m/%d/%Y")
+    to_date = end_date.strftime("%m/%d/%Y")
     search_country = matching_country if matching_country else country
 
-    # Using investiny to get around the 403 error with investment.com api
-    # We need to get an ID number
-
-    id_number = int(investiny.search_assets(name, limit=1)[0]["ticker"])
-
     try:
-        # return (
-        #     investpy.funds.get_fund_historical_data(
-        #         fund_name, search_country, from_date=from_date, to_date=to_date
-        #     ),
-        #     fund_name,
-        #     fund_symbol,
-        #     matching_country,
-        # )
-        df = pd.DataFrame.from_dict(
-            investiny.historical_data(id_number, from_date=from_date, to_date=to_date)
-        ).set_index("date")
+        # Using investiny to get around the 403 error with investment.com api
+        # We need to get an ID number
+        id_number = int(investiny.search_assets(name, limit=1)[0]["ticker"])
+        data = investiny.historical_data(
+            id_number, from_date=from_date, to_date=to_date
+        )
+        df = pd.DataFrame.from_dict(data).set_index("date")
         df.columns = [col.title() for col in df.columns]
         df.index = pd.to_datetime(df.index)
         return (df, fund_name, fund_symbol, matching_country)

--- a/openbb_terminal/mutual_funds/mutual_fund_controller.py
+++ b/openbb_terminal/mutual_funds/mutual_fund_controller.py
@@ -50,6 +50,7 @@ class FundController(BaseController):
         "equity",
         "al_swe",
         "info_swe",
+        "forecast",
     ]
 
     fund_countries = investpy.funds.get_fund_countries()
@@ -146,6 +147,7 @@ class FundController(BaseController):
         if self.country == "sweden":
             mt.add_cmd("al_swe", self.fund_symbol)
             mt.add_cmd("info_swe", self.fund_symbol)
+            mt.add_cmd("forecast", self.fund_symbol)
         console.print(text=mt.menu_text, menu="Mutual Funds")
 
     def custom_reset(self):
@@ -537,3 +539,16 @@ Potential errors
             avanza_view.display_info(self.fund_name)
 
         return self.queue
+
+    @log_start_end(log=logger)
+    def call_forecast(self, _):
+        """Process forecast command"""
+        # pylint: disable=import-outside-toplevel
+        from openbb_terminal.forecast import forecast_controller
+
+        self.queue = self.load_class(
+            forecast_controller.ForecastController,
+            self.fund_name,
+            self.data,
+            self.queue,
+        )


### PR DESCRIPTION
# Description

Fixes #2820 and allows users to type `forecast` to move the data into the forecast menu.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.
- [x] Make sure affected commands still run in terminal
- [x] Ensure the api still works
- [x] Check any related reports


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
