### PR TITLE
Fixed links

### DIFF
--- a/openbb_terminal/reports/reports_controller.py
+++ b/openbb_terminal/reports/reports_controller.py
@@ -156,7 +156,7 @@ class ReportController(BaseController):
                 "\n'forecast' menu dependencies are not installed."
                 " This part of the SDK will not be usable.\n\n"
                 "For more information see the official documentation at: "
-                "[blue]https://openbb-finance.github.io/OpenBBTerminal/sdk/[/blue]\n"
+                "[blue]https://openbb-finance.github.io/OpenBBTerminal/SDK/[/blue]\n"
             )
         if forecast:
             self.run_report("forecast", other_args)


### PR DESCRIPTION
# Description

Fixes #3123
Replaced the link from sdk to SDK.


# How has this been tested?

I installed the terminal without the forecast dependencies and then tried to run the forecasting menu. I clicked the link that was created as a result.


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
