### PR TITLE
Fixed `crypto/dd/mkt` controller uses bad parameter names

### DIFF
--- a/openbb_terminal/cryptocurrency/due_diligence/dd_controller.py
+++ b/openbb_terminal/cryptocurrency/due_diligence/dd_controller.py
@@ -1073,8 +1073,8 @@ class DueDiligenceController(CryptoBaseController):
         if ns_parser:
             if self.symbol:
                 coinpaprika_view.display_markets(
-                    symbol=self.symbol,
-                    currency=ns_parser.vs,
+                    from_symbol=self.symbol,
+                    to_symbol=ns_parser.vs,
                     limit=ns_parser.limit,
                     sortby=ns_parser.sortby,
                     ascend=not ns_parser.descend,


### PR DESCRIPTION
# Description

The controller for `crypto/dd/mkt` was using invalid parameter names. I fixed this by changing `symbol` -> `from_symbol` and `currency` -> `to_symbol`. 

Fixes #2846 

# How has this been tested?
Testing was limited due to the small scope of this change.
- [x] Make sure affected commands still run in terminal
    - Ran `python terminal.py crypto/load btc/dd/mkt`
- [x] Ensure the api still works
    - Ran the following lines in jupyter-lab:
    - `from openbb_terminal.api import openbb`
    -  `openbb.crypto.dd.mkt()`
- [x] Check any related reports
    - Ran `python terminal.py reports/crypto eth`


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
