### PR TITLE
Handle Bad Environment Variables

### DIFF
--- a/openbb_terminal/base_helpers.py
+++ b/openbb_terminal/base_helpers.py
@@ -1,0 +1,39 @@
+# This is for helpers that do NOT import any OpenBB Modules
+from typing import Callable, Any
+import os
+
+from rich.console import Console
+
+console = Console()
+
+
+def load_env_vars(name: str, converter: Callable, default: Any) -> Any:
+    """Loads an environment variable and attempts to convert it to the correct data type.
+    Will return the provided default if it fails
+
+    Parameters
+    ----------
+    name: str
+        The name of the environment variable
+    converter: Callable
+        The function to convert the env variable to the desired format
+    default: Any
+        The value to return if the converter fails
+
+    Returns
+    ----------
+    Any
+        The value or the default
+    """
+    raw_var = os.getenv(name)
+    try:
+        return converter(raw_var)
+    except ValueError:
+        console.print(f"[red]Invalid type provided for variable '{name}'.[/red]\n")
+        return default
+    except AttributeError:
+        console.print(f"[red]Invalid type provided for variable '{name}'.[/red]\n")
+        return default
+    except TypeError:
+        console.print(f"[red]Invalid type provided for variable '{name}'.[/red]\n")
+        return default

--- a/openbb_terminal/config_plot.py
+++ b/openbb_terminal/config_plot.py
@@ -3,18 +3,12 @@ import os
 import dotenv
 
 from openbb_terminal.core.config.paths import USER_ENV_FILE, REPOSITORY_ENV_FILE
-from openbb_terminal.rich_config import console
+from openbb_terminal import base_helpers
 
 dotenv.load_dotenv(USER_ENV_FILE)
 dotenv.load_dotenv(REPOSITORY_ENV_FILE, override=True)
 
-try:
-    PLOT_DPI = int(os.getenv("OPENBB_PLOT_DPI", "100"))
-except ValueError:
-    PLOT_DPI = 100
-    console.print(
-        f"[red]OPENBB_PLOT_DPI is not an integer, using default value of {PLOT_DPI}[/red]"
-    )
+PLOT_DPI = base_helpers.load_env_vars("OPENBB_PLOT_DPI", int, 100)
 
 # Backend to use for plotting
 BACKEND = os.getenv("OPENBB_BACKEND", "None")
@@ -28,40 +22,20 @@ if BACKEND == "None":
 # See more: https://matplotlib.org/stable/tutorials/introductory/usage.html#the-builtin-backends
 
 # Used when USE_PLOT_AUTOSCALING is set to False
-try:
-    PLOT_HEIGHT = int(os.getenv("OPENBB_PLOT_HEIGHT", "500"))
-except ValueError:
-    PLOT_HEIGHT = 500
-    console.print(
-        "[red] Invalid value for OPENBB_PLOT_HEIGHT. Please use a number.[/red]\n"
-    )
-try:
-    PLOT_WIDTH = int(os.getenv("OPENBB_PLOT_WIDTH", "800"))
-except ValueError:
-    PLOT_WIDTH = 800
-    console.print(
-        "[red] Invalid value for OPENBB_PLOT_WIDTH. Please use a number.[/red]\n"
-    )
+PLOT_HEIGHT = base_helpers.load_env_vars("OPENBB_PLOT_HEIGHT", int, 500)
+PLOT_WIDTH = base_helpers.load_env_vars("OPENBB_PLOT_WIDTH", int, 800)
 
 # Used when USE_PLOT_AUTOSCALING is set to True
-try:
-    PLOT_HEIGHT_PERCENTAGE = float(os.getenv("OPENBB_PLOT_HEIGHT_PERCENTAGE", "50.00"))
-except ValueError:
-    PLOT_HEIGHT_PERCENTAGE = 50.00
-    console.print(
-        "[red] Invalid value for OPENBB_PLOT_HEIGHT_PERCENTAGE. Please use a number.[/red]\n"
-    )
-try:
-    PLOT_WIDTH_PERCENTAGE = float(os.getenv("OPENBB_PLOT_WIDTH_PERCENTAGE", "70.00"))
-except ValueError:
-    PLOT_WIDTH_PERCENTAGE = 70.00
-    console.print(
-        "[red] Invalid value for OPENBB_PLOT_WIDTH_PERCENTAGE. Please use a number.[/red]\n"
-    )
+PLOT_HEIGHT_PERCENTAGE = base_helpers.load_env_vars(
+    "OPENBB_PLOT_HEIGHT_PERCENTAGE", float, 50.0
+)
+PLOT_WIDTH_PERCENTAGE = base_helpers.load_env_vars(
+    "OPENBB_PLOT_WIDTH_PERCENTAGE", float, 70.0
+)
 
 # When autoscaling is True, choose which monitor to scale to
 # Primary monitor = 0, secondary monitor use 1
