### PR TITLE
Alswe command name change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           key: ${{ runner.os }}-v1-linting
           restore-keys: ${{ runner.os }}-v1-linting
 
-      - run: python custom_pre_commit/check_doc.py --ignore-files=settings_controller.py,keys_controller.py,featflags_controller.py,degiro_controller.py,oanda_controller.py --ignore-commands=login,al_swe,info_swe,goodness,resources,yf,yolo,featflags,guess,settings,survey,intro
+      - run: python custom_pre_commit/check_doc.py --ignore-files=settings_controller.py,keys_controller.py,featflags_controller.py,degiro_controller.py,oanda_controller.py --ignore-commands=login,alswe,info_swe,goodness,resources,yf,yolo,featflags,guess,settings,survey,intro
       - run: pip install bandit black codespell flake8 mypy pyupgrade safety pylint==2.15.2
       - run: pip install types-pytz types-requests types-termcolor types-tabulate types-PyYAML types-python-dateutil types-setuptools types-six
       - run: bandit -x ./tests -r . || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         args:
           [
             "--ignore-files=settings_controller.py,featflags_controller.py,keys_controller.py,degiro_controller.py,",
-            "--ignore-commands=login,al_swe,info_swe,goodness,resources,yf,yolo,from,to,featflags,guess,settings,survey",
+            "--ignore-commands=login,alswe,info_swe,goodness,resources,yf,yolo,from,to,featflags,guess,settings,survey",
           ]
         entry: python custom_pre_commit/check_doc.py
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/openbb_terminal/miscellaneous/data_sources_default.json
+++ b/openbb_terminal/miscellaneous/data_sources_default.json
@@ -497,7 +497,7 @@
     "plot": ["Investing"],
     "sector": ["YahooFinance"],
     "equity": ["YahooFinance"],
-    "al_swe": ["Avanza"],
+    "alswe": ["Avanza"],
     "info_swe": ["Avanza"]
   },
   "alternative": {

--- a/openbb_terminal/miscellaneous/i18n/en.yml
+++ b/openbb_terminal/miscellaneous/i18n/en.yml
@@ -858,7 +858,7 @@ en:
   funds/plot: plot loaded historical fund data
   funds/sector: sector weightings
   funds/equity: equity holdings
-  funds/al_swe: display fund allocation (sector, country, holdings)
+  funds/alswe: display fund allocation (sector, country, holdings)
   funds/info_swe: get fund information
   funds/forecast: forecasting techniques
   alternative/covid: COVID menu,                 cases, deaths, rates

--- a/openbb_terminal/mutual_funds/mutual_fund_controller.py
+++ b/openbb_terminal/mutual_funds/mutual_fund_controller.py
@@ -48,7 +48,7 @@ class FundController(BaseController):
         "plot",
         "sector",
         "equity",
-        "al_swe",
+        "alswe",
         "info_swe",
         "forecast",
     ]
@@ -112,7 +112,7 @@ class FundController(BaseController):
                 "--min": one_to_hundred,
                 "-m": "--min",
             }
-            choices["al_swe"] = {"--focus": {c: {} for c in self.focus_choices}}
+            choices["alswe"] = {"--focus": {c: {} for c in self.focus_choices}}
 
             choices["support"] = self.SUPPORT_CHOICES
             choices["about"] = self.ABOUT_CHOICES
@@ -145,7 +145,7 @@ class FundController(BaseController):
             mt.add_cmd("sector", self.fund_symbol)
             mt.add_cmd("equity", self.fund_symbol)
         if self.country == "sweden":
-            mt.add_cmd("al_swe", self.fund_symbol)
+            mt.add_cmd("alswe", self.fund_symbol)
             mt.add_cmd("info_swe", self.fund_symbol)
             mt.add_cmd("forecast", self.fund_symbol)
         console.print(text=mt.menu_text, menu="Mutual Funds")
@@ -457,12 +457,12 @@ Potential errors
         return self.queue
 
     @log_start_end(log=logger)
-    def call_al_swe(self, other_args: List[str]):
-        """Process al_swe command"""
+    def call_alswe(self, other_args: List[str]):
+        """Process alswe command"""
         parser = argparse.ArgumentParser(
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            prog="al_swe",
+            prog="alswe",
             description="Show allocation of a swedish fund.",
         )
         parser.add_argument(


### PR DESCRIPTION
# Description

Fixes al_swe poriton of #2913. Basically just did find/replace all instances of al_swe with alswe. No-regeneration of documentation because of the command being ignored by pre-commit hooks.

# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
