### PR TITLE
Update pinned `lightgbm` conda version

### DIFF
--- a/build/conda/conda-3-9-env-full.yaml
+++ b/build/conda/conda-3-9-env-full.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.9.6
   - pip
   - poetry=1.1.13
-  - lightgbm=3.3.3
+  - lightgbm=3.3.5


### PR DESCRIPTION
Poetry had troubles updating `lightgbm`

![image](https://user-images.githubusercontent.com/105685594/217301992-25345951-6fee-4a5c-8ddf-75fdc7438387.png)

Now, on a fresh `env` the following should work:
```
conda env create -n pr --file build/conda/conda-3-9-env-full.yaml
poetry install -E all
```