### PR TITLE
Docker installation used wrong service

### DIFF
--- a/website/content/terminal/quickstart/installation.md
+++ b/website/content/terminal/quickstart/installation.md
@@ -142,7 +142,7 @@ Execute this commands:
 ```bash
 curl -o docker-compose.yaml https://raw.githubusercontent.com/OpenBB-finance/OpenBBTerminal/main/build/docker/docker-compose.yaml
 
-docker compose run poetry
+docker compose run openbb
 ```
 
 This will download and run the file: `docker-compose.yaml`


### PR DESCRIPTION
`docker-compose.yaml` service name was changed to `openbb` from `poetry` but documentation was not updated for all platforms