### PR TITLE
Fixed bug giving exception when calling balance in crypto

### DIFF
--- a/openbb_terminal/cryptocurrency/due_diligence/binance_view.py
+++ b/openbb_terminal/cryptocurrency/due_diligence/binance_view.py
@@ -78,7 +78,7 @@ def display_balance(
 
     df = get_balance(from_symbol, to_symbol)
 
-    if not df or df.empty:
+    if df is None or df.empty:
         console.print("[red]No data found[/red]\n")
         return
 


### PR DESCRIPTION
# Description

- Fixes: https://github.com/OpenBB-finance/OpenBBTerminal/issues/2997
- Checking dataframe using `not df` raises error. Replace it with condition `df is None`

![image](https://user-images.githubusercontent.com/114890815/197377719-f102825e-d1f5-48f6-908d-d48783166c58.png)

# How has this been tested?

- [x] Make sure affected commands still run in terminal

# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
