### PR TITLE
Set query arg in economy/eval as required

### DIFF
--- a/openbb_terminal/economy/economy_controller.py
+++ b/openbb_terminal/economy/economy_controller.py
@@ -1630,6 +1630,7 @@ class EconomyController(BaseController):
             type=str,
             nargs="+",
             dest="query",
+            required="-h" not in other_args,
             help="Query to evaluate on loaded datasets",
         )
         if other_args and "-" not in other_args[0][0]:

--- a/website/content/terminal/reference/economy/eval.md
+++ b/website/content/terminal/reference/economy/eval.md
@@ -19,6 +19,6 @@ eval [-q QUERY [QUERY ...]]
 
 | Name | Description | Default | Optional | Choices |
 | ---- | ----------- | ------- | -------- | ------- |
-| query | Query to evaluate on loaded datasets | None | True | None |
+| query | Query to evaluate on loaded datasets | None | False | None |
 
 ---


### PR DESCRIPTION
# Description

Closes #4238 by making the `--query` arg in `economy/eval` required. Bug was caused by `ns_parser` not being `NoneType` even if no argument was passed. Given that `--query` has no default value and is dependent on loaded data, it makes sense to require it.

# How has this been tested?

- [X] Make sure affected commands still run in terminal
- [X] Ensure the SDK still works
- [X] Check any related reports

# Checklist:

- [X] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [X] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [X] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).

# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
