### PR TITLE
Fixes traceback limit to 0

### DIFF
--- a/openbb_terminal/keys_model.py
+++ b/openbb_terminal/keys_model.py
@@ -38,8 +38,6 @@ from openbb_terminal.portfolio.brokers.degiro.degiro_model import DegiroModel
 
 logger = logging.getLogger(__name__)
 
-sys.tracebacklimit = 0
-
 # README PLEASE:
 # The API_DICT keys must match the set and check functions format.
 #


### PR DESCRIPTION
# Description

The current traceback limit was set to 0, settings all error messages to a limit of 1. This PR removes the issue and allows errors messages to be shown like normal.


# How has this been tested?
To test that this bug fix works add the line `raise ValueError("bad error")` to the end of the `__init__` function in `StocksController` then type: `python terminal.py stocks --debug`. If you see a full stack trace then this bug fix works.

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
    - Ran `python terminal.py` to ensure the terminal still works
- [ ] Ensure the SDK still works
    - Ran `from openbb_terminal.sdk import openbb` in a jupyter lab.

Found bug (but this is unrelated)
- #3005 

# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
