### PR TITLE
Fix spelling mistake in portfolio menu help message

### DIFF
--- a/openbb_terminal/portfolio/portfolio_controller.py
+++ b/openbb_terminal/portfolio/portfolio_controller.py
@@ -206,7 +206,7 @@ class PortfolioController(BaseController):
         mt.add_info("_risk_")
         mt.add_cmd("var", self.portfolio_name and self.benchmark_name)
         mt.add_cmd("es", self.portfolio_name and self.benchmark_name)
-        mt.add_cmd("os", self.portfolio_name and self.benchmark_name)
+        mt.add_cmd("om", self.portfolio_name and self.benchmark_name)
 
         console.print(text=mt.menu_text, menu="Portfolio - Portfolio Optimization")
         self.update_choices()
@@ -894,7 +894,7 @@ class PortfolioController(BaseController):
                 )
             else:
                 console.print(
-                    "[red]Please first define the portfolio (via 'load')[/red]\n"
+                    "[red]Please define the portfolio first (via 'load')[/red]\n"
                 )
 
     @log_start_end(log=logger)


### PR DESCRIPTION
# Description

Closes #4290 

The error was that the commands name is `om` and not `os`. This was only an error on the portfolio menu help message

# How has this been tested?

Running the command.
- [x] Make sure affected commands still run in terminal
- [x] Ensure the SDK still works
- [x] Check any related reports


# Checklist:

- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [x] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
