### PR TITLE
fix #3236

### DIFF
--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -546,6 +546,7 @@ class StocksController(StockBaseController):
             "--sources",
             dest="sources",
             type=str,
+            default="",
             help="Show news only from the sources specified (e.g bloomberg,reuters)",
         )
         if other_args and "-" not in other_args[0][0]:


### PR DESCRIPTION
fix /sources/news sources display error. (https://github.com/OpenBB-finance/OpenBBTerminal/issues/3236)

# Description
error:
![image](https://user-images.githubusercontent.com/23350634/199302737-a6f24cad-7dac-45b5-b0ac-ceef84e0bff1.png)

fix:
![image](https://user-images.githubusercontent.com/23350634/199302792-6d8338c8-ca54-478c-8989-37762be0df10.png)


# How has this been tested?
i used vscode debugger.
found that there's no default value for sources in the namespace parser.

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
