### PR TITLE
replaced deprecated df.append method with pd.concat

### DIFF
--- a/openbb_terminal/stocks/tradinghours/bursa_model.py
+++ b/openbb_terminal/stocks/tradinghours/bursa_model.py
@@ -36,16 +36,14 @@ def get_bursa(symbol: str) -> pd.DataFrame:
     if symbol in bursa["short_name"].values:
         df = pd.DataFrame(bursa.loc[bursa["short_name"] == symbol]).transpose()
         is_open = check_if_open(bursa, symbol)
-        df = df.append(
-            pd.DataFrame([is_open], index=["open"], columns=df.columns.values)
-        )
+        df_is_open = pd.DataFrame([is_open], index=["open"], columns=df.columns.values)
+        df = pd.concat([df, df_is_open], axis=0)
         return df
     if symbol in bursa.index:
         df = pd.DataFrame(bursa.loc[symbol])
         is_open = check_if_open(bursa, symbol)
-        df = df.append(
-            pd.DataFrame([is_open], index=["open"], columns=df.columns.values)
-        )
+        df_is_open = pd.DataFrame([is_open], index=["open"], columns=df.columns.values)
+        df = pd.concat([df, df_is_open], axis=0)
         return df
     return pd.DataFrame()
 


### PR DESCRIPTION
# Description

append method deprecated. pandas suggest replacing with concat. 
Fixes issue #3707 


# How has this been tested?

load any exchange in the following menu
`/stocks/th/exchange`

future warning no longer shows after method replaced.
