### PR TITLE
Fixing timezone not updating within same terminal session

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -1151,7 +1151,7 @@ def get_user_timezone() -> str:
     str
         user timezone based on .env file
     """
-    dotenv.load_dotenv(USER_ENV_FILE)
+    dotenv.load_dotenv(USER_ENV_FILE, override=True)
     user_tz = os.getenv("OPENBB_TIMEZONE")
     if user_tz:
         return user_tz


### PR DESCRIPTION
overrideing the get_user_timezone() so that the updated timezone variable is used. Previsously openbb needed to be restarted to reflect the change 

https://github.com/OpenBB-finance/OpenBBTerminal/issues/3863


https://user-images.githubusercontent.com/32000834/210728647-83eb69ef-5c30-41ab-8e63-e074ae7854d3.mp4


# Description
- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context.
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
