### PR TITLE
Fix the greeks calculations of the chain command

### DIFF
--- a/openbb_terminal/stocks/options/yfinance_model.py
+++ b/openbb_terminal/stocks/options/yfinance_model.py
@@ -128,13 +128,15 @@ def get_option_chain_expiry(
     # Add in greeks to each df
     # Time to expiration:
     dt = (
-        datetime.strptime(expiry, "%Y-%m-%d") + timedelta(hours=16) - datetime.now()
-    ).total_seconds() / (60 * 60 * 24)
+        (datetime.strptime(expiry, "%Y-%m-%d") - datetime.now()).total_seconds()
+        + 16 * 60 * 60
+    ) / (60 * 60 * 24)
+    rf = get_rf()
     # Note the way the Option class is defined, put has a -1 input and call has a +1 input
     for df, option_type in zip(df_list, option_factor):
         df["Delta"] = df.apply(
             lambda x: Option(
-                last_price, x.strike, 0.03, 0, dt, x.impliedVolatility, option_type
+                last_price, x.strike, rf, 0, dt, x.impliedVolatility, option_type
             ).Delta(),
             axis=1,
         )
@@ -142,13 +144,13 @@ def get_option_chain_expiry(
             warnings.simplefilter("ignore")
             df["Gamma"] = df.apply(
                 lambda x: Option(
-                    last_price, x.strike, 0.03, 0, dt, x.impliedVolatility, option_type
+                    last_price, x.strike, rf, 0, dt, x.impliedVolatility, option_type
                 ).Gamma(),
                 axis=1,
             )
             df["Theta"] = df.apply(
                 lambda x: Option(
-                    last_price, x.strike, 0.03, 0, dt, x.impliedVolatility, option_type
+                    last_price, x.strike, rf, 0, dt, x.impliedVolatility, option_type
                 ).Theta(),
                 axis=1,
             )
@@ -539,10 +541,8 @@ def get_greeks(
 
     risk_free = rf if rf is not None else get_rf()
     expire_dt = datetime.strptime(expire, "%Y-%m-%d")
-    dif = (expire_dt - datetime.now() + timedelta(hours=16)).total_seconds() / (
-        60 * 60 * 24
-    )
-    print(dif)
+    dif = ((expire_dt - datetime.now()).total_seconds() + 16 * 60 * 60) / (60 * 60 * 24)
+
     strikes = []
     for _, row in chain.iterrows():
         vol = row["impliedVolatility"]

--- a/openbb_terminal/stocks/options/yfinance_model.py
+++ b/openbb_terminal/stocks/options/yfinance_model.py
@@ -128,9 +128,8 @@ def get_option_chain_expiry(
     # Add in greeks to each df
     # Time to expiration:
     dt = (
-        (datetime.strptime(expiry, "%Y-%m-%d") - datetime.now()).total_seconds()
-        + 16 * 60 * 60
-    ) / (60 * 60 * 24)
+        datetime.strptime(expiry, "%Y-%m-%d") + timedelta(hours=16) - datetime.now()
+    ).total_seconds() / (60 * 60 * 24)
     rf = get_rf()
     # Note the way the Option class is defined, put has a -1 input and call has a +1 input
     for df, option_type in zip(df_list, option_factor):
@@ -541,8 +540,9 @@ def get_greeks(
 
     risk_free = rf if rf is not None else get_rf()
     expire_dt = datetime.strptime(expire, "%Y-%m-%d")
-    dif = ((expire_dt - datetime.now()).total_seconds() + 16 * 60 * 60) / (60 * 60 * 24)
-
+    dif = (expire_dt - datetime.now() + timedelta(hours=16)).total_seconds() / (
+        60 * 60 * 24
+    )
     strikes = []
     for _, row in chain.iterrows():
         vol = row["impliedVolatility"]


### PR DESCRIPTION
# Description
This makes the greeks calculations in the chains command (with YahooFinance) accurate. Closes #3779. There will still exist a difference between the sources due to different IV values, current asset prices (when the market is open) and so on ..., namely due to the data given.

# How has this been tested?

Running the command and comparing results with Nasdaq, Tradier and the greeks command.


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
