### PR TITLE
Report rendering can't handle save path for users that have a period (.) in username

### DIFF
--- a/openbb_terminal/reports/reports_model.py
+++ b/openbb_terminal/reports/reports_model.py
@@ -282,8 +282,9 @@ def create_output_path(input_path: str, parameters_dict: Dict[str, Any]) -> str:
         + "_"
         + f"{report_name}{args_to_output}"
     )
+    output_path = report_output_name.replace(".", "_")
     output_path = str(USER_REPORTS_DIRECTORY / report_output_name)
-    output_path = output_path.replace(".", "_")
+    
 
     return output_path
 


### PR DESCRIPTION
# Description

- [ ] Summary of the change / bug fix.
Report rendering can't handle save path for users that have a period (.) in username

- [ ] Link # issue, if applicable.
https://github.com/OpenBB-finance/OpenBBTerminal/issues/4174

- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context.
- [ ] List any dependencies that are required for this change.


# How has this been tested?
after change this code, report rendering can handle path for users that have a period (.) in username.

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [ ] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [ ] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
