### PR TITLE
Add divs chart to sdk

### DIFF
--- a/openbb_terminal/miscellaneous/library/trail_map.csv
+++ b/openbb_terminal/miscellaneous/library/trail_map.csv
@@ -431,7 +431,7 @@ stocks.fa.quote,openbb_terminal.stocks.fundamental_analysis.fmp_model.get_quote,
 stocks.fa.score,openbb_terminal.stocks.fundamental_analysis.fmp_model.get_score,
 stocks.fa.data,openbb_terminal.stocks.fundamental_analysis.finviz_model.get_data,
 stocks.fa.cal,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_model.get_calendar_earnings,
-stocks.fa.divs,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_model.get_dividends,
+stocks.fa.divs,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_model.get_dividends,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_view.display_dividends
 stocks.fa.hq,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_model.get_hq,
 stocks.fa.info,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_model.get_info,
 stocks.fa.mktcap,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_model.get_mktcap,openbb_terminal.stocks.fundamental_analysis.yahoo_finance_view.display_mktcap

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
@@ -266,7 +266,16 @@ def get_dividends(symbol: str) -> pd.DataFrame:
     pd.DataFrame
         Dataframe of dividends and dates
     """
-    return pd.DataFrame(yf.Ticker(symbol).dividends)
+    df = pd.DataFrame(yf.Ticker(symbol).dividends)
+
+    if df.empty:
+        console.print("No dividends found.\n")
+        return pd.DataFrame()
+
+    df["Change"] = df.diff()
+    df = df[::-1]
+
+    return df
 
 
 @log_start_end(log=logger)

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
@@ -265,6 +265,11 @@ def get_dividends(symbol: str) -> pd.DataFrame:
     -------
     pd.DataFrame
         Dataframe of dividends and dates
+
+    Examples
+    --------
+    >>> from openbb_terminal.sdk import openbb
+    >>> openbb.fa.divs("AAPL")
     """
     df = pd.DataFrame(yf.Ticker(symbol).dividends)
 

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -203,6 +203,11 @@ def display_dividends(
         Format to export data
     external_axes : Optional[List[plt.Axes]], optional
         External axes (1 axis is expected in the list), by default None
+
+    Examples
+    --------
+    >>> from openbb_terminal.sdk import openbb
+    >>> openbb.fa.divs_chart("AAPL")
     """
     div_history = yahoo_finance_model.get_dividends(symbol)
     if div_history.empty:

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -185,11 +185,12 @@ def display_calendar_earnings(symbol: str, export: str = ""):
 def display_dividends(
     symbol: str,
     limit: int = 12,
-    plot: bool = False,
+    plot: bool = True,
     export: str = "",
     external_axes: Optional[List[plt.Axes]] = None,
 ):
     """Display historical dividends
+
     Parameters
     ----------
     symbol: str
@@ -205,10 +206,8 @@ def display_dividends(
     """
     div_history = yahoo_finance_model.get_dividends(symbol)
     if div_history.empty:
-        console.print("No dividends found.\n")
         return
-    div_history["Dif"] = div_history.diff()
-    div_history = div_history[::-1]
+
     if plot:
 
         # This plot has 1 axis
@@ -231,7 +230,7 @@ def display_dividends(
             alpha=1,
             label="Dividends Payout",
         )
-        ax.set_ylabel("Amount ($)")
+        ax.set_ylabel("Amount Paid ($)")
         ax.set_title(f"Dividend History for {symbol}")
         ax.set_xlim(div_history.index[-1], div_history.index[0])
         ax.legend()


### PR DESCRIPTION
Fixes https://github.com/OpenBB-finance/OpenBBTerminal/issues/3515
* Adds docstring examples

`openbb.fa.divs("AAPL")`
`openbb.fa.divs_chart("AAPL")`

`stocks/load AAPL`
`fa/divs`
`fa/divs --plot`