-MONITOR = int(os.getenv("OPENBB_MONITOR", "0"))
+MONITOR = base_helpers.load_env_vars("OPENBB_MONITOR", int, 0)
 
 # Color for `view` command data.  All pyplot colors listed at:
 # https://matplotlib.org/stable/gallery/color/named_colors.html

--- a/openbb_terminal/config_terminal.py
+++ b/openbb_terminal/config_terminal.py
@@ -7,7 +7,12 @@ import dotenv
 
 # IMPORTATION INTERNAL
 
-from openbb_terminal.core.config.paths import PACKAGE_ENV_FILE, USER_ENV_FILE, REPOSITORY_ENV_FILE
+from openbb_terminal.core.config.paths import (
+    PACKAGE_ENV_FILE,
+    USER_ENV_FILE,
+    REPOSITORY_ENV_FILE,
+)
+from openbb_terminal import base_helpers
 from .helper_classes import TerminalStyle as _TerminalStyle
 
 dotenv.load_dotenv(USER_ENV_FILE)
@@ -24,9 +29,6 @@ theme = _TerminalStyle(
     PMF_STYLE,
     RICH_STYLE,
 )
-
-# Set to True to see full stack traces for debugging/error reporting
-DEBUG_MODE = False
 
 # By default the jupyter notebook will be run on port 8888
 PAPERMILL_NOTEBOOK_REPORT_PORT = (
@@ -52,8 +54,8 @@ LOGGING_COMMIT_HASH = str(os.getenv("OPENBB_LOGGING_COMMIT_HASH", "REPLACE_ME"))
 LOGGING_FREQUENCY = os.getenv("OPENBB_LOGGING_FREQUENCY") or "H"
 # stdout,stderr,noop,file
 LOGGING_HANDLERS = os.getenv("OPENBB_LOGGING_HANDLERS") or "file"
-LOGGING_ROLLING_CLOCK = bool(
-    strtobool(os.getenv("OPENBB_LOGGING_ROLLING_CLOCK", "False"))
+LOGGING_ROLLING_CLOCK = base_helpers.load_env_vars(
+    "OPENBB_LOGGING_ROLLING_CLOCK", strtobool, False
 )
 # CRITICAL = 50
 # FATAL = CRITICAL
@@ -63,7 +65,7 @@ LOGGING_ROLLING_CLOCK = bool(
 # INFO = 20
 # DEBUG = 10
 # NOTSET = 0
-LOGGING_VERBOSITY = int(os.getenv("OPENBB_LOGGING_VERBOSITY") or 20)
+LOGGING_VERBOSITY = base_helpers.load_env_vars("OPENBB_LOGGING_VERBOSITY", int, 20)
 # LOGGING SUB APP
 LOGGING_SUB_APP = os.getenv("OPENBB_LOGGING_SUB_APP") or "terminal"
 

--- a/openbb_terminal/feature_flags.py
+++ b/openbb_terminal/feature_flags.py
@@ -17,6 +17,7 @@ from openbb_terminal.core.config.paths import (
     USER_ENV_FILE,
 )
 from openbb_terminal.core.config import paths_helper
+from openbb_terminal import base_helpers
 
 paths_helper.init_userdata()
 
@@ -27,70 +28,92 @@ load_dotenv(REPOSITORY_ENV_FILE, override=True)
 load_dotenv(PACKAGE_ENV_FILE, override=True)
 
 # Retry unknown commands with `load`
-RETRY_WITH_LOAD = strtobool(os.getenv("OPENBB_RETRY_WITH_LOAD", "False"))
+RETRY_WITH_LOAD = base_helpers.load_env_vars("OPENBB_RETRY_WITH_LOAD", strtobool, False)
 
 # Use tabulate to print dataframes
-USE_TABULATE_DF = strtobool(os.getenv("OPENBB_USE_TABULATE_DF", "True"))
+USE_TABULATE_DF = base_helpers.load_env_vars("OPENBB_USE_TABULATE_DF", strtobool, True)
 
 # Use clear console after each command
-USE_CLEAR_AFTER_CMD = strtobool(os.getenv("OPENBB_USE_CLEAR_AFTER_CMD", "False"))
+USE_CLEAR_AFTER_CMD = base_helpers.load_env_vars(
+    "OPENBB_USE_CLEAR_AFTER_CMD", strtobool, False
+)
 
 # Use coloring features
-USE_COLOR = strtobool(os.getenv("OPENBB_USE_COLOR", "True"))
+USE_COLOR = base_helpers.load_env_vars("OPENBB_USE_COLOR", strtobool, True)
 
 # Select console flair (choose from config_terminal.py list)
 USE_FLAIR = str(os.getenv("OPENBB_USE_FLAIR", ":openbb"))
 
 # Add date and time to command line
-USE_DATETIME = strtobool(os.getenv("OPENBB_USE_DATETIME", "True"))
+USE_DATETIME = base_helpers.load_env_vars("OPENBB_USE_DATETIME", strtobool, True)
 
 # Enable interactive matplotlib mode
-USE_ION = strtobool(os.getenv("OPENBB_USE_ION", "True"))
+USE_ION = base_helpers.load_env_vars("OPENBB_USE_ION", strtobool, True)
 
 # Enable watermark in the figures
-USE_WATERMARK = strtobool(os.getenv("OPENBB_USE_WATERMARK", "True"))
+USE_WATERMARK = base_helpers.load_env_vars("OPENBB_USE_WATERMARK", strtobool, True)
 
 # Enable command and source in the figures
-USE_CMD_LOCATION_FIGURE = strtobool(os.getenv("OPENBB_USE_CMD_LOCATION_FIGURE", "True"))
+USE_CMD_LOCATION_FIGURE = base_helpers.load_env_vars(
+    "OPENBB_USE_CMD_LOCATION_FIGURE", strtobool, True
+)
 
 # Enable Prompt Toolkit
-USE_PROMPT_TOOLKIT = strtobool(os.getenv("OPENBB_USE_PROMPT_TOOLKIT", "True"))
+USE_PROMPT_TOOLKIT = base_helpers.load_env_vars(
+    "OPENBB_USE_PROMPT_TOOLKIT", strtobool, True
+)
 
 # Enable plot autoscaling
-USE_PLOT_AUTOSCALING = strtobool(os.getenv("OPENBB_USE_PLOT_AUTOSCALING", "False"))
+USE_PLOT_AUTOSCALING = base_helpers.load_env_vars(
+    "OPENBB_USE_PLOT_AUTOSCALING", strtobool, False
+)
 
 # Enable thoughts of the day
-ENABLE_THOUGHTS_DAY = strtobool(os.getenv("OPENBB_ENABLE_THOUGHTS_DAY", "False"))
+ENABLE_THOUGHTS_DAY = base_helpers.load_env_vars(
+    "OPENBB_ENABLE_THOUGHTS_DAY", strtobool, False
+)
 
 # Quick exit for testing
-ENABLE_QUICK_EXIT = strtobool(os.getenv("OPENBB_ENABLE_QUICK_EXIT", "False"))
+ENABLE_QUICK_EXIT = base_helpers.load_env_vars(
+    "OPENBB_ENABLE_QUICK_EXIT", strtobool, False
+)
 
 # Open report as HTML, otherwise notebook
-OPEN_REPORT_AS_HTML = strtobool(os.getenv("OPENBB_OPEN_REPORT_AS_HTML", "True"))
+OPEN_REPORT_AS_HTML = base_helpers.load_env_vars(
+    "OPENBB_OPEN_REPORT_AS_HTML", strtobool, True
+)
 
 # Enable auto print_help when exiting menus
-ENABLE_EXIT_AUTO_HELP = strtobool(os.getenv("OPENBB_ENABLE_EXIT_AUTO_HELP", "True"))
+ENABLE_EXIT_AUTO_HELP = base_helpers.load_env_vars(
+    "OPENBB_ENABLE_EXIT_AUTO_HELP", strtobool, True
+)
 
 # Remember contexts during session
-REMEMBER_CONTEXTS = strtobool(os.getenv("OPENBB_REMEMBER_CONTEXTS", "True"))
+REMEMBER_CONTEXTS = base_helpers.load_env_vars(
+    "OPENBB_REMEMBER_CONTEXTS", strtobool, True
+)
 
 # Use the colorful rich terminal
-ENABLE_RICH = strtobool(os.getenv("OPENBB_ENABLE_RICH", "True"))
+ENABLE_RICH = base_helpers.load_env_vars("OPENBB_ENABLE_RICH", strtobool, True)
 
 # Use the colorful rich terminal
-ENABLE_RICH_PANEL = strtobool(os.getenv("OPENBB_ENABLE_RICH_PANEL", "True"))
+ENABLE_RICH_PANEL = base_helpers.load_env_vars(
+    "OPENBB_ENABLE_RICH_PANEL", strtobool, True
+)
 
 # Check API KEYS before running a command
-ENABLE_CHECK_API = strtobool(os.getenv("OPENBB_ENABLE_CHECK_API", "True"))
+ENABLE_CHECK_API = base_helpers.load_env_vars(
+    "OPENBB_ENABLE_CHECK_API", strtobool, True
+)
 
 # Send logs to data lake
-LOG_COLLECTION = bool(strtobool(os.getenv("OPENBB_LOG_COLLECT", "True")))
+LOG_COLLECTION = base_helpers.load_env_vars("OPENBB_LOG_COLLECT", strtobool, True)
 
 # Provide export folder path. If empty that means default.
 EXPORT_FOLDER_PATH = str(os.getenv("OPENBB_EXPORT_FOLDER_PATH", ""))
 
 # Toolbar hint
-TOOLBAR_HINT = strtobool(os.getenv("OPENBB_TOOLBAR_HINT", "True"))
+TOOLBAR_HINT = base_helpers.load_env_vars("OPENBB_TOOLBAR_HINT", strtobool, True)
 
 # Select language to be used
 USE_LANGUAGE = str(os.getenv("OPENBB_USE_LANGUAGE", "en"))


### PR DESCRIPTION
# Description

Fixes #2865

Currently an environment variable with an incorrect type can cause the entire terminal not load This is a big issue for non technical users who will not be able to manually edit the environment variables. This PR fixes that by replacing any bad keys with the defaults we have already decided on. 

I also added `openbb_terminal/base_helpers.py`. This file is a place for helper functions that do not need to import other modules from inside the terminal, preventing the circular import error.

ALSO, while I was fixing this I found an issue with `python terminal.py source/get`, so I also fixed that.

# How has this been tested?

If this PR does something incorrect it could have large negative affects on the entire terminal. To test the PR itself works I gathered every environment variable that had its type converted (the ones not kept as strings), and I set them to something that should fail.
```
# TO TEST
OPENBB_MONITOR='hello'
OPENBB_ROLLING_CLOCK='tralse'
OPENBB_LOGGING_VERBOSITY='high'
OPENBB_RETRY_WITH_LOAD='tralse'
OPENBB_USE_TABULATE_DF='tralse'
OPENBB_USE_CLEAR_AFTER_CMD='tralse'
OPENBB_USE_COLOR='tralse'
OPENBB_USE_FLAIR='tralse'
OPENBB_USE_DATETIME='tralse'
OPENBB_USE_ION='tralse'
OPENBB_USE_WATERMARK='tralse'
OPENBB_USE_CMD_LOCATION_FIGURE='tralse'
OPENBB_USE_PROMPT_TOOLKIT='tralse'
OPENBB_USE_PLOT_AUTOSCALING='tralse'
OPENBB_ENABLE_THOUGHTS_DAY='tralse'
OPENBB_ENABLE_QUICK_EXIT='tralse'
OPENBB_OPEN_REPORT_AS_HTML='tralse'
OPENBB_ENABLE_EXIT_AUTO_HELP='tralse'
OPENBB_REMEMBER_CONTEXTS='tralse'
OPENBB_ENABLE_RICH='tralse'
OPENBB_ENABLE_RICH_PANEL='tralse'
OPENBB_ENABLE_CHECK_API='tralse'
OPENBB_LOG_COLLECTION='tralse'
OPENBB_EXPORT_FOLDER_PATH='tralse'
OPENBB_TOOLBAR_HINT='tralse'
OPENBB_PLOT_DPI='ever'
OPENBB_PLOT_HEIGHT='ervre'
OPENBB_PLOT_WIDTH='ervre'
OPENBB_PLOT_HEIGHT_PERCENTAGE='ervre'
OPENBB_PLOT_WIDTH_PERCENTAGE='ervre'
OPENBB_TIMEZONE='America/New_York'

```
I then tried to run the terminal, and got the below output:

<img width="899" alt="Screenshot 2022-11-03 at 9 57 11 AM" src="https://user-images.githubusercontent.com/72827203/199680948-818e3c96-4479-4fd7-9fe3-96ef96143785.png">

This is the desired outcome because the user is now aware of the issue, while also still being able to use the terminal.

To ensure that my functionality did not affect normal usage of the terminal I went into the settings and feature flags menus and changed all of my settings back to allowed values. I then made sure that the changes were applied in the .env file, and that the terminal no longer threw warnings for those items.


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
