### PR TITLE
Feature/general improvements

### DIFF
--- a/openbb_terminal/miscellaneous/i18n/en.yml
+++ b/openbb_terminal/miscellaneous/i18n/en.yml
@@ -398,7 +398,6 @@ en:
   stocks/bt/emacross: buy when EMA(short) > EMA(long)
   stocks/bt/rsi: buy when RSI < low and sell when RSI > high
   stocks/ta/_ticker: Ticker
-  stocks/ta/tv: open interactive chart on
   stocks/ta/view: view historical data and trendlines
   stocks/ta/summary: technical summary report
   stocks/ta/recom: recommendation based on technical indicators

--- a/openbb_terminal/miscellaneous/i18n/en.yml
+++ b/openbb_terminal/miscellaneous/i18n/en.yml
@@ -83,7 +83,7 @@ en:
   settings/_timezone: Timezone
   settings/source: specify data source file
   settings/_data_source: Data sources
-  _others_: Others
+  _toolkits_: OpenBB Toolkits
   stocks: access historical pricing data, options, sector and industry, and overall due diligence
   crypto: dive into onchain data, tokenomics, circulation supply, nfts and more
   etf: exchange traded funds. Historical pricing, compare holdings and screening
@@ -176,7 +176,7 @@ en:
   stocks/th/all: show all markets
   stocks/th/exchange: show one exchange
   stocks/th/holidays: show all dates on which there is a market holiday
-  stocks/disc/filings: the most-recent form submissions to the SEC 
+  stocks/disc/filings: the most-recent form submissions to the SEC
   stocks/disc/pipo: past IPOs dates
   stocks/disc/fipo: future IPOs dates
   stocks/disc/gainers: show latest top gainers

--- a/openbb_terminal/stocks/backtesting/bt_controller.py
+++ b/openbb_terminal/stocks/backtesting/bt_controller.py
@@ -18,7 +18,7 @@ from openbb_terminal.helper_funcs import (
     valid_date,
 )
 from openbb_terminal.menu import session
-from openbb_terminal.parent_classes import BaseController
+from openbb_terminal.parent_classes import StockBaseController
 from openbb_terminal.rich_config import MenuText, console
 
 # This code below aims to fix an issue with the fnn module, used by bt module
@@ -35,10 +35,15 @@ logger = logging.getLogger(__name__)
 mpl.use(default_backend)
 
 
-class BacktestingController(BaseController):
+def no_data_message():
+    """Print message when no ticker is loaded"""
+    console.print("[red]No data loaded. Use 'load' command to load a symbol[/red]")
+
+
+class BacktestingController(StockBaseController):
     """Backtesting Controller class"""
 
-    CHOICES_COMMANDS = ["ema", "emacross", "rsi", "whatif"]
+    CHOICES_COMMANDS = ["load", "ema", "emacross", "rsi", "whatif"]
     PATH = "/stocks/bt/"
     CHOICES_GENERATION = True
 
@@ -48,7 +53,6 @@ class BacktestingController(BaseController):
 
         self.ticker = ticker
         self.stock = stock
-
         if session and obbff.USE_PROMPT_TOOLKIT:
             choices: dict = self.choices_default
 
@@ -57,7 +61,9 @@ class BacktestingController(BaseController):
     def print_help(self):
         """Print help"""
         mt = MenuText("stocks/bt/")
+        mt.add_raw("\n")
         mt.add_param("_ticker", self.ticker.upper())
+        mt.add_cmd("load")
         mt.add_raw("\n")
         mt.add_cmd("whatif")
         mt.add_raw("\n")
