### PR TITLE
Eliminate `update` for packaged app

### DIFF
--- a/openbb_terminal/terminal_controller.py
+++ b/openbb_terminal/terminal_controller.py
@@ -141,7 +141,8 @@ class TerminalController(BaseController):
         mt.add_cmd("about")
         mt.add_cmd("support")
         mt.add_cmd("survey")
-        mt.add_cmd("update")
+        if not obbff.PACKAGED_APPLICATION:
+            mt.add_cmd("update")
         mt.add_cmd("wiki")
         mt.add_cmd("record")
         mt.add_cmd("stop")


### PR DESCRIPTION
Since the update does not do anything on installer, can we hide it?