### PR TITLE
Spacc command name change (part 2)

### DIFF
--- a/openbb_terminal/miscellaneous/data_sources_default.json
+++ b/openbb_terminal/miscellaneous/data_sources_default.json
@@ -165,7 +165,7 @@
       "wsb": ["Reddit"],
       "watchlist": ["Reddit"],
       "popular": ["Reddit"],
-      "spac_c": ["Reddit"],
+      "spacc": ["Reddit"],
       "spac": ["Reddit"],
       "getdd": ["Reddit"],
       "reddit_sent": ["Reddit"],

--- a/openbb_terminal/miscellaneous/i18n/en.yml
+++ b/openbb_terminal/miscellaneous/i18n/en.yml
@@ -306,7 +306,7 @@ en:
   stocks/ba/wsb: show what WSB gang is up to in subreddit wallstreetbets
   stocks/ba/watchlist: show other users watchlist
   stocks/ba/popular: show popular tickers
-  stocks/ba/spac_c: show other users spacs announcements from subreddit SPACs
+  stocks/ba/spacc: show other users spacs announcements from subreddit SPACs
   stocks/ba/spac: show other users spacs announcements from other subs
   stocks/ba/getdd: gets due diligence from another user's post
   stocks/ba/reddit_sent: searches reddit for ticker and finds reddit sentiment

--- a/openbb_terminal/miscellaneous/scripts/test_stocks_ba.openbb
+++ b/openbb_terminal/miscellaneous/scripts/test_stocks_ba.openbb
@@ -5,7 +5,7 @@ headlines
 wsb
 watchlist
 popular -l 5 -n 10
-spac_c
+spacc
 spac
 getdd
 reddit_sent