@@ -101,6 +107,9 @@ class BacktestingController(BaseController):
             other_args.insert(0, "-d")
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             bt_view.display_whatif_scenario(
                 symbol=self.ticker,
                 num_shares_acquired=ns_parser.num_shares_acquired,
@@ -141,6 +150,9 @@ class BacktestingController(BaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             bt_view.display_simple_ema(
                 symbol=self.ticker,
                 data=self.stock,
@@ -204,6 +216,9 @@ class BacktestingController(BaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             if ns_parser.long < ns_parser.short:
                 console.print("Short EMA period is longer than Long EMA period\n")
 
@@ -280,6 +295,9 @@ class BacktestingController(BaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             if ns_parser.high < ns_parser.low:
                 console.print("Low RSI value is higher than Low RSI value\n")
 

--- a/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -37,6 +37,7 @@ from openbb_terminal.stocks.fundamental_analysis import (
     seeking_alpha_view,
     yahoo_finance_view,
 )
+from openbb_terminal.terminal_helper import suppress_stdout
 
 # pylint: disable=inconsistent-return-statements,C0302,R0904
 
@@ -168,6 +169,11 @@ class FundamentalAnalysisController(StockBaseController):
             return ["stocks", f"load {self.ticker}", "fa"]
         return []
 
+    def custom_load_wrapper(self, other_args: List[str]):
+        """Class specific component of load command"""
+        with suppress_stdout():
+            self.call_load(other_args)
+
     @log_start_end(log=logger)
     def call_analysis(self, other_args: List[str]):
         """Process analysis command."""
@@ -177,10 +183,22 @@ class FundamentalAnalysisController(StockBaseController):
             prog="analysis",
             description="""Display analysis of SEC filings based on NLP model. [Source: https://eclect.us]""",
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
             eclect_us_view.display_analysis(
                 symbol=self.ticker,
                 export=ns_parser.export,
@@ -201,11 +219,22 @@ class FundamentalAnalysisController(StockBaseController):
                 (potentially) Insider Activity page. [Source: Business Insider]
             """,
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
 
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
             business_insider_view.display_management(
                 symbol=self.ticker,
                 export=ns_parser.export,
@@ -225,11 +254,22 @@ class FundamentalAnalysisController(StockBaseController):
                 Prints information about, among other things, the industry, sector exchange and company description.
                 """,
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
 
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
             if ns_parser.source == "Finviz":
                 finviz_view.display_screen_data(
                     symbol=self.ticker,
@@ -283,10 +323,22 @@ class FundamentalAnalysisController(StockBaseController):
             dest="years",
             help="Define the amount of years required to calculate the score.",
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             fmp_view.valinvest_score(
                 self.ticker,
                 ns_parser.years,
@@ -309,6 +361,14 @@ class FundamentalAnalysisController(StockBaseController):
                     Enterprise value, Market capitalization, Minus cash and cash equivalents, Number
                     of shares, Stock price, and Symbol. [Source: Financial Modeling Prep]
                 """,
+        )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
         )
         parser.add_argument(
             "-l",
@@ -342,6 +402,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             if ns_parser.source == "FinancialModelingPrep":
                 fmp_view.display_enterprise(
                     symbol=self.ticker,
@@ -390,6 +454,14 @@ class FundamentalAnalysisController(StockBaseController):
                 """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-l",
             "--limit",
             action="store",
@@ -410,6 +482,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             if ns_parser.source == "FinancialModelingPrep":
                 fmp_view.display_key_metrics(
                     symbol=self.ticker,
@@ -458,6 +534,14 @@ class FundamentalAnalysisController(StockBaseController):
                 """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-l",
             "--limit",
             action="store",
@@ -478,6 +562,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             fmp_view.display_financial_ratios(
                 symbol=self.ticker,
                 limit=ns_parser.limit,
@@ -513,6 +601,14 @@ class FundamentalAnalysisController(StockBaseController):
                 """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-l",
             "--limit",
             action="store",
@@ -533,6 +629,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             fmp_view.display_financial_statement_growth(
                 symbol=self.ticker,
                 limit=ns_parser.limit,
@@ -552,11 +652,23 @@ class FundamentalAnalysisController(StockBaseController):
             prog="epsfc",
             description="""Estimated EPS [Source: Seeking Alpha]""",
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
 
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             seeking_alpha_view.display_eps_estimates(
                 self.ticker,
                 export=ns_parser.export,
@@ -574,11 +686,23 @@ class FundamentalAnalysisController(StockBaseController):
             prog="revfc",
             description="""Estimated revenue [Source: Seeking Alpha]""",
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
 
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             seeking_alpha_view.display_rev_estimates(
                 self.ticker,
                 export=ns_parser.export,
@@ -600,6 +724,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             yahoo_finance_view.display_splits(
                 self.ticker,
                 export=ns_parser.export,
@@ -619,6 +747,14 @@ class FundamentalAnalysisController(StockBaseController):
             [Source: Yahoo Finance]""",
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "--holder",
             choices=self.SHRS_CHOICES,
             default="institutional",
@@ -633,6 +769,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             if not self.suffix:
                 yahoo_finance_view.display_shareholders(
                     self.ticker,
@@ -655,6 +795,14 @@ class FundamentalAnalysisController(StockBaseController):
             description="Historical dividends for a company",
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-l",
             "--limit",
             dest="limit",
@@ -674,6 +822,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             if not self.suffix:
                 yahoo_finance_view.display_dividends(
                     symbol=self.ticker,
@@ -704,6 +856,14 @@ class FundamentalAnalysisController(StockBaseController):
                 ratio, Other expenses, Period, Research and development expenses, Revenue, Selling and
                 marketing expenses, Total other income expenses net, Weighted average shs out, Weighted
                 average shs out dil [Source: Alpha Vantage]""",
+        )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
         )
         parser.add_argument(
             "-q",
@@ -739,6 +899,10 @@ class FundamentalAnalysisController(StockBaseController):
             limit=5,
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             ns_parser.plot = list_from_str(ns_parser.plot)
             # TODO: Switch to actually getting data
             if ns_parser.source == "YahooFinance" and ns_parser.b_quarter:
@@ -833,6 +997,14 @@ class FundamentalAnalysisController(StockBaseController):
             """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-q",
             "--quarter",
             action="store_true",
@@ -866,6 +1038,10 @@ class FundamentalAnalysisController(StockBaseController):
             limit=5,
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             ns_parser.plot = list_from_str(ns_parser.plot)
             # TODO: Switch to actually getting data
             if ns_parser.source == "YahooFinance" and ns_parser.b_quarter:
@@ -956,6 +1132,14 @@ class FundamentalAnalysisController(StockBaseController):
             """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-l",
             "--limit",
             action="store",
@@ -997,6 +1181,10 @@ class FundamentalAnalysisController(StockBaseController):
             export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED,
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             ns_parser.plot = list_from_str(ns_parser.plot)
             # TODO: Switch to actually getting data
             if ns_parser.source == "YahooFinance" and ns_parser.b_quarter:
@@ -1077,6 +1265,14 @@ class FundamentalAnalysisController(StockBaseController):
             """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-q",
             "--quarter",
             action="store_true",
@@ -1099,6 +1295,10 @@ class FundamentalAnalysisController(StockBaseController):
             EXPORT_ONLY_RAW_DATA_ALLOWED,
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             if ns_parser.source == "AlphaVantage":
                 av_view.display_earnings(
                     symbol=self.ticker,
@@ -1162,6 +1362,14 @@ class FundamentalAnalysisController(StockBaseController):
             ),
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-e",
             "--explanation",
             action="store_true",
@@ -1181,6 +1389,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             av_view.display_fraud(
                 symbol=self.ticker,
                 export=ns_parser.export,
@@ -1200,6 +1412,14 @@ class FundamentalAnalysisController(StockBaseController):
             description="The extended dupont deconstructs return on equity to allow investors to understand it better",
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "--raw",
             action="store_true",
             default=False,
@@ -1210,6 +1430,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             av_view.display_dupont(
                 self.ticker, raw=ns_parser.raw, export=ns_parser.export
             )
@@ -1240,6 +1464,14 @@ class FundamentalAnalysisController(StockBaseController):
                 this value by the number of shares outstanding allows us to calculate the value of
                 each share in a company.\n\n
                 """,
+        )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
         )
         parser.add_argument(
             "-a",
@@ -1292,6 +1524,10 @@ class FundamentalAnalysisController(StockBaseController):
         )
 
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             dcf = dcf_view.CreateExcelFA(
                 symbol=self.ticker,
                 audit=ns_parser.audit,
@@ -1316,6 +1552,14 @@ class FundamentalAnalysisController(StockBaseController):
                 """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-l",
             "--limit",
             action="store",
@@ -1336,6 +1580,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             fmp_view.display_discounted_cash_flow(
                 symbol=self.ticker,
                 limit=ns_parser.limit,
@@ -1361,6 +1609,14 @@ class FundamentalAnalysisController(StockBaseController):
             """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-d",
             "--debug",
             action="store_true",
@@ -1372,6 +1628,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             market_watch_view.display_sean_seah_warnings(
                 symbol=self.ticker, debug=ns_parser.b_debug
             )
@@ -1408,6 +1668,14 @@ class FundamentalAnalysisController(StockBaseController):
             description="""Prints price target from analysts. [Source: Business Insider]""",
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "--raw",
             action="store_true",
             dest="raw",
@@ -1429,6 +1697,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             business_insider_view.price_target_from_analysts(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1451,6 +1723,14 @@ class FundamentalAnalysisController(StockBaseController):
             [Source: Business Insider]""",
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-e",
             "--estimate",
             help="Estimates to get",
@@ -1462,6 +1742,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             business_insider_view.estimates(
                 symbol=self.ticker,
                 estimate=ns_parser.estimate,
@@ -1480,6 +1764,14 @@ class FundamentalAnalysisController(StockBaseController):
             description="""
                 Rating over time (monthly). [Source: Finnhub]
             """,
+        )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
         )
         parser.add_argument(
             "-l",
@@ -1504,6 +1796,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             finnhub_view.rating_over_time(
                 symbol=self.ticker,
                 limit=ns_parser.limit,
@@ -1527,6 +1823,14 @@ class FundamentalAnalysisController(StockBaseController):
             """,
         )
         parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
             "-l",
             "--limit",
             action="store",
@@ -1543,6 +1847,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             if ns_parser.source == "Finviz":
                 finviz_view.analyst(
                     symbol=self.ticker,
@@ -1606,6 +1914,10 @@ class FundamentalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             if ns_parser.source == "MarketWatch":
                 marketwatch_view.sec_filings(
                     symbol=ns_parser.ticker,
@@ -1634,11 +1946,23 @@ class FundamentalAnalysisController(StockBaseController):
             add_help=False,
             description="List of suppliers from ticker provided. [Source: CSIMarket]",
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
 
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             csimarket_view.suppliers(
                 symbol=self.ticker,
                 export=ns_parser.export,
@@ -1655,11 +1979,23 @@ class FundamentalAnalysisController(StockBaseController):
             add_help=False,
             description="List of customers from ticker provided. [Source: CSIMarket]",
         )
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            help="Ticker to analyze",
+            type=str,
+            default=None,
+        )
 
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if ns_parser.ticker:
+                self.ticker = ns_parser.ticker
+                self.custom_load_wrapper([self.ticker])
+
             csimarket_view.customers(
                 symbol=self.ticker,
                 export=ns_parser.export,

--- a/openbb_terminal/stocks/quantitative_analysis/qa_controller.py
+++ b/openbb_terminal/stocks/quantitative_analysis/qa_controller.py
@@ -32,6 +32,11 @@ from openbb_terminal.stocks.quantitative_analysis.qa_model import full_stock_df
 logger = logging.getLogger(__name__)
 
 
+def no_data_message():
+    """Print message when no ticker is loaded"""
+    console.print("[red]No data loaded. Use 'load' command to load a symbol[/red]")
+
+
 class QaController(StockBaseController):
     """Quantitative Analysis Controller class"""
 
@@ -83,12 +88,14 @@ class QaController(StockBaseController):
     ):
         """Constructor"""
         super().__init__(queue)
-
-        self.stock = full_stock_df(stock)
+        if not stock.empty:
+            self.stock = full_stock_df(stock)
+        else:
+            self.stock = stock
         self.ticker = ticker
         self.start = start
         self.interval = interval
-        self.target = "returns"
+        self.target = "returns" if not stock.empty else ""
 
         if session and obbff.USE_PROMPT_TOOLKIT:
             choices: dict = self.choices_default
@@ -175,6 +182,9 @@ class QaController(StockBaseController):
 
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             self.target = ns_parser.target
 
     @log_start_end(log=logger)
@@ -220,6 +230,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_raw(
                 data=self.stock,
                 limit=ns_parser.limit,
@@ -246,6 +259,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_summary(
                 data=self.stock,
                 export=ns_parser.export,
@@ -289,6 +305,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_FIGURES_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_line(
                 self.stock[self.target],
                 title=f"{self.ticker} {self.target}",
@@ -313,6 +332,9 @@ class QaController(StockBaseController):
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_hist(
                 symbol=self.ticker,
                 data=self.stock,
@@ -335,6 +357,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_cdf(
                 data=self.stock,
                 symbol=self.ticker,
@@ -366,6 +391,9 @@ class QaController(StockBaseController):
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_bw(
                 data=self.stock,
                 symbol=self.ticker,
@@ -398,6 +426,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_seasonal(
                 symbol=self.ticker,
                 data=self.stock,
@@ -429,7 +460,9 @@ class QaController(StockBaseController):
                 max(self.stock[self.target].values)
                 - min(self.stock[self.target].values)
             )
-            / 40,
+            / 40
+            if not self.stock.empty
+            else 0,
             help="threshold",
         )
         parser.add_argument(
@@ -441,11 +474,16 @@ class QaController(StockBaseController):
                 max(self.stock[self.target].values)
                 - min(self.stock[self.target].values)
             )
-            / 80,
+            / 80
+            if not self.stock.empty
+            else 0,
             help="drift",
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_cusum(
                 data=self.stock,
                 target=self.target,
@@ -474,6 +512,9 @@ class QaController(StockBaseController):
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             if self.target != "adjclose":
                 console.print(
                     "Target not adjclose.  For best results, use `pick adjclose` first."
@@ -510,6 +551,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             rolling_view.display_mean_std(
                 symbol=self.ticker,
                 data=self.stock,
@@ -544,6 +588,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             rolling_view.display_spread(
                 data=self.stock,
                 symbol=self.ticker,
@@ -595,6 +642,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             rolling_view.display_quantile(
                 data=self.stock,
                 symbol=self.ticker,
@@ -636,6 +686,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             rolling_view.display_skew(
                 symbol=self.ticker,
                 data=self.stock,
@@ -676,6 +729,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             rolling_view.display_kurtosis(
                 symbol=self.ticker,
                 data=self.stock,
@@ -702,6 +758,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_normality(
                 data=self.stock, target=self.target, export=ns_parser.export
             )
@@ -719,6 +778,9 @@ class QaController(StockBaseController):
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_qqplot(
                 symbol=self.ticker, data=self.stock, target=self.target
             )
@@ -756,6 +818,9 @@ class QaController(StockBaseController):
             parser, other_args, export_allowed=EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_unitroot(
                 data=self.stock,
                 target=self.target,
@@ -780,6 +845,9 @@ class QaController(StockBaseController):
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if not self.ticker:
+                no_data_message()
+                return
             capm_view(self.ticker)
 
     @log_start_end(log=logger)
@@ -812,6 +880,9 @@ class QaController(StockBaseController):
         # Work on the intersections
         interval = "".join(c for c in self.interval if c.isdigit())
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             beta_view(
                 symbol=self.ticker,
                 ref_symbol=ns_parser.ref,
@@ -890,6 +961,9 @@ class QaController(StockBaseController):
             if ns_parser.adjusted and ns_parser.student_t:
                 console.print("Select the adjusted or the student_t parameter.\n")
             else:
+                if self.stock.empty:
+                    no_data_message()
+                    return
                 qa_view.display_var(
                     self.stock,
                     self.ticker,
@@ -941,6 +1015,9 @@ class QaController(StockBaseController):
 
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             qa_view.display_es(
                 self.stock,
                 self.ticker,
@@ -976,11 +1053,14 @@ class QaController(StockBaseController):
             action="store",
             dest="window",
             type=int,
-            default=min(len(self.stock["adjclose"].values), 252),
+            default=252,
             help="Rolling window length",
         )
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             data = self.stock["adjclose"]
             qa_view.display_sharpe(data, ns_parser.rfr, ns_parser.window)
 
@@ -1018,12 +1098,15 @@ class QaController(StockBaseController):
             action="store",
             dest="window",
             type=int,
-            default=min(len(self.stock["returns"].values), 252),
+            default=252,
             help="Rolling window length",
         )
 
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             data = self.stock["returns"]
             qa_view.display_sortino(
                 data, ns_parser.target_return, ns_parser.window, ns_parser.adjusted
@@ -1065,6 +1148,9 @@ class QaController(StockBaseController):
 
         ns_parser = self.parse_known_args_and_warn(parser, other_args)
         if ns_parser:
+            if self.stock.empty:
+                no_data_message()
+                return
             data = self.stock["returns"]
             qa_view.display_omega(
                 data,

--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -124,12 +124,13 @@ class StocksController(StockBaseController):
         mt.add_menu("gov")
         mt.add_menu("ba")
         mt.add_menu("ca")
-        mt.add_menu("fa", self.ticker)
+        mt.add_menu("fa")
+        mt.add_menu("bt")
+        mt.add_menu("ta")
+        mt.add_menu("qa")
+        mt.add_menu("forecast")
         mt.add_menu("res", self.ticker)
-        mt.add_menu("bt", self.ticker)
-        mt.add_menu("ta", self.ticker)
-        mt.add_menu("qa", self.ticker)
-        mt.add_menu("forecast", self.ticker)
+
         console.print(text=mt.menu_text, menu="Stocks")
 
     def custom_reset(self):
@@ -652,49 +653,40 @@ class StocksController(StockBaseController):
     @log_start_end(log=logger)
     def call_fa(self, _):
         """Process fa command."""
-        if self.ticker:
-            from openbb_terminal.stocks.fundamental_analysis import fa_controller
+        from openbb_terminal.stocks.fundamental_analysis import fa_controller
 
-            self.queue = self.load_class(
-                fa_controller.FundamentalAnalysisController,
-                self.ticker,
-                self.start,
-                self.interval,
-                self.stock,
-                self.suffix,
-                self.queue,
-            )
-        else:
-            console.print("Use 'load <ticker>' prior to this command!")
+        self.queue = self.load_class(
+            fa_controller.FundamentalAnalysisController,
+            self.ticker,
+            self.start,
+            self.interval,
+            self.stock,
+            self.suffix,
+            self.queue,
+        )
 
     @log_start_end(log=logger)
     def call_bt(self, _):
         """Process bt command."""
-        if self.ticker:
-            from openbb_terminal.stocks.backtesting import bt_controller
+        from openbb_terminal.stocks.backtesting import bt_controller
 
-            self.queue = self.load_class(
-                bt_controller.BacktestingController, self.ticker, self.stock, self.queue
-            )
-        else:
-            console.print("Use 'load <ticker>' prior to this command!")
+        self.queue = self.load_class(
+            bt_controller.BacktestingController, self.ticker, self.stock, self.queue
+        )
 
     @log_start_end(log=logger)
     def call_ta(self, _):
         """Process ta command."""
-        if self.ticker:
-            from openbb_terminal.stocks.technical_analysis import ta_controller
+        from openbb_terminal.stocks.technical_analysis import ta_controller
 
-            self.queue = self.load_class(
-                ta_controller.TechnicalAnalysisController,
-                self.ticker,
-                self.start,
-                self.interval,
-                self.stock,
-                self.queue,
-            )
-        else:
-            console.print("Use 'load <ticker>' prior to this command!")
+        self.queue = self.load_class(
+            ta_controller.TechnicalAnalysisController,
+            self.ticker,
+            self.start,
+            self.interval,
+            self.stock,
+            self.queue,
+        )
 
     @log_start_end(log=logger)
     def call_ba(self, _):
@@ -711,19 +703,16 @@ class StocksController(StockBaseController):
     @log_start_end(log=logger)
     def call_qa(self, _):
         """Process qa command."""
-        if self.ticker:
-            from openbb_terminal.stocks.quantitative_analysis import qa_controller
+        from openbb_terminal.stocks.quantitative_analysis import qa_controller
 
-            self.queue = self.load_class(
-                qa_controller.QaController,
-                self.ticker,
-                self.start,
-                self.interval,
-                self.stock,
-                self.queue,
-            )
-        else:
-            console.print("Use 'load <ticker>' prior to this command!")
+        self.queue = self.load_class(
+            qa_controller.QaController,
+            self.ticker,
+            self.start,
+            self.interval,
+            self.stock,
+            self.queue,
+        )
 
     @log_start_end(log=logger)
     def call_forecast(self, _):

--- a/openbb_terminal/stocks/technical_analysis/ta_controller.py
+++ b/openbb_terminal/stocks/technical_analysis/ta_controller.py
@@ -4,7 +4,6 @@ __docformat__ = "numpy"
 
 import argparse
 import logging
-import webbrowser
 from datetime import datetime
 from typing import List
 
@@ -45,12 +44,16 @@ from openbb_terminal.stocks.technical_analysis import (
 logger = logging.getLogger(__name__)
 
 
+def no_ticker_message():
+    """Print message when no ticker is loaded"""
+    console.print("[red]No ticker loaded. Use 'load' command to load a symbol[/red]")
+
+
 class TechnicalAnalysisController(StockBaseController):
     """Technical Analysis Controller class"""
 
     CHOICES_COMMANDS = [
         "load",
-        "view",
         "summary",
         "recom",
         "ema",
@@ -162,20 +165,6 @@ class TechnicalAnalysisController(StockBaseController):
         return []
 
     # SPECIFIC
-
-    @log_start_end(log=logger)
-    def call_tv(self, other_args):
-        """Process tv command"""
-        parser = argparse.ArgumentParser(
-            add_help=False,
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            prog="tv",
-            description="""View TradingView for technical analysis. [Source: TradingView]""",
-        )
-        ns_parser = self.parse_known_args_and_warn(parser, other_args)
-        if ns_parser:
-            webbrowser.open(f"https://www.tradingview.com/chart/?symbol={self.ticker}")
-
     @log_start_end(log=logger)
     def call_view(self, other_args: List[str]):
         """Process view command"""
@@ -189,6 +178,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_FIGURES_ALLOWED
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             finviz_view.view(self.ticker)
 
     @log_start_end(log=logger)
@@ -209,6 +201,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             finbrain_view.technical_summary_report(self.ticker)
 
     @log_start_end(log=logger)
@@ -259,6 +254,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             tradingview_view.print_recommendation(
                 symbol=self.ticker,
                 screener=ns_parser.screener,
@@ -317,6 +315,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             overlap_view.view_ma(
                 ma_type="EMA",
                 symbol=self.ticker,
@@ -372,6 +373,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             overlap_view.view_ma(
                 ma_type="SMA",
                 symbol=self.ticker,
@@ -424,6 +428,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             overlap_view.view_ma(
                 ma_type="WMA",
                 symbol=self.ticker,
@@ -476,6 +483,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             overlap_view.view_ma(
                 ma_type="HMA",
                 symbol=self.ticker,
@@ -531,6 +541,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             overlap_view.view_ma(
                 ma_type="ZLMA",
                 symbol=self.ticker,
@@ -583,6 +596,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             # Daily
             if self.interval == "1440min":
                 if ns_parser.start:
@@ -648,6 +664,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             momentum_view.display_cci(
                 symbol=self.ticker,
                 data=self.stock,
@@ -707,6 +726,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             momentum_view.display_macd(
                 symbol=self.ticker,
                 data=self.stock["Adj Close"],
@@ -770,6 +792,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             momentum_view.display_rsi(
                 symbol=self.ticker,
                 data=self.stock["Adj Close"],
@@ -815,6 +840,9 @@ class TechnicalAnalysisController(StockBaseController):
         )
 
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             rsp_view.display_rsp(
                 s_ticker=self.ticker,
                 export=ns_parser.export,
@@ -871,6 +899,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             momentum_view.display_stoch(
                 symbol=self.ticker,
                 data=self.stock,
@@ -915,6 +946,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             momentum_view.display_fisher(
                 symbol=self.ticker,
                 data=self.stock,
@@ -957,6 +991,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             momentum_view.display_cg(
                 symbol=self.ticker,
                 data=self.stock["Adj Close"],
@@ -1015,6 +1052,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             trend_indicators_view.display_adx(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1074,6 +1114,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             trend_indicators_view.display_aroon(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1142,6 +1185,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             volatility_view.display_bbands(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1193,6 +1239,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             volatility_view.display_donchian(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1264,6 +1313,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             volatility_view.view_kc(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1309,6 +1361,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             volume_view.display_ad(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1364,6 +1419,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             volume_view.display_adosc(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1398,6 +1456,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             volume_view.display_obv(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1446,6 +1507,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             custom_indicators_view.fibonacci_retracement(
                 symbol=self.ticker,
                 data=self.stock,
@@ -1480,6 +1544,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_ONLY_FIGURES_ALLOWED
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             if self.interval == "1440min":
                 momentum_view.display_clenow_momentum(
                     self.stock["Adj Close"],
@@ -1514,6 +1581,9 @@ class TechnicalAnalysisController(StockBaseController):
             parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             momentum_view.display_demark(
                 self.stock,
                 self.ticker.upper(),
@@ -1569,6 +1639,9 @@ class TechnicalAnalysisController(StockBaseController):
         )
 
         if ns_parser:
+            if not self.ticker:
+                no_ticker_message()
+                return
             volatility_view.display_atr(
                 data=self.stock,
                 symbol=self.ticker,

--- a/openbb_terminal/stocks/technical_analysis/ta_controller.py
+++ b/openbb_terminal/stocks/technical_analysis/ta_controller.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 def no_ticker_message():
     """Print message when no ticker is loaded"""
-    console.print("[red]No ticker loaded. Use 'load' command to load a symbol[/red]")
+    console.print("[red]No data loaded. Use 'load' command to load a symbol[/red]")
 
 
 class TechnicalAnalysisController(StockBaseController):

--- a/openbb_terminal/terminal_controller.py
+++ b/openbb_terminal/terminal_controller.py
@@ -194,7 +194,7 @@ class TerminalController(BaseController):
         mt.add_menu("alternative")
         mt.add_menu("funds")
         mt.add_raw("\n")
-        mt.add_info("_others_")
+        mt.add_info("_toolkits_")
         mt.add_menu("econometrics")
         mt.add_menu("forecast")
         mt.add_menu("portfolio")


### PR DESCRIPTION
This PR mainly allows users to enter any stocks submenu without doing load first (except for research).

Within the fa menu, this adds ticker arguments to all functions, ie (cash -t aapl) instead of load appl/cash.