### PR TITLE
Formatting, first image is not given a new line.

### DIFF
--- a/website/content/terminal/futures/_index.md
+++ b/website/content/terminal/futures/_index.md
@@ -5,6 +5,7 @@ excerpt: "This guide explains how to use the Futures menu and provides a brief d
 geekdocCollapseSection: true
 ---
 The Futures menu provides historical prices and the current term structure for an asset. This menu is accessible from the Main menu by typing `futures` and pressing the `enter` key.
+
 <img width="1135" alt="Futures Menu" src="https://user-images.githubusercontent.com/85772166/197641556-80d83abb-6290-4fc9-b80a-331bcc5751e5.png">
 
 ## How to Use 


### PR DESCRIPTION
Attempting to resolve this:

![Screenshot 2022-11-02 at 12 45 15 AM](https://user-images.githubusercontent.com/85772166/199429710-de0809de-550a-4842-b80c-c729908551cf.png)

Proposed solution is an additional line between content and embedded image.