### PR TITLE
Improves Error Handling for option.grhist

### DIFF
--- a/openbb_terminal/custom_prompt_toolkit.py
+++ b/openbb_terminal/custom_prompt_toolkit.py
@@ -260,11 +260,7 @@ class NestedCompleter(Completer):
                                 self.flags_processed.remove(same_flags[1])
 
                 if cmd and self.original_options.get(cmd):
-                    self.options = {
-                        k: self.original_options.get(cmd).options[k]  # type: ignore
-                        for k in self.original_options.get(cmd).options.keys()  # type: ignore
-                        if k not in self.flags_processed
-                    }
+                    self.options = self.original_options
                 else:
                     self.options = {
                         k: self.original_options[k]

--- a/openbb_terminal/stocks/options/screen/syncretism_view.py
+++ b/openbb_terminal/stocks/options/screen/syncretism_view.py
@@ -141,6 +141,10 @@ def view_historical_greeks(
         External axes (1 axis is expected in the list), by default None
     """
     df = syncretism_model.get_historical_greeks(symbol, expiry, strike, chain_id, put)
+    if df is None:
+        return
+    if df.empty:
+        return
 
     if raw:
         print_rich_table(
@@ -154,7 +158,12 @@ def view_historical_greeks(
     else:
         return
 
-    im1 = ax.plot(df.index, df[greek], label=greek.title(), color=theme.up_color)
+    try:
+        greek_df = df[greek.lower()]
+    except KeyError:
+        console.print(f"[red]Could not find greek {greek} in data.[/red]\n")
+        return
+    im1 = ax.plot(df.index, greek_df, label=greek.title(), color=theme.up_color)
     ax.set_ylabel(greek)
     ax1 = ax.twinx()
     im2 = ax1.plot(df.index, df.price, label="Stock Price", color=theme.down_color)

--- a/openbb_terminal/stocks/options/screen/syncretism_view.py
+++ b/openbb_terminal/stocks/options/screen/syncretism_view.py
@@ -4,7 +4,7 @@ __docformat__ = "numpy"
 import configparser
 import logging
 import os
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import matplotlib.pyplot as plt
 
@@ -106,7 +106,7 @@ def view_screener_output(
 def view_historical_greeks(
     symbol: str,
     expiry: str,
-    strike: float,
+    strike: Union[float, str],
     greek: str = "Delta",
     chain_id: str = "",
     put: bool = False,
@@ -123,7 +123,7 @@ def view_historical_greeks(
         Stock ticker
     expiry: str
         Expiration date
-    strike: float
+    strike: Union[str, float]
         Strike price to consider
     greek: str
         Greek variable to plot


### PR DESCRIPTION
# Description

Fixes #3282 

This pr adds error handling for someone sending a string instead of a float for the strike price. It also handles a strike price being provided that is not valid.

Also allows`view_screener_output` to handle bad greek options gracefully.

Fixes #3276

Adds handling for when the limit is a string and not an integer. Also forces the argparse for limit to be an integer. Lastly, it adds the datetimeindex to the output of raw.

Also adds some minor styling updates

# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [x] Make sure affected commands still run in terminal
    - `python terminal.py "stocks/load gme/options/exp 2/grhist -s 22.5"`
    - `python terminal.py "stocks/load spy/options/exp 1/grhist --strike 450.0 -g delta --raw -l 300"`
    - `python terminal.py "stocks/load spy/options/exp 1/grhist --strike 450.0 -g delta --raw -l 300a"`
- [x] Ensure the SDK still works
    - `openbb.stocks.options.grhist(symbol = 'SPY', expiry = '2022-11-04', strike = '401')`
    - `openbb.stocks.options.grhist(symbol = 'SPY', expiry = '2022-11-04', strike = '401.1')`
    - `openbb.stocks.options.grhist(symbol = 'SPY', expiry = '2022-11-04', strike = '401', chart=True)`
- [x] Check any related reports


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
