### PR TITLE
Fixed stocks dashboard tz issue

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: github pages
 on: push
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # actions/checkout v3.0.2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # actions/checkout v3.0.2
 
       - name: Setup hugo
         uses: peaceiris/actions-hugo@v2

--- a/openbb_terminal/dashboards/voila/stocks.ipynb
+++ b/openbb_terminal/dashboards/voila/stocks.ipynb
@@ -206,6 +206,8 @@
     "                        interval=interval,\n",
     "                        progress=False,\n",
     "                    )\n",
+    "                if not self.df.empty:\n",
+    "                    self.df.index = self.df.index.tz_localize(None)\n",
     "                self.last_tickers = tickers\n",
     "                self.last_interval = interval\n",
     "\n",
@@ -391,7 +393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.6"
   },
   "metadata": {
    "interpreter": {


### PR DESCRIPTION
# Description

Fixes #2839 

The report was running into issues because yfinance only includes time zone information if the interval is less than one day. I fixed this issue by always removing the timezone from the data.

Note: I also updated the gh-pages yaml to avoid issues with our CI, however I do not see this affecting our codebase adversely (the version of Ubuntu now matches that in every other pipeline)
# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.
- [x] Make sure affected commands still run in terminal
    - Ran `python terminal.py dashboards/stocks -n` and set interval to `1h`
- [x] Ensure the api still works
    - No need, this does not affect the api
- [x] Check any related reports
    - No need, this does not affect reports

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