--- a/openbb_terminal/sdk.py
+++ b/openbb_terminal/sdk.py
@@ -133,7 +133,7 @@ functions = {
     "stocks.ba.spac": {
         "model": "openbb_terminal.common.behavioural_analysis.reddit_model.get_spac"
     },
-    "stocks.ba.spac_c": {
+    "stocks.ba.spacc": {
         "model": "openbb_terminal.common.behavioural_analysis.reddit_model.get_spac_community"
     },
     "stocks.ba.watchlist": {

--- a/openbb_terminal/stocks/behavioural_analysis/ba_controller.py
+++ b/openbb_terminal/stocks/behavioural_analysis/ba_controller.py
@@ -44,7 +44,7 @@ class BehaviouralAnalysisController(StockBaseController):
         "load",
         "watchlist",
         "spac",
-        "spac_c",
+        "spacc",
         "wsb",
         "popular",
         "bullbear",
@@ -127,7 +127,7 @@ class BehaviouralAnalysisController(StockBaseController):
                 "--sub": None,
                 "-s": "--sub",
             }
-            choices["spac_c"] = {
+            choices["spacc"] = {
                 "--popular": {},
                 "-p": "--popular",
                 "--limit": one_to_hundred,
@@ -207,7 +207,7 @@ class BehaviouralAnalysisController(StockBaseController):
         mt.add_cmd("wsb")
         mt.add_cmd("watchlist")
         mt.add_cmd("popular")
-        mt.add_cmd("spac_c")
+        mt.add_cmd("spacc")
         mt.add_cmd("spac")
         mt.add_cmd("getdd", self.ticker)
         mt.add_cmd("reddit_sent", self.ticker)
@@ -298,12 +298,12 @@ class BehaviouralAnalysisController(StockBaseController):
             reddit_view.display_spac(limit=ns_parser.n_limit)
 
     @log_start_end(log=logger)
-    def call_spac_c(self, other_args: List[str]):
-        """Process spac_c command"""
+    def call_spacc(self, other_args: List[str]):
+        """Process spacc command"""
         parser = argparse.ArgumentParser(
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            prog="spac_c",
+            prog="spacc",
             description="""Print other users SPACs announcement under subreddit 'SPACs'. [Source: Reddit]""",
         )
         parser.add_argument(

--- a/tests/openbb_terminal/stocks/behavioural_analysis/test_ba_controller.py
+++ b/tests/openbb_terminal/stocks/behavioural_analysis/test_ba_controller.py
@@ -247,7 +247,7 @@ def test_call_func_expect_queue(expected_queue, queue, func):
             dict(limit=2),
         ),
         (
-            "call_spac_c",
+            "call_spacc",
             ["--limit=5", "--popular"],
             "reddit_view.display_spac_community",
             [],
@@ -454,7 +454,7 @@ def test_call_func(
     [
         "call_watchlist",
         "call_spac",
-        "call_spac_c",
+        "call_spacc",
         "call_wsb",
         "call_popular",
         "call_bullbear",

--- a/tests/openbb_terminal/stocks/behavioural_analysis/txt/test_ba_controller/test_print_help.txt
+++ b/tests/openbb_terminal/stocks/behavioural_analysis/txt/test_ba_controller/test_print_help.txt
@@ -7,7 +7,7 @@ Ticker: TSLA
     wsb                show what WSB gang is up to in subreddit wallstreetbets         [Reddit]
     watchlist          show other users watchlist                                      [Reddit]
     popular            show popular tickers                                            [Reddit]
-    spac_c             show other users spacs announcements from subreddit SPACs       [Reddit]
+    spacc              show other users spacs announcements from subreddit SPACs       [Reddit]
     spac               show other users spacs announcements from other subs            [Reddit]
     getdd              gets due diligence from another user's post                     [Reddit]
     reddit_sent        searches reddit for ticker and finds reddit sentiment           [Reddit]

--- a/website/content/SDK/stocks/ba/spacc/_index.md
+++ b/website/content/SDK/stocks/ba/spacc/_index.md
@@ -1,5 +1,5 @@
-## Get underlying data 
-### stocks.ba.spac_c(limit: int = 10, popular: bool = False) -> Tuple[pandas.core.frame.DataFrame, dict]
+## Get underlying data
+### stocks.ba.spacc(limit: int = 10, popular: bool = False) -> Tuple[pandas.core.frame.DataFrame, dict]
 
 Get top tickers from r/SPACs [Source: reddit]
 

--- a/website/content/terminal/common/ba/spacc/_index.md
+++ b/website/content/terminal/common/ba/spacc/_index.md
@@ -1,5 +1,5 @@
 ```
-usage: spac_c [-l N_LIMIT] [-p] [-h]
+usage: spacc [-l N_LIMIT] [-p] [-h]
 ```
 
 Print other users SPACs announcements under subreddit 'SPACs'. [Source: Reddit]
@@ -14,7 +14,7 @@ optional arguments:
 
 Example:
 ```
-2022 Feb 16, 10:43 (✨) /stocks/ba/ $ spac_c
+2022 Feb 16, 10:43 (✨) /stocks/ba/ $ spacc
 2022-02-16 11:35:01 - I scraped r/SPACs for the top ticker mentions in the last 24H. Here are the results (Wednesday February 16, 2022)
 https://old.reddit.com/r/SPACs/comments/sttsnl/i_scraped_rspacs_for_the_top_ticker_mentions_in/
 

--- a/website/data/menu/main.yml
+++ b/website/data/menu/main.yml
@@ -72,8 +72,8 @@ main:
               ref: /terminal/common/ba/snews
             - name: spac
               ref: /terminal/common/ba/spac
-            - name: spac_c
-              ref: /terminal/common/ba/spac_c
+            - name: spacc
+              ref: /terminal/common/ba/spacc
             - name: stalker
               ref: /terminal/common/ba/stalker
             - name: stats
@@ -1114,8 +1114,8 @@ main:
                 ref: /terminal/common/ba/snews
               - name: spac
                 ref: /terminal/common/ba/spac
-              - name: spac_c
-                ref: /terminal/common/ba/spac_c
+              - name: spacc
+                ref: /terminal/common/ba/spacc
               - name: stalker
                 ref: /terminal/common/ba/stalker
               - name: stats
@@ -2424,8 +2424,8 @@ main:
                 ref: /SDK/stocks/ba/messages
               - name: snews
                 ref: /SDK/stocks/ba/snews
-              - name: spac_c
-                ref: /SDK/stocks/ba/spac_c
+              - name: spacc
+                ref: /SDK/stocks/ba/spacc
               - name: stalker
                 ref: /SDK/stocks/ba/stalker
               - name: trend


### PR DESCRIPTION
# Description

Changing name from spac_c to spacc. Updated test files using --rewrite-expected.

Command working:
<img width="717" alt="Screen Shot 2022-10-21 at 5 47 11 PM" src="https://user-images.githubusercontent.com/53658028/197293614-a238c8f7-401c-4ece-8819-ea7c96fc4b70.png">


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
