### PR TITLE
Dashboards working on installer

### DIFF
--- a/openbb_terminal/dashboards/dashboards_controller.py
+++ b/openbb_terminal/dashboards/dashboards_controller.py
@@ -164,7 +164,7 @@ class DashboardsController(BaseController):
                 args += "--theme=dark"
             if ns_parser.input or response.lower() == "y":
                 cfg.LOGGING_SUPPRESS = True
-                subprocess.Popen(f"{cmd} {file} {args}", **cls.__subprocess_args())
+                subprocess.Popen([cmd, file, args], **cls.__subprocess_args())
                 cfg.LOGGING_SUPPRESS = False
             else:
                 console.print(f"Type: {cmd} voila/{file}\ninto a terminal to run.")
@@ -205,7 +205,7 @@ class DashboardsController(BaseController):
             args = ""
             if ns_parser.input or response.lower() == "y":
                 cfg.LOGGING_SUPPRESS = True
-                subprocess.Popen(f"{cmd} {file} {args}", **cls.__subprocess_args())
+                subprocess.Popen([cmd, file, args], **cls.__subprocess_args())
                 cfg.LOGGING_SUPPRESS = False
             else:
                 console.print(f"Type: {cmd} stream/{file}\ninto a terminal to run.")

--- a/openbb_terminal/dashboards/dashboards_controller.py
+++ b/openbb_terminal/dashboards/dashboards_controller.py
@@ -231,6 +231,7 @@ class DashboardsController(BaseController):
             "startupinfo": si,
             "env": env,
             "cwd": cwd,
+            "shell": True,
         }
 
         ret.update(options)

--- a/openbb_terminal/dashboards/dashboards_controller.py
+++ b/openbb_terminal/dashboards/dashboards_controller.py
@@ -164,7 +164,10 @@ class DashboardsController(BaseController):
                 args += "--theme=dark"
             if ns_parser.input or response.lower() == "y":
                 cfg.LOGGING_SUPPRESS = True
-                subprocess.Popen([cmd, file, args], **cls.__subprocess_args())
+                subprocess.Popen(
+                    [cmd, file] if not args else [cmd, file, args],
+                    **cls.__subprocess_args(),
+                )
                 cfg.LOGGING_SUPPRESS = False
             else:
                 console.print(f"Type: {cmd} voila/{file}\ninto a terminal to run.")
@@ -202,10 +205,9 @@ class DashboardsController(BaseController):
                     f"Warning: opens a port on your computer to run a {cmd} server."
                 )
                 response = input("Would you like us to run the server for you [yn]? ")
-            args = ""
             if ns_parser.input or response.lower() == "y":
                 cfg.LOGGING_SUPPRESS = True
-                subprocess.Popen([cmd, file, args], **cls.__subprocess_args())
+                subprocess.Popen([cmd, file], **cls.__subprocess_args())
                 cfg.LOGGING_SUPPRESS = False
             else:
                 console.print(f"Type: {cmd} stream/{file}\ninto a terminal to run.")

--- a/openbb_terminal/dashboards/dashboards_controller.py
+++ b/openbb_terminal/dashboards/dashboards_controller.py
@@ -233,7 +233,6 @@ class DashboardsController(BaseController):
             "startupinfo": si,
             "env": env,
             "cwd": cwd,
-            "shell": True,
         }
 
         ret.update(options)

--- a/openbb_terminal/terminal_controller.py
+++ b/openbb_terminal/terminal_controller.py
@@ -410,17 +410,11 @@ class TerminalController(BaseController):
 
     def call_dashboards(self, _):
         """Process dashboards command."""
-        if not is_packaged_application():
-            from openbb_terminal.dashboards.dashboards_controller import (
-                DashboardsController,
-            )
+        from openbb_terminal.dashboards.dashboards_controller import (
+            DashboardsController,
+        )
 
-            self.queue = self.load_class(DashboardsController, self.queue)
-        else:
-            console.print("This feature is coming soon.")
-            console.print(
-                "Use the source code and an Anaconda environment if you are familiar with Python."
-            )
+        self.queue = self.load_class(DashboardsController, self.queue)
 
     def call_alternative(self, _):
         """Process alternative command."""


### PR DESCRIPTION
# Description

Enable the usage of `dashboards` menu on installer versions.

# How has this been tested?

- [x] Dashboards running on Ubuntu (git clone version)
- [x] Dashboards running on Windows (git clone version)
- [x] Dashboards running on Windows Installer (manually created)
- [ ] Dashboards running on Windows Installer within a fresh environment (no conda no python)
- [ ] Dashboards running on Mac Installer (manually created)
- [ ] Dashboards running on Mac Installer within a fresh environment (no conda no python)

