### PR TITLE
Make docs go fast....maybe?

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ env:
   OPENBB_USE_PROMPT_TOOLKIT: false
   PIP_DEFAULT_TIMEOUT: 100
 on: [pull_request, push]
+paths-ignore:
+  - "website/**"
 jobs:
   linting:
     name: General Linting


### PR DESCRIPTION
This attempts to stop the tests workflow if there are only changes in the  website folder:

Using this as reference:
<img width="734" alt="Screen Shot 2022-11-22 at 4 05 05 PM" src="https://user-images.githubusercontent.com/18151143/203421044-dce94c1c-2591-4a1b-89cb-5ae67df11fb8.png">
