### PR TITLE
Attempting to improve accuracy of latest version message

### DIFF
--- a/openbb_terminal/terminal_helper.py
+++ b/openbb_terminal/terminal_helper.py
@@ -210,7 +210,7 @@ def check_for_updates() -> None:
 
     if r is not None and r.status_code == 200:
         release = r.json()["html_url"].split("/")[-1].replace("v", "")
-        if obbff.VERSION == release:
+        if obbff.VERSION.replace("m", "") == release:
             console.print("[green]You are using the latest version[/green]")
         else:
             console.print("[red]You are not using the latest version[/red]")


### PR DESCRIPTION
# Description

Fixes #2776 

Currently this command checks the obff.VERSION against our current release number on Github. The issue is that we add an "m" the obff.VERSION after we modify the installer. However we do not add an "m" to the release. To fix this I replaced the "m" with "". In the future it would be better to increment the minor release number.


# How has this been tested?
- [x] Make sure affected commands still run in terminal
    - Ran `python terminal.py` to ensure the terminal still works
- [x] Ensure the api still works
    - Not directly affected, ran `from openbb_terminal.api import openbb` to ensure the api still works
- [x] Check any related reports
    - Not directly affected, did not test. 


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
