### PR TITLE
SDK to be logged as config parameter

### DIFF
--- a/openbb_terminal/config_terminal.py
+++ b/openbb_terminal/config_terminal.py
@@ -62,6 +62,8 @@ LOGGING_ROLLING_CLOCK = bool(
 # DEBUG = 10
 # NOTSET = 0
 LOGGING_VERBOSITY = int(os.getenv("OPENBB_LOGGING_VERBOSITY") or 20)
+# LOGGING SUB APP
+LOGGING_SUB_APP = os.getenv("OPENBB_LOGGING_SUB_APP") or "terminal"
 
 # API Keys section
 

--- a/openbb_terminal/core/log/generation/settings.py
+++ b/openbb_terminal/core/log/generation/settings.py
@@ -51,7 +51,7 @@ class AppSettings:
     ):
         """
         Args:
-            name (str): Name of the application.
+            name (str): Source of the application.
             commit_hash (str): Commit hash of the current running code.
             identifier (str): Unique key identifying a particular installation.
             session_id (str): Key identifying a particular running session.

--- a/openbb_terminal/sdk.py
+++ b/openbb_terminal/sdk.py
@@ -11,6 +11,7 @@ from typing import Optional, Callable, List
 import logging
 from traceback import format_stack
 
+import openbb_terminal.config_terminal as cfg
 from openbb_terminal.rich_config import console
 from openbb_terminal.reports.reports_controller import ReportController
 from openbb_terminal.dashboards.dashboards_controller import DashboardsController
@@ -2380,7 +2381,8 @@ class Loader:
 
     @staticmethod
     def __initialize_logging():
-        setup_logging(app_name="gst_sdk")
+        cfg.LOGGING_SUB_APP = "sdk"
+        setup_logging()
         log_all_settings()
 
     @classmethod


### PR DESCRIPTION
## Goals:

- [x] Removes the `appname="gst_sdk"`, as the Appname should be used as source 
- [x] Add a parameter to indicate we are logging from any `LOGGING_SUB_APP` in the `config_terminal.py`  (e.g. terminal, sdk ...)


## Testing
- [x] Pass all unit tests
- [x] Conda (`"LOGGING_SUB_APP": "terminal"` and `"LOGGING_SUB_APP": "sdk"`)
- [ ] Docker (`"LOGGING_SUB_APP": "terminal"`)
- [ ] Pyinstaller (`"LOGGING_SUB_APP": "terminal"`)
- [ ] Pypi (`"LOGGING_SUB_APP": "terminal"` and `"LOGGING_SUB_APP": "sdk"`)
