### PR TITLE
Small etf bug fixes for `load` and `ca/volume`

### DIFF
--- a/openbb_terminal/etf/etf_controller.py
+++ b/openbb_terminal/etf/etf_controller.py
@@ -313,6 +313,7 @@ class ETFController(BaseController):
             if holdings.empty:
                 console.print("No company holdings found!")
             else:
+                self.etf_holdings.clear()
                 console.print("Top holdings found:")
                 for val in holdings["Name"].values[: ns_parser.limit].tolist():
                     console.print(f"   {val}")

--- a/openbb_terminal/stocks/comparison_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/comparison_analysis/yahoo_finance_model.py
@@ -157,7 +157,7 @@ def get_volume(
         start_date = (datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d")
 
     df_similar = get_historical(similar, start_date, "v")
-    df_similar = df_similar[similar]
+    df_similar = df_similar[df_similar.columns]
     return df_similar
 
 


### PR DESCRIPTION
# Description
Fixes #3517 by clearing the etf holdings that are shown if the user loads in a new etf. Additionally addresses the "not in index" error , which occurs on the `ca/volume` command and arises by trying to graph *all* of the holding data. However sometimes certain holding data is returned `NaN` by yfinance and as a result, we remove it from the dataframe that we want to graph. 

Load fix
<img width="882" alt="Screen Shot 2022-11-27 at 12 46 44 AM" src="https://user-images.githubusercontent.com/53658028/204122939-79f86e03-470a-4a76-a4af-38daf5cde1d8.png">

`ca/volume` "not in index" fix
<img width="788" alt="Screen Shot 2022-11-27 at 12 48 42 AM" src="https://user-images.githubusercontent.com/53658028/204122981-02fa43df-5fa3-4c65-94d7-c40e9468962a.png">


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
