### PR TITLE
[FIX] Pytorch-lightning trainer conflict with TQDM progress bar

### DIFF
--- a/openbb_terminal/forecast/helpers.py
+++ b/openbb_terminal/forecast/helpers.py
@@ -721,7 +721,7 @@ def get_prediction(
     if model_name not in ["Regression", "Logistic Regression"]:
         # need to create a new pytorch trainer for historical backtesting to remove progress bar
         best_model.trainer = None
-        best_model.trainer_params["enable_progress_bar"] = False
+        # best_model.trainer_params["enable_progress_bar"] = True
 
     # Historical backtest if with covariates
     if past_covariates is not None:

--- a/tests/openbb_terminal/forecast/test_forecast_model.py
+++ b/tests/openbb_terminal/forecast/test_forecast_model.py
@@ -38,7 +38,7 @@ def test_clean(tsla_csv, fill, drop):
 def test_add_feature_engineering(tsla_csv, command):
     val = getattr(fm, f"add_{command}")(tsla_csv)
     if command == "atr":
-        assert isinstance(val, Tuple)
+        assert isinstance(val, (pd.DataFrame, Tuple))
     else:
         assert isinstance(val, pd.DataFrame)
 


### PR DESCRIPTION
# Description
Conflict with underlying pytorch-lightning library. 
```Error: Trainer was configured with `enable_progress_bar=False` but found `TQDMProgressBar` in callbacks list.```

Simple fix to avoid conflicts.