### PR TITLE
Spoooooky bugs - Futures menu ++

### DIFF
--- a/openbb_terminal/alternative/covid/covid_controller.py
+++ b/openbb_terminal/alternative/covid/covid_controller.py
@@ -253,6 +253,9 @@ class CovidController(BaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED, limit=10
         )
         if ns_parser:
+            if ns_parser.days < 2:
+                console.print("[red]Days must be greater than 1[/red]")
+                return
             covid_view.display_case_slopes(
                 days_back=ns_parser.days,
                 limit=ns_parser.limit,

--- a/openbb_terminal/economy/alphavantage_view.py
+++ b/openbb_terminal/economy/alphavantage_view.py
@@ -56,10 +56,18 @@ def realtime_performance_sector(
         )
 
     else:
+
+        if external_axes is None:
+            _, ax = plt.subplots(figsize=plot_autoscale(), dpi=cfp.PLOT_DPI)
+        elif is_valid_axes_count(external_axes, 1):
+            (ax,) = external_axes
+        else:
+            return
+
         df_rtp.set_index("Sector", inplace=True)
         df_rtp = df_rtp.squeeze(axis=1)
         colors = [theme.up_color if x > 0 else theme.down_color for x in df_rtp.values]
-        ax = df_rtp.plot(kind="barh", color=colors)
+        df_rtp.plot(kind="barh", color=colors, ax=ax)
         theme.style_primary_axis(ax)
         ax.set_title("Real Time Performance (%) per Sector")
         ax.tick_params(axis="x", labelrotation=90)

--- a/openbb_terminal/futures/futures_controller.py
+++ b/openbb_terminal/futures/futures_controller.py
@@ -218,9 +218,9 @@ class FuturesController(BaseController):
             dest="ticker",
             type=str,
             choices=self.all_tickers,
-            default="",
             help="Future curve to be selected",
             metavar="Futures symbol",
+            required="-h" not in other_args,
         )
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-t")

--- a/openbb_terminal/futures/yfinance_model.py
+++ b/openbb_terminal/futures/yfinance_model.py
@@ -148,4 +148,6 @@ def get_curve_futures(
     if not futures_index:
         return pd.DataFrame()
 
+    futures_index = pd.to_datetime(futures_index)
+
     return pd.DataFrame(index=futures_index, data=futures_curve, columns=["Futures"])

--- a/openbb_terminal/futures/yfinance_view.py
+++ b/openbb_terminal/futures/yfinance_view.py
@@ -281,7 +281,7 @@ def display_curve(
             marker="o",
             linestyle="dashed",
             linewidth=2,
-            markersize=12,
+            markersize=8,
             color=next(colors, "#FCED00"),
         )
         make_white(ax)

--- a/openbb_terminal/sdk.py
+++ b/openbb_terminal/sdk.py
@@ -1008,10 +1008,6 @@ functions = {
         "model": "openbb_terminal.economy.investingcom_model.get_yieldcurve",
         "view": "openbb_terminal.economy.investingcom_view.display_yieldcurve",
     },
-    "economy.spread": {
-        "model": "openbb_terminal.economy.investingcom_model.get_spread_matrix",
-        "view": "openbb_terminal.economy.investingcom_view.display_spread_matrix",
-    },
     "economy.country_codes": {
         "model": "openbb_terminal.economy.nasdaq_model.get_country_codes"
     },


### PR DESCRIPTION
Okay so what I got is small

- Fixes #3149 
```
2022 Oct 31, 21:38 (🦋) /futures/ $ curve

usage: curve -t Futures symbol [-h] [--export EXPORT] [--raw]
curve: error: the following arguments are required: -t/--ticker
```
- Fixes #3147 (not the auto complete part)

```
2022 Oct 31, 21:38 (🦋) /futures/ $ historical -h

usage: historical [-t TICKER] [-s START] [-e EXPIRY] [-h] [--export EXPORT] [--raw]

Display futures historical. [Source: YahooFinance]

optional arguments:
  -t TICKER, --ticker TICKER
                        Future ticker to display timeseries separated by comma when multiple, e.g.: BLK,QI (default: )
  -s START, --start START
                        Initial date. Default: 3 years ago (default: 2019-11-01 21:39:35.833968)
  -e EXPIRY, --expiry EXPIRY
                        Select future expiry date with format YYYY-MM (default: )
  -h, --help            show this help message (default: False)
  --export EXPORT       Export raw data into csv, json, xlsx and figure into png, jpg, pdf, svg (default: )
  --raw                 Flag to display raw data (default: False)

For more information and examples, use 'about historical' to access the related guide.
```

- Fixes #3008  - made the curve index a datetime.
<img width="798" alt="Screen Shot 2022-10-31 at 9 40 39 PM" src="https://user-images.githubusercontent.com/18151143/199140186-9a42fd33-bb6e-439c-a36c-cd91656d974c.png">

- Fixes #3141 

- Fixes #3146 
<img width="1710" alt="Screen Shot 2022-10-31 at 9 55 09 PM" src="https://user-images.githubusercontent.com/18151143/199141939-d1a9d98e-1eeb-4fce-8943-e8955b2894e7.png">

- Add a check in alternative/covid/slopes that days > 1