### PR TITLE
[UX improvement] Adding in docs URL to help commands on terminal

### DIFF
--- a/openbb_terminal/forecast/expo_model.py
+++ b/openbb_terminal/forecast/expo_model.py
@@ -46,7 +46,7 @@ def get_expo_data(
     This is a wrapper around statsmodels Holt-Winters' Exponential Smoothing;
     we refer to this link for the original and more complete documentation of the parameters.
 
-    https://unit8co.github.io/darts/generated_api/darts.models.forecasting.exponential_smoothing.html?highlight=exponential
+    https://unit8co.github.io/darts/generated_api/darts.models.forecasting.exponential_smoothing.html
 
     Parameters
     ----------

--- a/openbb_terminal/forecast/forecast_controller.py
+++ b/openbb_terminal/forecast/forecast_controller.py
@@ -1696,7 +1696,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="autoets",
             description="""
-                Perform Automatic ETS (Error, Trend, Seasonality) forecast
+                Perform Automatic ETS (Error, Trend, Seasonality) forecast:
+                https://nixtla.github.io/statsforecast/examples/getting_started_with_auto_arima_and_ets.html
             """,
         )
         if other_args and "-" not in other_args[0][0]:
@@ -1750,10 +1751,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="expo",
             description="""
-                Perform Probabilistic Exponential Smoothing forecast
-                Trend: N: None, A: Additive, M: Multiplicative
-                Seasonality: N: None, A: Additive, M: Multiplicative
-                Dampen: T: True, F: False
+                Perform Probabilistic Exponential Smoothing forecast:
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.exponential_smoothing.html
             """,
         )
         parser.add_argument(
@@ -1824,7 +1823,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="theta",
             description="""
-                Perform Theta forecast
+                Perform Theta forecast:
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.theta.html
             """,
         )
         # if user does not put in --target-dataset
@@ -1879,7 +1879,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="rnn",
             description="""
-                Perform RNN forecast (Vanilla RNN, LSTM, GRU)
+                Perform RNN forecast (Vanilla RNN, LSTM, GRU):
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.rnn_model.html
             """,
         )
         # RNN Hyperparameters
@@ -1970,7 +1971,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="nbeats",
             description="""
-                Perform NBEATS forecast (Neural Bayesian Estimation of Time Series).
+                Perform NBEATS forecast (Neural Bayesian Estimation of Time Series):
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.nbeats.html
             """,
         )
         # NBEATS Hyperparameters
@@ -2084,7 +2086,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="tcn",
             description="""
-                Perform TCN forecast.
+                Perform TCN forecast:
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.tcn_model.html
             """,
         )
         # TCN Hyperparameters
@@ -2190,7 +2193,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="regr",
             description="""
-                Perform a regression forecast
+                Perform a regression forecast:
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.regression_model.html
             """,
         )
 
@@ -2256,7 +2260,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="linregr",
             description="""
-                Perform a linear regression forecast
+                Perform a linear regression forecast:
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.linear_regression_model.html
             """,
         )
         # if user does not put in --target-dataset
@@ -2320,7 +2325,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="brnn",
             description="""
-                Perform BRNN forecast (Vanilla RNN, LSTM, GRU)
+                Perform BRNN forecast (Vanilla RNN, LSTM, GRU):
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.block_rnn_model.html
             """,
         )
         # BRNN Hyperparameters
