### PR TITLE
Removed the --raw option from economy/plot

### DIFF
--- a/openbb_terminal/economy/economy_controller.py
+++ b/openbb_terminal/economy/economy_controller.py
@@ -1409,7 +1409,6 @@ class EconomyController(BaseController):
             parser,
             other_args,
             export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED,
-            raw=True,
             limit=10,
         )
 

--- a/website/content/terminal/economy/plot/_index.md
+++ b/website/content/terminal/economy/plot/_index.md
@@ -13,7 +13,6 @@ optional arguments:
   -h, --help            show this help message (default: False)
   --export {csv,json,xlsx}
                         Export raw data into csv, json, xlsx (default: )
-  --raw                 Flag to display raw data (default: False)
   -l LIMIT, --limit LIMIT
                         Number of entries to show in data. (default: 10)
 ```


### PR DESCRIPTION
# Description

Fixes #2974

Removed the --raw option from the plot function on economy. If users want to see the raw data they can navigate to qa/raw. 

# How has this been tested?

`python terminal.py "economy/plot -h"`


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
