### PR TITLE
Convert flake8 to ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
           key: ${{ runner.os }}-linting-${{ hashFiles('**/poetry.lock') }}
           restore-keys: ${{ runner.os }}-linting-${{ hashFiles('**/poetry.lock') }}
 
-      - run: pip install bandit black codespell flake8 mypy==0.982 pyupgrade safety pylint==2.15.2 packaging==22
+      - run: pip install bandit black codespell mypy==0.982 pyupgrade safety pylint==2.15.2 packaging==22 ruff
       - run: pip install types-pytz types-requests types-termcolor types-tabulate types-PyYAML types-python-dateutil types-setuptools types-six
       - run: bandit -x ./tests -r . || true
       - run: black --diff --check .
       - run: codespell --ignore-words-list=commun,statics,ro,zar,zlot,jewl,ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld,shold,ist,varian,datas,ake,creat,vie,hel,ket,toke,certi,buidl,ot,te --quiet-level=2 --skip=./tests,.git,*.css,*.csv,*.html,*.ini,*.ipynb,*.js,*.json,*.lock,*.scss,*.txt,*.yaml,./build/pyinstaller,./website/config.toml
-      - run: flake8 . --count --ignore=E203,W503 --max-line-length=122 --show-source --statistics --exclude ./build/pyinstaller,./website/content
+      - run: ruff .
       - run: mypy --ignore-missing-imports openbb_terminal
       - run: shopt -s globstar && pyupgrade --py38-plus **/*.py
       - run: safety check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,10 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.206'
     hooks:
-      - id: flake8
-        entry: flake8 --ignore=E203,W503 --max-line-length=122 --exclude ./build/pyinstaller/*
+      - id: ruff
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:
@@ -25,7 +24,7 @@ repos:
         entry: codespell
         args:
           [
-            "--ignore-words-list=te,commun,ro,zar,vie,hel,jewl,zlot,ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld,shold,ist,varian,datas,ake,creat,statics,ket,toke,certi,buidl",
+            "--ignore-words-list=te,commun,ro,zar,vie,hel,jewl,zlot,ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld,shold,ist,varian,datas,ake,creat,statics,ket,toke,certi,buidl,ot",
             "--quiet-level=2",
             "--skip=./tests,.git,*.css,*.csv,*.html,*.ini,*.ipynb,*.js,*.json,*.lock,*.scss,*.txt,*.yaml,build/pyinstaller/*,./website/config.toml",
           ]

--- a/openbb_terminal/cryptocurrency/due_diligence/dd_controller.py
+++ b/openbb_terminal/cryptocurrency/due_diligence/dd_controller.py
@@ -498,7 +498,9 @@ class DueDiligenceController(CryptoBaseController):
     @log_start_end(log=logger)
     def call_oi(self, other_args):
         """Process oi command"""
-        assert isinstance(self.symbol, str)
+        if not isinstance(self.symbol, str):
+            console.print("[red]Invalid symbol was provided[/red]")
+            return
         parser = argparse.ArgumentParser(
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -533,7 +535,9 @@ class DueDiligenceController(CryptoBaseController):
     @log_start_end(log=logger)
     def call_liquidations(self, other_args):
         """Process liquidations command"""
-        assert isinstance(self.symbol, str)
+        if not isinstance(self.symbol, str):
+            console.print("[red]Invalid symbol was provided[/red]")
+            return
         parser = argparse.ArgumentParser(
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -557,7 +561,9 @@ class DueDiligenceController(CryptoBaseController):
     @log_start_end(log=logger)
     def call_fundrate(self, other_args):
         """Process fundrate command"""
-        assert isinstance(self.symbol, str)
+        if not isinstance(self.symbol, str):
+            console.print("[red]Invalid symbol was provided[/red]")
+            return
         parser = argparse.ArgumentParser(
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/openbb_terminal/custom_prompt_toolkit.py
+++ b/openbb_terminal/custom_prompt_toolkit.py
@@ -53,7 +53,8 @@ class WordCompleter(Completer):
         pattern: Optional[Pattern[str]] = None,
     ) -> None:
 
-        assert not (WORD and sentence)
+        if WORD and sentence:
+            raise ValueError("WORD and sentence cannot both be true")
 
         self.words = words
         self.ignore_case = ignore_case
@@ -177,7 +178,8 @@ class NestedCompleter(Completer):
             elif isinstance(key, str) and isinstance(value, str):
                 options[key] = options[value]
             else:
-                assert value is None
+                if value is not None:
+                    raise ValueError("Invalid value type")
                 options[key] = None
 
         for items in cls.complementary:

--- a/openbb_terminal/decorators.py
+++ b/openbb_terminal/decorators.py
@@ -27,7 +27,8 @@ def log_start_end(func=None, log=None):
     -------
         Wrapped function
     """
-    assert callable(func) or func is None  # nosec
+    if not callable(func) or func is None:
+        raise ValueError("Invalid parameters for log_start_end")
 
     def decorator(func):
         @functools.wraps(func)

--- a/openbb_terminal/economy/economy_helpers.py
+++ b/openbb_terminal/economy/economy_helpers.py
@@ -8,6 +8,10 @@ import pandas as pd
 from openbb_terminal.rich_config import console
 
 
+def text_transform(raw_text: str) -> str:
+    return f"{round(float(raw_text)/100, 3)}%"
+
+
 def create_new_entry(dataset: Dict[str, pd.DataFrame], query: str) -> Dict:
     """Create a new series based off previously loaded columns
 

--- a/openbb_terminal/economy/investingcom_view.py
+++ b/openbb_terminal/economy/investingcom_view.py
@@ -18,6 +18,7 @@ from openbb_terminal.config_plot import PLOT_DPI
 from openbb_terminal.config_terminal import theme
 from openbb_terminal.decorators import log_start_end
 from openbb_terminal.economy import investingcom_model
+from openbb_terminal.economy.economy_helpers import text_transform
 from openbb_terminal.helper_funcs import (
     export_data,
     plot_autoscale,
@@ -185,9 +186,6 @@ def display_spread_matrix(
                         k += spacing
                         spacing -= 1
 
-                        text_transform = (
-                            lambda x: f"{round(float(x)/100, 3)}%"
-                        )  # flake8: noqa
                         t.set_text(text_transform(current_text))
                     else:
                         t.set_text(current_text)

--- a/openbb_terminal/forecast/brnn_model.py
+++ b/openbb_terminal/forecast/brnn_model.py
@@ -87,7 +87,13 @@ def get_brnn_data(
 
     Returns
     -------
-    Tuple[List[TimeSeries], List[TimeSeries], List[TimeSeries], Optional[Union[float, ndarray]], type[GlobalForecastingModel]]  # noqa: E501
+    Tuple[
+        List[TimeSeries],
+        List[TimeSeries],
+        List[TimeSeries],
+        Optional[Union[float, ndarray]],
+        type[GlobalForecastingModel]
+    ]
         Adjusted Data series,
         Historical forecast by best RNN model,
         list of Predictions,

--- a/openbb_terminal/reports/reports_controller.py
+++ b/openbb_terminal/reports/reports_controller.py
@@ -150,9 +150,9 @@ class ReportController(BaseController):
         #     return
 
         try:
-            import darts  # pyright: reportMissingImports=false # noqa: F401, E501 #pylint: disable=import-outside-toplevel, unused-import
-            from darts import (  # pyright: reportMissingImports=false # noqa: F401, E501 #pylint: disable=import-outside-toplevel, unused-import
-                utils,
+            import darts  # pyright: reportMissingImports=false # noqa: F401, E501 # pylint: disable=C0415, W0611
+            from darts import (  # pyright: reportMissingImports=false, pylint: disable=C0415, W0611
+                utils,  # noqa: F401, E501
             )
 
             FORECASTING_TOOLKIT_ENABLED = True

--- a/openbb_terminal/sdk.py
+++ b/openbb_terminal/sdk.py
@@ -3,8 +3,8 @@ from openbb_terminal.config_terminal import theme  # noqa: F401
 from openbb_terminal.helper_classes import TerminalStyle
 from openbb_terminal import helper_funcs as helper  # noqa: F401
 from openbb_terminal.reports import widget_helpers as widgets  # noqa: F401
-from openbb_terminal.cryptocurrency.due_diligence.pycoingecko_model import (  # noqa: F401
-    Coin,
+from openbb_terminal.cryptocurrency.due_diligence.pycoingecko_model import (
+    Coin,  # noqa: F401
 )
 
 from openbb_terminal.core.library.breadcrumb import Breadcrumb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ target-version = "py38"
 # This is an introductory addition of ruff. We should look to adding:
 # D: pydocstyle, PD: pandas-vet, I: isort
 # All options here: https://github.com/charliermarsh/ruff#supported-rules
-select = ["E", "W", "F", "Q", "W", "S", "UP"] # "D", "PD", "I"
+select = ["E", "W", "F", "Q", "W", "S", "UP"]
 ignore = ["S105", "S106", "S107"]
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,3 +150,23 @@ build-backend = "poetry.core.masonry.api"
 [tool.pydocstyle]
 convention = "numpy"
 match = '((?!test_).)*\.py'
+
+
+[tool.ruff]
+line-length = 122
+target-version = "py38"
+# This is an introductory addition of ruff. We should look to adding:
+# D: pydocstyle, PD: pandas-vet, I: isort
+# All options here: https://github.com/charliermarsh/ruff#supported-rules
+select = ["E", "W", "F", "Q", "W", "S", "UP"] # "D", "PD", "I"
+ignore = ["S105", "S106", "S107"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101"]
+
+[tool.ruff.flake8-import-conventions.aliases]
+altair = "alt"
+"matplotlib.pyplot" = "plt"
+numpy = "np"
+pandas = "pd"
+seaborn = "sns"

--- a/tests/openbb_terminal/test_thought_of_the_day.py
+++ b/tests/openbb_terminal/test_thought_of_the_day.py
@@ -3,10 +3,7 @@ import unittest
 from unittest import mock
 
 # pylint: disable=unused-import
-from tests.helpers.tools import (  # noqa: F401
-    parameterize_from_file,
-    pytest_generate_tests,
-)
+from tests.helpers.tools import parameterize_from_file
 from openbb_terminal import thought_of_the_day
 
 assertions = unittest.TestCase("__init__")


### PR DESCRIPTION
# Description

Ruff is like 100 times faster than flake8. Also, it supports isort already, and we are working on getting full support for pyupgrade. This PR is one small step in eventually fully integrating more ruff linters such as: pydocstyle, pandas-vet, and isort. 


# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
