### PR TITLE
Fix stocks/dps/ftd

### DIFF
--- a/openbb_terminal/stocks/dark_pool_shorts/sec_model.py
+++ b/openbb_terminal/stocks/dark_pool_shorts/sec_model.py
@@ -4,6 +4,7 @@ __docformat__ = "numpy"
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
+from urllib.error import HTTPError
 
 import pandas as pd
 import requests
@@ -170,16 +171,19 @@ def get_fails_to_deliver(
         ftd_urls = catching_diff_url_formats(ftd_urls)
 
         for ftd_link in ftd_urls:
-            all_ftds = pd.read_csv(
-                ftd_link,
-                compression="zip",
-                sep="|",
-                engine="python",
-                skipfooter=2,
-                usecols=[0, 2, 3, 5],
-                dtype={"QUANTITY (FAILS)": "Int64"},
-                encoding="iso8859",
-            )
+            try:
+                all_ftds = pd.read_csv(
+                    ftd_link,
+                    compression="zip",
+                    sep="|",
+                    engine="python",
+                    skipfooter=2,
+                    usecols=[0, 2, 3, 5],
+                    dtype={"QUANTITY (FAILS)": "Int64"},
+                    encoding="iso8859",
+                )
+            except HTTPError:
+                continue
             tmp_ftds = all_ftds[all_ftds["SYMBOL"] == symbol]
             del tmp_ftds["PRICE"]
             del tmp_ftds["SYMBOL"]

--- a/openbb_terminal/stocks/dark_pool_shorts/sec_model.py
+++ b/openbb_terminal/stocks/dark_pool_shorts/sec_model.py
@@ -184,6 +184,7 @@ def get_fails_to_deliver(
                 )
             except HTTPError:
                 continue
+
             tmp_ftds = all_ftds[all_ftds["SYMBOL"] == symbol]
             del tmp_ftds["PRICE"]
             del tmp_ftds["SYMBOL"]


### PR DESCRIPTION
# Description

Closing #3945. The ftd generates one invalid url (https://www.sec.gov/files/data/fails-deliver-data/cnsfails202212b.zip). This fixes the ftd command by just ignoring invalid http requests, which it performs. 

I couldn't find something wrong with the url generating code part, thus this might just be an irregularity. That's why I choose to ignore invalid https requests. 

# How has this been tested?

Testing the ftd command and their results and the potential loss of information due to ignoring.

- [x] Make sure affected commands still run in terminal
- [x] Ensure the SDK still works
- [x] Check any related reports


# Checklist:

- [x] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
