### PR TITLE
Fix long/short issue and fix transform issue

### DIFF
--- a/openbb_terminal/economy/econdb_model.py
+++ b/openbb_terminal/economy/econdb_model.py
@@ -553,6 +553,13 @@ def get_macro_data(
 
             df = pd.DataFrame(data["dataarray"])
 
+            if code not in df.columns:
+                console.print(
+                    f"No data available for {parameter} of {country} "
+                    f"{f'with transform method {transform}' if transform else ''}"
+                )
+                return pd.DataFrame(), "NA/NA"
+
             df = df.set_index(pd.to_datetime(df["date"]))[code] * SCALES[scale]
             df = df.sort_index().dropna()
 

--- a/openbb_terminal/fixedincome/oecd_model.py
+++ b/openbb_terminal/fixedincome/oecd_model.py
@@ -223,6 +223,8 @@ def get_treasury(
     end_date: str
         End date of data, in YYYY-MM-DD format
     """
+    df_short, df_long = pd.DataFrame(), pd.DataFrame()
+
     if short_term:
         df_short = get_interest_rate_data(
             f"short{'_forecast' if forecast else ''}",
@@ -239,4 +241,5 @@ def get_treasury(
         )
 
     df = pd.concat([df_short, df_long], axis=1)
+
     return df


### PR DESCRIPTION
Saw this:

```
(🦋) /fixedincome/ $ treasury --long portugal

Error: local variable 'df_short' referenced before assignment


(🦋) /fixedincome/ $ treasury --long portugal

Error: local variable 'df_short' referenced before assignment


(🦋) /fixedincome/ $ treasury --short australia

Error: local variable 'df_long' referenced before assignment
```

So fixed it. Also saw this:

```
(🦋) /economy/ $ macro CPI --transform TPOP

Error: 'CPIUS~TPOP'

Error: not enough values to unpack (expected 2, got 0)

Error: not enough values to unpack (expected 3, got 0)
```

So fixed it.