### PR TITLE
Initialize econonmetrics choices so that -h can be used

### DIFF
--- a/openbb_terminal/econometrics/econometrics_controller.py
+++ b/openbb_terminal/econometrics/econometrics_controller.py
@@ -189,6 +189,8 @@ class EconometricsController(BaseController):
             ]:
                 choices[feature] = dict()
 
+            # Inititialzie this for regressions to be able to use -h flag
+            choices["regressions"] = {}
             self.choices = choices
 
             choices["support"] = self.SUPPORT_CHOICES


### PR DESCRIPTION
Previously running `OLS -h` or `panel -h` before loading any data would throw an error.

This initializes the self.choices["regressions"] so that we can do OLS -h or panel -h