@@ -2407,7 +2413,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="trans",
             description="""
-                Perform Transformer Forecast.
+                Perform Transformer Forecast:
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.transformer_model.html
             """,
         )
         parser.add_argument(
@@ -2534,7 +2541,8 @@ class ForecastController(BaseController):
             add_help=False,
             prog="tft",
             description="""
-                Perform TFT forecast (Temporal Fusion Transformer).
+                Perform TFT forecast (Temporal Fusion Transformer):
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.tft_model.html
             """,
         )
         parser.add_argument(
@@ -2645,7 +2653,10 @@ class ForecastController(BaseController):
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
             add_help=False,
             prog="nhits",
-            description="Perform nhits forecast",
+            description="""
+                Perform nhits forecast:
+                https://unit8co.github.io/darts/generated_api/darts.models.forecasting.tft_model.html
+            """,
         )
         parser.add_argument(
             "--num-stacks",

--- a/website/content/terminal/forecast/autoets/_index.md
+++ b/website/content/terminal/forecast/autoets/_index.md
@@ -4,7 +4,8 @@ usage: autoets [--naive] [-d {AAPL}] [-c TARGET_COLUMN] [-n N_DAYS] [-s {N,A,M}]
 
 ```
 
-Perform Automatic ETS (Error, Trend, Seasonality) forecast
+Perform Automatic ETS (Error, Trend, Seasonality) forecast:
+https://nixtla.github.io/statsforecast/examples/getting_started_with_auto_arima_and_ets.html
 
 ```
 optional arguments:
@@ -40,7 +41,7 @@ Example:
 
 
 
-   Actual price: 143.39    
+   Actual price: 143.39
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Datetime   ┃ Prediction ┃
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━┩

--- a/website/content/terminal/forecast/brnn/_index.md
+++ b/website/content/terminal/forecast/brnn/_index.md
@@ -6,7 +6,8 @@ usage: brnn [--n-rnn-layers N_RNN_LAYERS] [--past-covariates PAST_COVARIATES] [-
             [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform BRNN forecast (Vanilla RNN, LSTM, GRU)
+Perform BRNN forecast (Vanilla RNN, LSTM, GRU):
+https://unit8co.github.io/darts/generated_api/darts.models.forecasting.block_rnn_model.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/expo/_index.md
+++ b/website/content/terminal/forecast/expo/_index.md
@@ -4,7 +4,8 @@ usage: expo [--trend {N,A,M}] [--dampen DAMPEN] [--naive] [-d {AAPL}] [-c TARGET
             [--export EXPORT]
 ```
 
-Perform Probabilistic Exponential Smoothing forecast Trend: N: None, A: Additive, M: Multiplicative Seasonality: N: None, A: Additive, M: Multiplicative Dampen: T: True, F: False
+Perform Probabilistic Exponential Smoothing forecast:
+https://unit8co.github.io/darts/generated_api/darts.models.forecasting.exponential_smoothing.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/linregr/_index.md
+++ b/website/content/terminal/forecast/linregr/_index.md
@@ -5,7 +5,8 @@ usage: linregr [--past-covariates PAST_COVARIATES] [--all-past-covariates] [--na
                 [--export EXPORT]
 ```
 
-Perform a linear regression forecast.
+Perform a linear regression forecast:
+https://unit8co.github.io/darts/generated_api/darts.models.forecasting.linear_regression_model.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/nbeats/_index.md
+++ b/website/content/terminal/forecast/nbeats/_index.md
@@ -5,7 +5,8 @@ usage: nbeats [--num_stacks NUM_STACKS] [--num_blocks NUM_BLOCKS] [--num_layers 
               [--learning-rate LEARNING_RATE] [--residuals] [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform NBEATS forecast (Neural Bayesian Estimation of Time Series).
+Perform NBEATS forecast (Neural Bayesian Estimation of Time Series):
+https://unit8co.github.io/darts/generated_api/darts.models.forecasting.nbeats.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/nhits/_index.md
+++ b/website/content/terminal/forecast/nhits/_index.md
@@ -6,7 +6,7 @@ usage: nhits [--num-stacks NUM_STACKS] [--num-blocks NUM_BLOCKS] [--num-layers N
              [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform NHits forecast (Neural Hierarchical Interpolation for Time Series Forecasting).
+Perform nhits forecast: https://unit8co.github.io/darts/generated_api/darts.models.forecasting.tft_model.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/regr/_index.md
+++ b/website/content/terminal/forecast/regr/_index.md
@@ -2,7 +2,7 @@
 usage: regr [--past-covariates PAST_COVARIATES] [--all-past-covariates] [--naive] [-d {AAPL}] [-c TARGET_COLUMN] [-n N_DAYS] [-t TRAIN_SPLIT] [-o OUTPUT_CHUNK_LENGTH] [--end S_END_DATE] [--start S_START_DATE] [--lags LAGS] [--residuals] [--forecast-only] [--explainability-raw] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform a regression forecast.
+Perform a regression forecast: https://unit8co.github.io/darts/generated_api/darts.models.forecasting.regression_model.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/rnn/_index.md
+++ b/website/content/terminal/forecast/rnn/_index.md
@@ -4,7 +4,8 @@ usage: rnn [--hidden-dim HIDDEN_DIM] [--training_length TRAINING_LENGTH] [--naiv
            [--batch-size BATCH_SIZE] [--end S_END_DATE] [--start S_START_DATE] [--learning-rate LEARNING_RATE] [--residuals] [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform RNN forecast (Vanilla RNN, LSTM, GRU)
+Perform RNN forecast (Vanilla RNN, LSTM, GRU):
+https://unit8co.github.io/darts/generated_api/darts.models.forecasting.rnn_model.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/tcn/_index.md
+++ b/website/content/terminal/forecast/tcn/_index.md
@@ -5,7 +5,7 @@ usage: tcn [--num-filters NUM_FILTERS] [--weight-norm WEIGHT_NORM] [--dilation-b
            [--residuals] [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform TCN forecast.
+Perform TCN forecast: https://unit8co.github.io/darts/generated_api/darts.models.forecasting.tcn_model.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/tft/_index.md
+++ b/website/content/terminal/forecast/tft/_index.md
@@ -5,7 +5,8 @@ usage: tft [--lstm-layers LSTM_LAYERS] [--num-attention-heads NUM_ATTENTION_HEAD
            [--batch-size BATCH_SIZE] [--end S_END_DATE] [--start S_START_DATE] [--residuals] [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform TFT forecast (Temporal Fusion Transformer).
+Perform TFT forecast (Temporal Fusion Transformer):
+https://unit8co.github.io/darts/generated_api/darts.models.forecasting.tft_model.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/theta/_index.md
+++ b/website/content/terminal/forecast/theta/_index.md
@@ -3,7 +3,7 @@ usage: theta [--naive] [-d {AAPL}] [-c TARGET_COLUMN] [-n N_DAYS] [-s {N,A,M}] [
              [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform Theta forecast.
+Perform Theta forecast: https://unit8co.github.io/darts/generated_api/darts.models.forecasting.theta.html
 
 ```
 optional arguments:

--- a/website/content/terminal/forecast/trans/_index.md
+++ b/website/content/terminal/forecast/trans/_index.md
@@ -5,7 +5,7 @@ usage: trans [--d-model D_MODEL] [--nhead NHEAD] [--num_encoder_layers NUM_ENCOD
              [--dropout DROPOUT] [--batch-size BATCH_SIZE] [--end S_END_DATE] [--start S_START_DATE] [--residuals] [--forecast-only] [--export-pred-raw] [-h] [--export EXPORT]
 ```
 
-Perform Transformer forecast.
+Perform Transformer Forecast: https://unit8co.github.io/darts/generated_api/darts.models.forecasting.transformer_model.html
 
 ```
 optional arguments:


### PR DESCRIPTION
# Description

Users can use the `-h` command on any of the models and show the link to the docs.

<img width="654" alt="image" src="https://user-images.githubusercontent.com/105685594/200369805-6f25168c-2f9b-4de3-88be-8a0bb4862c27.png">

Very simple.
This is intended to allow users to understand where underlying model comes from and also the inner workings of it if they choose to explore the docs. 