### PR TITLE
Remove hcp endpoint from SDK

### DIFF
--- a/openbb_terminal/miscellaneous/library/trail_map_optimization.csv
+++ b/openbb_terminal/miscellaneous/library/trail_map_optimization.csv
@@ -5,7 +5,6 @@ portfolio.po.ef,openbb_terminal.portfolio.portfolio_optimization.po_model.get_ef
 portfolio.po.equal,openbb_terminal.portfolio.portfolio_optimization.po_model.get_equal,
 portfolio.po.file,openbb_terminal.portfolio.portfolio_optimization.po_model.load_parameters_file,
 portfolio.po.get_properties,openbb_terminal.portfolio.portfolio_optimization.optimizer_model.get_properties,
-portfolio.po.hcp,openbb_terminal.portfolio.portfolio_optimization.optimizer_model.get_hcp_portfolio,
 portfolio.po.herc,openbb_terminal.portfolio.portfolio_optimization.po_model.get_herc,
 portfolio.po.hrp,openbb_terminal.portfolio.portfolio_optimization.po_model.get_hrp,
 portfolio.po.load,openbb_terminal.portfolio.portfolio_optimization.po_model.generate_portfolio,


### PR DESCRIPTION
This endpoint `openbb.portfolio.po.hcp` was only available in previous po version. I'm removing it to avoid confusing users.

It's not available in the terminal either

<img width="555" alt="Screenshot 2022-11-28 at 18 44 45" src="https://user-images.githubusercontent.com/79287829/204355938-0870c745-70ba-44b4-bf20-b22119de2523.png">
