### PR TITLE
Small options fix + docstring

### DIFF
--- a/openbb_terminal/stocks/insider/sdk_helper.py
+++ b/openbb_terminal/stocks/insider/sdk_helper.py
@@ -160,7 +160,7 @@ def blcp() -> pd.DataFrame:
     Examples
     --------
     >>> from openbb_terminal.sdk import openbb
-    >>> openbb.stocks.ins.bclp()
+    >>> openbb.stocks.ins.blcp()
     """
     return openinsider_model.get_print_insider_data("blcp")
 

--- a/openbb_terminal/stocks/options/yfinance_model.py
+++ b/openbb_terminal/stocks/options/yfinance_model.py
@@ -127,9 +127,9 @@ def get_option_chain_expiry(
     df_list = [x[x["impliedVolatility"] > 0].copy() for x in df_list]
     # Add in greeks to each df
     # Time to expiration:
-    dt = (datetime.strptime(expiry, "%Y-%m-%d") - datetime.now()).seconds / (
-        60 * 60 * 24
-    )
+    dt = (
+        datetime.strptime(expiry, "%Y-%m-%d") + timedelta(hours=16) - datetime.now()
+    ).total_seconds() / (60 * 60 * 24)
     # Note the way the Option class is defined, put has a -1 input and call has a +1 input
     for df, option_type in zip(df_list, option_factor):
         df["Delta"] = df.apply(
@@ -539,8 +539,10 @@ def get_greeks(
 
     risk_free = rf if rf is not None else get_rf()
     expire_dt = datetime.strptime(expire, "%Y-%m-%d")
-    dif = (expire_dt - datetime.now()).total_seconds() / (60 * 60 * 24)
-
+    dif = (expire_dt - datetime.now() + timedelta(hours=16)).total_seconds() / (
+        60 * 60 * 24
+    )
+    print(dif)
     strikes = []
     for _, row in chain.iterrows():
         vol = row["impliedVolatility"]


### PR DESCRIPTION
1) Fix the greek calculation in `chains` where we were using .seconds instead of .total_seconds
2) Change the time to expiration calculation in options to be 4PM instead of midnight am (hence the + 16 hours)
3) Fix the typo I reverted from @hjoaquim 