### PR TITLE
fix: wordwrap

### DIFF
--- a/website/generate_sdk_markdown.py
+++ b/website/generate_sdk_markdown.py
@@ -296,7 +296,7 @@ def generate_markdown_section(meta: Dict[str, Any]):
     markdown = (
         f"{meta['description']}\n\nSource Code: [[link]({meta['source_code_url']})]\n\n"
     )
-    markdown += f"```python\n{meta['func_def']}\n```\n\n"
+    markdown += f"```python wordwrap\n{meta['func_def']}\n```\n\n"
 
     markdown += "---\n\n## Parameters\n\n"
     if meta["params"]:

--- a/website/generate_terminal_markdown.py
+++ b/website/generate_terminal_markdown.py
@@ -171,7 +171,7 @@ description: OpenBB Terminal Function
 
     # head meta https://docusaurus.io/docs/markdown-features/head-metadata
     markdown += f"# {cmd_meta['cmd_name']}\n\n{cmd_meta['description']}\n\n"
-    markdown += f"### Usage\n\n```python\n{cmd_meta['usage']}\n```\n\n"
+    markdown += f"### Usage\n\n```python wordwrap\n{cmd_meta['usage']}\n```\n\n"
 
     markdown += "---\n\n## Parameters\n\n"
     if cmd_meta["actions"]:

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "dev": "docusaurus start",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
-  "version": "0.0.0",
-  "private": true,
+  "version": "1.0.0",
+  "private": false,
   "scripts": {
     "docusaurus": "docusaurus",
     "dev": "docusaurus start",

--- a/website/src/theme/CodeBlock/Content/String.js
+++ b/website/src/theme/CodeBlock/Content/String.js
@@ -42,7 +42,7 @@ export default function CodeBlockString({
   const showLineNumbers =
     showLineNumbersProp ?? containsLineNumbers(metastring);
   
-  const shouldWordwrapByDefault = code.startsWith("openbb.")
+  const shouldWordwrapByDefault = metastring?.includes("wordwrap")
 
   return (
     <Container


### PR DESCRIPTION
enables passing `wordwrap` to markdown code block to wordwrap it by default