### PR TITLE
Fixed issues with Futures menu

### DIFF
--- a/openbb_terminal/futures/futures_helper.py
+++ b/openbb_terminal/futures/futures_helper.py
@@ -1,0 +1,16 @@
+from matplotlib.axes import Axes
+
+
+def make_white(ax: Axes) -> None:
+    """Make the labels and ticks white
+
+    Parameters
+    ----------
+    ax: Axes
+        The axes to make white
+
+    """
+    ax.xaxis.label.set_color("white")
+    ax.tick_params(axis="x", colors="white")
+    ax.yaxis.label.set_color("white")
+    ax.tick_params(axis="y", colors="white")

--- a/openbb_terminal/futures/yfinance_view.py
+++ b/openbb_terminal/futures/yfinance_view.py
@@ -2,6 +2,7 @@
 __docformat__ = "numpy"
 
 from typing import Optional, List
+from itertools import cycle
 import logging
 import os
 
@@ -19,6 +20,7 @@ from openbb_terminal.helper_funcs import (
     is_valid_axes_count,
 )
 from openbb_terminal.rich_config import console
+from openbb_terminal.futures.futures_helper import make_white
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +131,7 @@ def display_historical(
         else:
             return
 
+        colors = cycle(theme.get_colors())
         if len(tickers) > 1:
             name = list()
             for tick in historicals["Adj Close"].columns.tolist():
@@ -160,6 +163,7 @@ def display_historical(
                 ax.plot(
                     historicals["Adj Close"][tick].dropna().index,
                     historicals["Adj Close"][tick].dropna().values,
+                    color=next(colors, "#FCED00"),
                 )
                 ax.legend(name)
 
@@ -169,6 +173,7 @@ def display_historical(
                 ax.set_xlim(first, historicals["Adj Close"].index[-1])
                 theme.style_primary_axis(ax)
 
+                make_white(ax)
                 if external_axes is None:
                     theme.visualize_output()
         else:
@@ -193,6 +198,7 @@ def display_historical(
                 ax.plot(
                     historicals["Adj Close"].dropna().index,
                     historicals["Adj Close"].dropna().values,
+                    color=next(colors, "#FCED00"),
                 )
                 if expiry:
                     ax.set_title(f"{name} with expiry {expiry}")
@@ -205,6 +211,7 @@ def display_historical(
                 ax.set_xlim(first, historicals["Adj Close"].index[-1])
                 theme.style_primary_axis(ax)
 
+                make_white(ax)
                 if external_axes is None:
                     theme.visualize_output()
 
@@ -267,6 +274,7 @@ def display_curve(
         name = yfinance_model.FUTURES_DATA[
             yfinance_model.FUTURES_DATA["Ticker"] == ticker
         ]["Description"].values[0]
+        colors = cycle(theme.get_colors())
         ax.plot(
             df.index,
             df.values,
@@ -274,7 +282,9 @@ def display_curve(
             linestyle="dashed",
             linewidth=2,
             markersize=12,
+            color=next(colors, "#FCED00"),
         )
+        make_white(ax)
         ax.set_title(name)
         theme.style_primary_axis(ax)
 

--- a/openbb_terminal/sdk.py
+++ b/openbb_terminal/sdk.py
@@ -2048,15 +2048,15 @@ forecast_extras = {
     },
     "futures.search": {
         "model": "openbb_terminal.futures.yfinance_model.get_search_futures",
-        "view": "openbb_terminal.forecast.nhits_view.display_search",
+        "view": "openbb_terminal.futures.yfinance_view.display_search",
     },
     "futures.historical": {
         "model": "openbb_terminal.futures.yfinance_model.get_historical_futures",
-        "view": "openbb_terminal.forecast.nhits_view.display_historical",
+        "view": "openbb_terminal.futures.yfinance_view.display_historical",
     },
     "futures.curve": {
         "model": "openbb_terminal.futures.yfinance_model.get_curve_futures",
-        "view": "openbb_terminal.forecast.nhits_view.display_curve",
+        "view": "openbb_terminal.futures.yfinance_view.display_curve",
     },
 }
 


### PR DESCRIPTION
# Description

Fixes #3005 

The futures menu was importing some incorrect paths in the SDK, and the charts shown in the SDK were not formatted properly. This PR fixes this.


# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [x] Make sure affected commands still run in terminal
    - `python terminal.py futures/search`
    - `python terminal.py historical TRM`
    - `python terminal.py historical TRM,CL`
    - `python terminal.py curve TRM`

- [x] Ensure the SDK still works
    - `openbb.futures.search(chart=True)`
    - `openbb.futures.historical(["NG", "ALI"], chart=True)`
    - `openbb.futures.historical(["NG"], chart=True)`
    - `openbb.futures.curve("NG", chart=True)`

# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
