### PR TITLE
Fix "Target not AdjClose" warning incorrectly appearing

### DIFF
--- a/openbb_terminal/stocks/quantitative_analysis/qa_controller.py
+++ b/openbb_terminal/stocks/quantitative_analysis/qa_controller.py
@@ -587,9 +587,9 @@ class QaController(StockBaseController):
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
-            if self.target != "AdjClose":
+            if self.target != "adjclose":
                 console.print(
-                    "Target not AdjClose.  For best results, use `pick AdjClose` first."
+                    "Target not adjclose.  For best results, use `pick adjclose` first."
                 )
 
             qa_view.display_acf(

--- a/openbb_terminal/stocks/quantitative_analysis/qa_controller.py
+++ b/openbb_terminal/stocks/quantitative_analysis/qa_controller.py
@@ -99,7 +99,7 @@ class QaController(StockBaseController):
             zero_to_hundred_detailed: dict = {
                 str(c): {} for c in np.arange(0.0, 100.0, 0.1)
             }
-            choices["pick"] = {c: {} for c in list(stock.columns)}
+            choices["pick"] = {c: {} for c in list(self.stock.columns)}
             choices["load"] = {
                 "--ticker": None,
                 "-t": "--ticker",


### PR DESCRIPTION
# Description

Fixes #2966 
Also fixed the choices for the "pick" autocomplete so that they are actually the names of the columns

# How has this been tested?

```
stocks
load aapl
qa
acf -l 3  (The warning appears)
pick adjclose (Notice here the autocomplete options)
acf -l 3 (The warning does not appear. The plot shows adjclose data instead of returns)
```

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
