### PR TITLE
Fix portfolio engine assigning close values to the wrong tickers

### DIFF
--- a/openbb_terminal/portfolio/portfolio_engine.py
+++ b/openbb_terminal/portfolio/portfolio_engine.py
@@ -695,7 +695,7 @@ class PortfolioEngine:
 
         # Make historical prices columns a multi-index. This helps the merging.
         self.portfolio_historical_prices.columns = pd.MultiIndex.from_product(
-            [["Close"], self.tickers_list]
+            [["Close"], self.portfolio_historical_prices.columns]
         )
 
         trade_data = pd.merge(


### PR DESCRIPTION
When running the report of the portfolio one thing is very noticable being the close price. For example, Google's price is about 100 and not 150. This was due to a sorting issue when creating a MultiIndex.

<div>

Date | Ticker | Type | Sector | Industry | Country | Region | Price | Quantity | Fees | Premium | Investment | Side | Currency | ISIN | Signal | yf_Ticker | Portfolio Investment | Close | Portfolio Value | Portfolio % Return | Abs Portfolio Return
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
2010-05-03 | GOOGL | STOCK | Communication Services | Internet Content & Information | United States | North America | 13.27 | 2 | 5 | 6 | 31.54 | Buy | USD | NaN | 1 | NaN | 31.54 | 154.500000 | 309.000000 | 8.797083 | 277.460000
2010-07-06 | AMZN | STOCK | Technology | Internet Retail | United States | North America | 5.50 | 5 | 3 | 3 | 30.50 | Buy | USD | NaN | 1 | NaN | 30.50 | 94.660004 | 473.300018 | 14.518033 | 442.800018
2011-08-06 | AAPL | STOCK | Technology | Consumer Electronics | United States | North America | 12.61 | 3 | 1 | 0 | 38.83 | Buy | USD | NaN | 1 | NaN | 38.83 | 106.330002 | 318.990005 | 7.215040 | 280.160005
2011-12-12 | APTV | STOCK | Consumer Cyclical | Auto Parts | United States | North America | 18.02 | 5 | 0 | 2 | 90.10 | Buy | USD | NaN | 1 | NaN | 90.10 | 103.389999 | 516.949997 | 4.737514 | 426.849997

This is now fixed:


Date | Ticker | Type | Sector | Industry | Country | Region | Price | Quantity | Fees | Premium | Investment | Side | Currency | ISIN | Signal | yf_Ticker | Portfolio Investment | Close | Portfolio Value | Portfolio % Return | Abs Portfolio Return
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | 
2010-05-03 | GOOGL | STOCK | Communication Services | Internet Content & Information | United States | North America | 13.27 | 2 | 5 | 6 | 31.54 | Buy | USD | NaN | 1 | NaN | 31.54 | 101.919998 | 203.839996 | 5.462904 | 172.299996
2010-07-06 | AMZN | STOCK | Technology | Internet Retail | United States | North America | 5.50 | 5 | 3 | 3 | 30.50 | Buy | USD | NaN | 1 | NaN | 30.50 | 101.330002 | 506.650009 | 15.611476 | 476.150009
2011-08-06 | AAPL | STOCK | Technology | Consumer Electronics | United States | North America | 12.61 | 3 | 1 | 0 | 38.83 | Buy | USD | NaN | 1 | NaN | 38.83 | 150.979996 | 452.939987 | 10.664692 | 414.109987
2011-12-12 | APTV | STOCK | Consumer Cyclical | Auto Parts | United States | North America | 18.02 | 5 | 0 | 2 | 90.10 | Buy | USD | NaN | 1 | NaN | 90.10 | 113.940002 | 569.700012 | 5.322975 | 479.600012