### PR TITLE
Forecasting Pylint Pre-Commit Error Fixes

### DIFF
--- a/openbb_terminal/forecast/autoarima_model.py
+++ b/openbb_terminal/forecast/autoarima_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,E1101
 """Automatic ARIMA Model"""
 __docformat__ = "numpy"
 

--- a/openbb_terminal/forecast/autoces_model.py
+++ b/openbb_terminal/forecast/autoces_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,E1101
 """Automatic Comples Exponential Smoothing Model"""
 __docformat__ = "numpy"
 

--- a/openbb_terminal/forecast/autoets_model.py
+++ b/openbb_terminal/forecast/autoets_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,E1101
 """Automatic ETS (Error, Trend, and Seasonality) Model"""
 __docformat__ = "numpy"
 

--- a/openbb_terminal/forecast/autoselect_model.py
+++ b/openbb_terminal/forecast/autoselect_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,E1101
 """Automatic Statistical Forecast"""
 __docformat__ = "numpy"
 

--- a/openbb_terminal/forecast/mstl_model.py
+++ b/openbb_terminal/forecast/mstl_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,E1101
 """Multiple Seasonalities and Trend using Loess (MSTL) Model"""
 __docformat__ = "numpy"
 

--- a/openbb_terminal/forecast/rwd_model.py
+++ b/openbb_terminal/forecast/rwd_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,E1101
 """Random Walk with Drift Model"""
 __docformat__ = "numpy"
 

--- a/openbb_terminal/forecast/seasonalnaive_model.py
+++ b/openbb_terminal/forecast/seasonalnaive_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,E1101
 """Seasonal Naive Model"""
 __docformat__ = "numpy"
 


### PR DESCRIPTION
# Description
When using pre-commit hooks, pylint was snagged by the following errors: 
```
************* Module openbb_terminal.forecast.mstl_model
openbb_terminal/forecast/mstl_model.py 114: E1101 Instance of 'StatsForecast' has no 'cross_validation' member (no-member)
openbb_terminal/forecast/mstl_model.py 123: E1101 Instance of 'StatsForecast' has no 'forecast' member (no-member)
************* Module openbb_terminal.forecast.autoarima_model
openbb_terminal/forecast/autoarima_model.py 101: E1101 Instance of 'StatsForecast' has no 'cross_validation' member (no-member)
openbb_terminal/forecast/autoarima_model.py 110: E1101 Instance of 'StatsForecast' has no 'forecast' member (no-member)
************* Module openbb_terminal.forecast.autoselect_model
openbb_terminal/forecast/autoselect_model.py 147: E1101 Instance of 'StatsForecast' has no 'cross_validation' member (no-member)
openbb_terminal/forecast/autoselect_model.py 161: E1101 Instance of 'StatsForecast' has no 'forecast' member (no-member)
************* Module openbb_terminal.forecast.seasonalnaive_model
openbb_terminal/forecast/seasonalnaive_model.py 104: E1101 Instance of 'StatsForecast' has no 'cross_validation' member (no-member)
openbb_terminal/forecast/seasonalnaive_model.py 113: E1101 Instance of 'StatsForecast' has no 'forecast' member (no-member)
************* Module openbb_terminal.forecast.autoces_model
openbb_terminal/forecast/autoces_model.py 104: E1101 Instance of 'StatsForecast' has no 'cross_validation' member (no-member)
openbb_terminal/forecast/autoces_model.py 113: E1101 Instance of 'StatsForecast' has no 'forecast' member (no-member)
************* Module openbb_terminal.forecast.autoets_model
openbb_terminal/forecast/autoets_model.py 105: E1101 Instance of 'StatsForecast' has no 'cross_validation' member (no-member)
openbb_terminal/forecast/autoets_model.py 114: E1101 Instance of 'StatsForecast' has no 'forecast' member (no-member)
************* Module openbb_terminal.forecast.rwd_model
openbb_terminal/forecast/rwd_model.py 93: E1101 Instance of 'StatsForecast' has no 'cross_validation' member (no-member)
openbb_terminal/forecast/rwd_model.py 102: E1101 Instance of 'StatsForecast' has no 'forecast' member (no-member)
```
Per @martinb-bb, this is a false, positive. As such, `E1101` was added to the pylint ignore line in each file.

# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
