### PR TITLE
Fixing the greeks calculations

### DIFF
--- a/openbb_terminal/stocks/options/op_helpers.py
+++ b/openbb_terminal/stocks/options/op_helpers.py
@@ -282,19 +282,14 @@ class Option:
 
     def Vega(self):
         """Vega for 1% change in vol"""
-        return (
-            0.01
-            * self.price
-            * np.exp(-self.div_cont * self.exp_time)
-            * norm.pdf(self.d1)
-            * self.exp_time**0.5
-        )
+        dfq = np.exp(-self.div_cont * self.exp_time)
+        return 0.01 * self.price * dfq * norm.pdf(self.d1) * self.exp_time**0.5
 
-    def Theta(self):
-        """Theta for 1 day change"""
+    def Theta(self, time_factor=1.0 / 365.0):
+        """Theta, by default for 1 calendar day change"""
         df = np.exp(-self.risk_free * self.exp_time)
         dfq = np.exp(-self.div_cont * self.exp_time)
-        tmptheta = (1.0 / 365.0) * (
+        tmptheta = time_factor * (
             -0.5
             * self.price
             * dfq
@@ -310,7 +305,7 @@ class Option:
         return tmptheta
 
     def Rho(self):
-        df = e ** -(self.risk_free * self.exp_time)
+        df = np.exp(-self.risk_free * self.exp_time)
         return (
             self.Type
             * self.strike
@@ -321,30 +316,28 @@ class Option:
         )
 
     def Phi(self):
+        dfq = np.exp(-self.div_cont * self.exp_time)
         return (
             0.01
             * -self.Type
             * self.exp_time
             * self.price
-            * e ** (-self.div_cont * self.exp_time)
+            * dfq
             * norm.cdf(self.Type * self.d1)
         )
 
     # 2nd order greeks
 
     def Gamma(self):
-        return (
-            e ** (-self.div_cont * self.exp_time)
-            * norm.pdf(self.d1)
-            / (self.price * self.sigmaT)
-        )
+        dfq = np.exp(-self.div_cont * self.exp_time)
+        return dfq * norm.pdf(self.d1) / (self.price * self.sigmaT)
 
-    def Charm(self):
-        """Calculates Charm for one day change"""
-        dfq = e ** (-self.div_cont * self.exp_time)
+    def Charm(self, time_factor=1.0 / 365.0):
+        """Calculates Charm, by default for 1 calendar day change"""
+        dfq = np.exp(-self.div_cont * self.exp_time)
         cdf = norm.cdf(self.Type * self.d1)
         return (
-            (1.0 / 365.0)
+            time_factor
             * -dfq
             * (
                 norm.pdf(self.d1)

--- a/openbb_terminal/stocks/options/yfinance_model.py
+++ b/openbb_terminal/stocks/options/yfinance_model.py
@@ -539,7 +539,7 @@ def get_greeks(
 
     risk_free = rf if rf is not None else get_rf()
     expire_dt = datetime.strptime(expire, "%Y-%m-%d")
-    dif = (expire_dt - datetime.now()).seconds / (60 * 60 * 24)
+    dif = (expire_dt - datetime.now()).total_seconds() / (60 * 60 * 24)
 
     strikes = []
     for _, row in chain.iterrows():


### PR DESCRIPTION
# Description

Closes #3660 and also makes the code a bit more readable & versatile. There is _no_ error with the IV normalization, since this command can only take the data from yahoo finance that already annualizes the IV.

# How has this been tested?
Tried the command with several values and compared the results with https://ops.syncretism.io and https://www.cboe.com/optionsinstitute/tools/options_calculator/.

- [x] Make sure affected commands still run in terminal
- [x] Ensure the SDK still works
- [x] Check any related reports


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
