### PR TITLE
Updating Integration Tests Path

### DIFF
--- a/.github/workflows/intel_macos_build.yml
+++ b/.github/workflows/intel_macos_build.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Unmount DMG
         run: hdiutil detach /dev/disk3
       - name: Run Integration Tests
-        run: /Users/openbb/Desktop/OpenBB\ Terminal/.OpenBB/OpenBBTerminal /Users/openbb/actions-runner/_work/OpenBBTerminal/OpenBBTerminal/scripts/*.openbb -t
+        run: /Users/openbb/Desktop/OpenBB\ Terminal/.OpenBB/OpenBBTerminal /Users/openbb/actions-runner/_work/OpenBBTerminal/OpenBBTerminal/openbb_terminal/miscellaneous/scripts/*.openbb -t
       - name: Remove OpenBB Folder
         run: rm -rf /Users/openbb/Desktop/OpenBB\ Terminal
       - name: Remove OpenBB Exports Folder

--- a/.github/workflows/m1_macos_build.yml
+++ b/.github/workflows/m1_macos_build.yml
@@ -80,7 +80,7 @@ jobs:
           name: M1 MacOS DMG Artifact
           path: OpenBB\ Terminal.dmg
       - name: Convert & Mount DMG
-        run: | 
+        run: |
           hdiutil convert OpenBB\ Terminal.dmg -format UDTO -o openbbterminal.cdr
           hdiutil attach openbbterminal.cdr
           rm -rf openbbterminal.cdr
@@ -93,7 +93,7 @@ jobs:
       - name: Unmount DMG
         run: hdiutil detach /dev/disk5
       - name: Run Integration Tests
-        run: /Users/openbb/Desktop/OpenBB\ Terminal/.OpenBB/OpenBBTerminal /Users/openbb/actions-runner/_work/OpenBBTerminal/OpenBBTerminal/scripts/*.openbb -t
+        run: /Users/openbb/Desktop/OpenBB\ Terminal/.OpenBB/OpenBBTerminal /Users/openbb/actions-runner/_work/OpenBBTerminal/OpenBBTerminal/openbb_terminal/miscellaneous/scripts/*.openbb -t
       - name: Remove OpenBB Folder
         run: rm -rf /Users/openbb/Desktop/OpenBB\ Terminal
       - name: Remove OpenBB Exports Folder

--- a/.github/workflows/windows10_build.yml
+++ b/.github/workflows/windows10_build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build Terminal.spec file
         run: |
           conda activate obb
-          conda remove --force sigtool -y 
+          conda remove --force sigtool -y
           pyinstaller build/pyinstaller/terminal.spec --clean
       - name: Move Files into App Folder
         run: cp -r .\dist\OpenBBTerminal\ .\build\nsis\app\
@@ -61,7 +61,7 @@ jobs:
           name: Windows EXE Artifact
           path: '.\build\nsis\OpenBB Terminal Setup.exe'
       - name: Run Integration Tests
-        run: dist\OpenBBTerminal\OpenBBTerminal.exe C:\Users\Administrator\actions-runner\_work\OpenBBTerminal\OpenBBTerminal\scripts -t
+        run: dist\OpenBBTerminal\OpenBBTerminal.exe C:\Users\Administrator\actions-runner\_work\OpenBBTerminal\OpenBBTerminal\openbb_terminal\miscellaneous\scripts\*.openbb -t
       # Cleaning ------------------------
       # Make sure to add Remove-Item C:\Users\Administrator\Desktop\OPENBB-exports -Recurse whenever integration tests get fixed
       - name: Remove Previous Build


### PR DESCRIPTION
# Description
The location of the scripts folder was changed, so I am updating the path for build automations.

This image demonstrates that the scripts folder is not running all of the scripts. They were moved to `openbb_terminal/miscellaneous/scripts/`.
<img width="1333" alt="Screen Shot 2022-10-17 at 11 53 50 AM" src="https://user-images.githubusercontent.com/53658028/196224820-f3151386-4832-4ce2-ada4-46b26bcbb6e6.png">


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
