### PR TITLE
remove export choices on export argument

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -1243,7 +1243,8 @@ def check_file_type_saved(valid_types: List[str] = None):
                 valid_filenames.append(filename)
             else:
                 console.print(
-                    f"[red]Filename '{filename}' provided is not valid![/red]"
+                    f"[red]Filename '{filename}' provided is not valid!\nPlease use one of the following file types:"
+                    f"{','.join(valid_types)}[/red]\n"
                 )
         return ",".join(valid_filenames)
 

--- a/openbb_terminal/parent_classes.py
+++ b/openbb_terminal/parent_classes.py
@@ -747,7 +747,6 @@ class BaseController(metaclass=ABCMeta):
                 type=check_file_type_saved(choices_export),
                 dest="export",
                 help=help_export,
-                choices=choices_export,
             )
 
         if raw:


### PR DESCRIPTION
See below.  After changing the choices, we get something like in #3508.  The reason is that the refactoring for choices forces the input to be a file type.

By removing this we have the following:

```
2022 Nov 29, 11:56 (🦋) /stocks/ $ load aapl --export aapl1.csv

Loading Daily data for AAPL with starting period 2019-11-25.

Company:  Apple Inc.
Exchange: NASDAQ/NMS (GLOBAL MARKET)
Currency: USD

                                          AAPL Performance                                          
┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ 1 Day   ┃ 1 Week  ┃ 1 Month ┃ 1 Year ┃ YTD     ┃ Volatility (1Y) ┃ Volume (10D avg) ┃ Last Price ┃
┡━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ -4.53 % │ -4.67 % │ -0.24 % │ -7.5 % │ -20.3 % │ 35.48 %         │ 76.42 M          │ 144.22     │
└─────────┴─────────┴─────────┴────────┴─────────┴─────────────────┴──────────────────┴────────────┘

Saved file: /Users/james/OpenBBUserData/exports/aapl1.csv

```

```
2022 Nov 29, 11:56 (🦋) /stocks/ $ load aapl --export csv

Loading Daily data for AAPL with starting period 2019-11-25.

Company:  Apple Inc.
Exchange: NASDAQ/NMS (GLOBAL MARKET)
Currency: USD

                                          AAPL Performance                                          
┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ 1 Day   ┃ 1 Week  ┃ 1 Month ┃ 1 Year ┃ YTD     ┃ Volatility (1Y) ┃ Volume (10D avg) ┃ Last Price ┃
┡━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ -4.53 % │ -4.67 % │ -0.24 % │ -7.5 % │ -20.3 % │ 35.48 %         │ 76.42 M          │ 144.22     │
└─────────┴─────────┴─────────┴────────┴─────────┴─────────────────┴──────────────────┴────────────┘

Saved file: /Users/james/OpenBBUserData/exports/20221129_115839_OpenBBTerminal_openbb_terminal_load.csv
```


```
2022 Nov 29, 11:58 (🦋) /stocks/ $ load aapl --export cfgfgsfg

Filename 'cfgfgsfg' provided is not valid!
Loading Daily data for AAPL with starting period 2019-11-25.
```

Since this is the base controller, it will port.

Note: Fixes #3508 