### PR TITLE
Updating terminal version message

### DIFF
--- a/openbb_terminal/terminal_helper.py
+++ b/openbb_terminal/terminal_helper.py
@@ -233,9 +233,9 @@ def check_for_updates() -> None:
                     "[yellow]Check for updates at https://openbb.co/products/terminal#get-started[/yellow]"
                 )
                 break
-            if int(lastest_split[i]) < int(
-                current[i]
-            ) or release == obbff.VERSION.replace("m", ""):
+            if int(lastest_split[i]) < int(current[i]):
+                console.print("[yellow]You are using an unreleased version[/yellow]")
+            if release == obbff.VERSION.replace("m", ""):
                 console.print("[green]You are using the latest version[/green]")
                 break
     else:


### PR DESCRIPTION
# Description
Small change to make the terminal version message more accurate.

- If the version is less than the latest release:
"You are not using the latest version"

- If the version is equal to the latest release:
"You are using the latest version"

-  If the version is greater than the latest release:
"You are using an unreleased version"
<img width="1388" alt="Screen Shot 2022-11-13 at 7 58 26 PM" src="https://user-images.githubusercontent.com/53658028/201554734-87a7493d-c6ed-4b4b-bab4-b5b8fd68e989.png">



# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
