### PR TITLE
Downgrade Protobuf for Forecast Usage

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2548,7 +2548,7 @@ python-versions = ">= 3.5"
 
 [[package]]
 name = "protobuf"
-version = "3.20.3"
+version = "3.20.1"
 description = "Protocol Buffers"
 category = "main"
 optional = false
@@ -4449,7 +4449,7 @@ prediction = ["torch"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11, !=3.9.7"
-content-hash = "5a330ed6d4ca21e04198bc7d65b5ccecbe084e1f1829b80b4e671eb9ff1f5320"
+content-hash = "bae7149ae676b7a1f3c621db7b969aec37200123e3cc4140e31958bdbd463cd3"
 
 [metadata.files]
 aiodns = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ ipyflex = "^0.2.4"
 setuptools = "^65.4.1"
 investiny = "^0.5.0"
 numpy = "1.21.6"
+protobuf = "3.20.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"


### PR DESCRIPTION
# Description
After investigating if forecasting is supported if a user downloads OpenBB SDK via pip (pypi), it is apparent that the user will need to create a conda environment, install `pytorch-lightning` from conda-forge, and install `u8darts-torch` from conda-forge. After doing those things and installing OpenBB SDK via pip, the follow error appeared:

<img width="1181" alt="Screen Shot 2022-10-13 at 3 47 50 PM" src="https://user-images.githubusercontent.com/53658028/195908852-49da3d01-4c15-4ab4-8702-4594dda32bf6.png">

This error actually does not disallow usage of forecasting features, but mitigating this error would be still a good idea. As such, I have downgraded to 3.20.1.

# How has this been tested?
I tested this by creating a new conda environment, installing the two forecasting packages, and downloading the pip package locally  with the command `pip install .` After doing so, the error did not appear.


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
