### PR TITLE
Fix `--help` for `stocks/candle`, `stocks/tob` and `stocks/news`

### DIFF
--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -264,7 +264,7 @@ class StocksController(StockBaseController):
             "--ticker",
             action="store",
             dest="s_ticker",
-            required="-h" not in other_args and not self.ticker,
+            required=not any(x in other_args for x in ["-h", "--help"]) and not self.ticker,
             help="Ticker to get data for",
         )
         parser.add_argument(
@@ -363,7 +363,7 @@ class StocksController(StockBaseController):
             help="Ticker to analyze",
             type=str,
             default=None,
-            required="-h" not in other_args and not self.ticker,
+            required=not any(x in other_args for x in ["-h", "--help"]) and not self.ticker,
         )
         parser.add_argument(
             "-p",
@@ -495,7 +495,7 @@ class StocksController(StockBaseController):
             "--ticker",
             action="store",
             dest="ticker",
-            required="-h" not in other_args and not self.ticker,
+            required=not any(x in other_args for x in ["-h", "--help"]) and not self.ticker,
             help="Ticker to get data for",
         )
         parser.add_argument(

--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -264,7 +264,8 @@ class StocksController(StockBaseController):
             "--ticker",
             action="store",
             dest="s_ticker",
-            required=not any(x in other_args for x in ["-h", "--help"]) and not self.ticker,
+            required=not any(x in other_args for x in ["-h", "--help"])
+            and not self.ticker,
             help="Ticker to get data for",
         )
         parser.add_argument(
@@ -363,7 +364,8 @@ class StocksController(StockBaseController):
             help="Ticker to analyze",
             type=str,
             default=None,
-            required=not any(x in other_args for x in ["-h", "--help"]) and not self.ticker,
+            required=not any(x in other_args for x in ["-h", "--help"])
+            and not self.ticker,
         )
         parser.add_argument(
             "-p",
@@ -495,7 +497,8 @@ class StocksController(StockBaseController):
             "--ticker",
             action="store",
             dest="ticker",
-            required=not any(x in other_args for x in ["-h", "--help"]) and not self.ticker,
+            required=not any(x in other_args for x in ["-h", "--help"])
+            and not self.ticker,
             help="Ticker to get data for",
         )
         parser.add_argument(


### PR DESCRIPTION
# Description

Closes #4278 

Fixes the `--help` parameter for the following commands `stocks/candle`, `stocks/tob` and `stocks/news`.


# How has this been tested?

Running the commands following commands:
* `stocks/candle --help`
* `stocks/tob --help`
* `stocks/news --help`
- [x] Make sure affected commands still run in terminal
- [x] Ensure the SDK still works
- [x] Check any related reports


# Checklist:

- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [x] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [x] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
