### PR TITLE
fix for #2953 Qty and Year showing up as floats instead of int

### DIFF
--- a/openbb_terminal/stocks/government/quiverquant_view.py
+++ b/openbb_terminal/stocks/government/quiverquant_view.py
@@ -573,6 +573,7 @@ def display_hist_contracts(
         print_rich_table(
             df_contracts,
             headers=list(df_contracts.columns),
+            floatfmt=[".0f", ".0f", ".2f"],
             title="Historical Quarterly Government Contracts",
         )
 


### PR DESCRIPTION
# Description

- [ ] Summary of the change / bug fix.
Updated the table helper function to be called with explicit float precisions
- [ ] Link # issue, if applicable.
Fixes #2953 
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
![image](https://user-images.githubusercontent.com/56005940/197383622-4779d408-c679-4405-ad73-a5cfc94a3ecf.png)

# How has this been tested?

- [x] Make sure affected commands still run in terminal
- [x] Ensure the SDK still works
- [x] Check any related reports


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
