### PR TITLE
Notify users of old `darts` version

### DIFF
--- a/openbb_terminal/forecast/forecast_controller.py
+++ b/openbb_terminal/forecast/forecast_controller.py
@@ -11,12 +11,26 @@ from typing import Any, Optional, List, Dict
 try:
     import torch
     import darts
+
+    darts_latest = "0.22.0"
+    # check darts version
+    if darts.__version__ != darts_latest:
+        print(
+            f"You are currently using Darts version {darts.__version__}"
+        )
+        print(
+            f"Follow instructions on creating a new conda environment with the latest Darts version ({darts_latest}):"
+        )
+        print(
+            "https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/openbb_terminal/README.md"
+        )
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
         "Please install the forecast version of the terminal. Instructions "
         "are here: https://github.com/OpenBB-finance/OpenBBTerminal/"
         "blob/main/openbb_terminal/README.md#anaconda--python"
     )
+
 import pandas as pd
 import psutil
 

--- a/openbb_terminal/forecast/forecast_controller.py
+++ b/openbb_terminal/forecast/forecast_controller.py
@@ -15,9 +15,7 @@ try:
     darts_latest = "0.22.0"
     # check darts version
     if darts.__version__ != darts_latest:
-        print(
-            f"You are currently using Darts version {darts.__version__}"
-        )
+        print(f"You are currently using Darts version {darts.__version__}")
         print(
             f"Follow instructions on creating a new conda environment with the latest Darts version ({darts_latest}):"
         )


### PR DESCRIPTION
# Description

If user has imported an earlier version of `darts`, notify them to update so that they can continue using the menu.

<img width="720" alt="image" src="https://user-images.githubusercontent.com/105685594/195938985-172e12bc-e788-423a-a4ea-24ba240f1bfe.png">


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.
- [x] Make sure affected commands still run in terminal
- [x] Ensure the api still works
- [x] Check any related reports


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
