### PR TITLE
Allow turning charts into fig on SDK

### DIFF
--- a/openbb_terminal/helper_classes.py
+++ b/openbb_terminal/helper_classes.py
@@ -1,6 +1,7 @@
 """Helper classes."""
 __docformat__ = "numpy"
 import argparse
+import io
 import json
 import os
 from importlib import machinery, util
@@ -8,7 +9,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import matplotlib.pyplot as plt
+import plotly.express as px
 from matplotlib import font_manager, ticker
+from PIL import Image
 
 from openbb_terminal.core.config.paths import MISCELLANEOUS_DIRECTORY
 from openbb_terminal.core.session.current_user import get_current_user
@@ -346,7 +349,9 @@ class TerminalStyle:
             )
 
     # pylint: disable=import-outside-toplevel
-    def visualize_output(self, force_tight_layout: bool = True):
+    def visualize_output(
+        self, force_tight_layout: bool = True, external_axes: bool = False
+    ):
         """Show chart in an interactive widget."""
         current_user = get_current_user()
 
@@ -356,9 +361,20 @@ class TerminalStyle:
             self.add_label(plt.gcf())
         if force_tight_layout:
             plt.tight_layout(pad=self.tight_layout_padding)
-        if current_user.preferences.USE_ION:
-            plt.ion()
-        plt.show()
+
+        if external_axes:
+            img_buf = io.BytesIO()
+            plt.savefig(img_buf, format="jpg")
+            im = Image.open(img_buf)
+            fig = px.imshow(im)
+        else:
+            if current_user.preferences.USE_ION:
+                plt.ion()
+
+            fig = None
+            plt.show()
+
+        return fig
 
 
 class AllowArgsWithWhiteSpace(argparse.Action):

--- a/openbb_terminal/portfolio/portfolio_optimization/optimizer_view.py
+++ b/openbb_terminal/portfolio/portfolio_optimization/optimizer_view.py
@@ -2175,12 +2175,9 @@ def display_ef(
     try:
         risk_free_rate = risk_free_rate / time_factor[freq.upper()]
 
-        if external_axes is None:
-            _, ax = plt.subplots(
-                figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-            )
-        else:
-            ax = external_axes[0]
+        _, ax = plt.subplots(
+            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+        )
 
         ax = rp.plot_frontier(
             w_frontier=frontier,
@@ -2277,8 +2274,10 @@ def display_ef(
         ax1 = ax.get_figure().axes
         ll, bb, ww, hh = ax1[-1].get_position().bounds
         ax1[-1].set_position([ll * 1.02, bb, ww, hh])
-        if external_axes is None:
-            theme.visualize_output(force_tight_layout=False)
+
+        return theme.visualize_output(
+            force_tight_layout=False, external_axes=external_axes
+        )
     except Exception as _:
         console.print("[red]Error plotting efficient frontier.[/red]")
 
@@ -3644,12 +3643,9 @@ def pie_chart_weights(
     total_size = np.sum(sizes)
     colors = theme.get_colors()
 
-    if external_axes is None:
-        _, ax = plt.subplots(
-            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-        )
-    else:
-        ax = external_axes[0]
+    _, ax = plt.subplots(
+        figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+    )
 
     if math.isclose(sum(sizes), 1, rel_tol=0.1):
         _, _, autotexts = ax.pie(
@@ -3714,8 +3710,7 @@ def pie_chart_weights(
     title += "Portfolio Composition"
     ax.set_title(title)
 
-    if external_axes is None:
-        theme.visualize_output()
+    return theme.visualize_output(force_tight_layout=True, external_axes=external_axes)
 
 
 @log_start_end(log=logger)
@@ -3868,12 +3863,9 @@ def additional_plots(
         pie_chart_weights(weights, title_opt, external_axes)
 
     if hist:
-        if external_axes is None:
-            _, ax = plt.subplots(
-                figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-            )
-        else:
-            ax = external_axes[0]
+        _, ax = plt.subplots(
+            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+        )
 
         ax = rp.plot_hist(data, w=pd.Series(weights).to_frame(), alpha=alpha, ax=ax)
         ax.legend(fontsize="x-small", loc="best")
@@ -3894,16 +3886,14 @@ def additional_plots(
         title += ax.get_title(loc="left")
         ax.set_title(title)
 
-        if external_axes is None:
-            theme.visualize_output()
+        return theme.visualize_output(
+            force_tight_layout=False, external_axes=external_axes
+        )
 
     if dd:
-        if external_axes is None:
-            _, ax = plt.subplots(
-                figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-            )
-        else:
-            ax = external_axes[0]
+        _, ax = plt.subplots(
+            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+        )
 
         nav = data.cumsum()
         ax = rp.plot_drawdown(
@@ -3932,16 +3922,14 @@ def additional_plots(
         title += ax.get_title(loc="left")
         ax.set_title(title)
 
-        if external_axes is None:
-            theme.visualize_output()
+        return theme.visualize_output(
+            force_tight_layout=False, external_axes=external_axes
+        )
 
     if rc_chart:
-        if external_axes is None:
-            _, ax = plt.subplots(
-                figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-            )
-        else:
-            ax = external_axes[0]
+        _, ax = plt.subplots(
+            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+        )
 
         ax = rp.plot_risk_con(
             w=pd.Series(weights).to_frame(),
@@ -3968,8 +3956,9 @@ def additional_plots(
         title += ax.get_title(loc="left")
         ax.set_title(title)
 
-        if external_axes is None:
-            theme.visualize_output()
+        return theme.visualize_output(
+            force_tight_layout=False, external_axes=external_axes
+        )
 
     if heat:
         if len(weights) == 1:
@@ -3979,12 +3968,9 @@ def additional_plots(
             )
             return
 
-        if external_axes is None:
-            _, ax = plt.subplots(
-                figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-            )
-        else:
-            ax = external_axes[0]
+        _, ax = plt.subplots(
+            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+        )
 
         if len(weights) <= 3:
             number_of_clusters = len(weights)
@@ -4047,8 +4033,9 @@ def additional_plots(
         title += ax[3].get_title(loc="left")
         ax[3].set_title(title)
 
-        if external_axes is None:
-            theme.visualize_output(force_tight_layout=True)
+        return theme.visualize_output(
+            force_tight_layout=False, external_axes=external_axes
+        )
 
 
 def display_show(weights: Dict, tables: List[str], categories_dict: Dict[Any, Any]):

--- a/openbb_terminal/portfolio/portfolio_optimization/po_view.py
+++ b/openbb_terminal/portfolio/portfolio_optimization/po_view.py
@@ -144,12 +144,9 @@ def display_ef(portfolio_engine: Optional[PoEngine] = None, **kwargs):
 
     risk_free_rate = risk_free_rate / TIME_FACTOR[freq.upper()]
 
-    if external_axes is None:
-        _, ax = plt.subplots(
-            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-        )
-    else:
-        ax = external_axes[0]
+    _, ax = plt.subplots(
+        figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+    )
 
     ax = rp.plot_frontier(
         w_frontier=frontier,
@@ -246,8 +243,8 @@ def display_ef(portfolio_engine: Optional[PoEngine] = None, **kwargs):
     ax1 = ax.get_figure().axes
     ll, bb, ww, hh = ax1[-1].get_position().bounds
     ax1[-1].set_position([ll * 1.02, bb, ww, hh])
-    if external_axes is None:
-        theme.visualize_output(force_tight_layout=False)
+
+    return theme.visualize_output(force_tight_layout=False, external_axes=external_axes)
 
 
 @log_start_end(log=logger)
@@ -417,12 +414,9 @@ def display_heat(**kwargs):
         )
         return
 
-    if external_axes is None:
-        _, ax = plt.subplots(
-            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-        )
-    else:
-        ax = external_axes[0]
+    _, ax = plt.subplots(
+        figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+    )
 
     if len(weights) <= 3:
         number_of_clusters = len(weights)
@@ -485,8 +479,7 @@ def display_heat(**kwargs):
     title += ax[3].get_title(loc="left")
     ax[3].set_title(title)
 
-    if external_axes is None:
-        theme.visualize_output(force_tight_layout=True)
+    return theme.visualize_output(force_tight_layout=True, external_axes=external_axes)
 
 
 @log_start_end(log=logger)
@@ -505,12 +498,9 @@ def display_rc(**kwargs):
     b_sim = get_kwarg("b_sim", kwargs)
     freq = get_kwarg("freq", kwargs)
 
-    if external_axes is None:
-        _, ax = plt.subplots(
-            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-        )
-    else:
-        ax = external_axes[0]
+    _, ax = plt.subplots(
+        figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+    )
 
     ax = rp.plot_risk_con(
         w=pd.Series(weights).to_frame(),
@@ -537,8 +527,7 @@ def display_rc(**kwargs):
     title += ax.get_title(loc="left")
     ax.set_title(title)
 
-    if external_axes is None:
-        theme.visualize_output()
+    return theme.visualize_output(force_tight_layout=True, external_axes=external_axes)
 
 
 @log_start_end(log=logger)
@@ -551,12 +540,9 @@ def display_hist(**kwargs):
 
     alpha = kwargs.get("alpha", 0.05)
 
-    if external_axes is None:
-        _, ax = plt.subplots(
-            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-        )
-    else:
-        ax = external_axes[0]
+    _, ax = plt.subplots(
+        figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+    )
 
     ax = rp.plot_hist(data, w=pd.Series(weights).to_frame(), alpha=alpha, ax=ax)
     ax.legend(fontsize="x-small", loc="best")
@@ -577,8 +563,7 @@ def display_hist(**kwargs):
     title += ax.get_title(loc="left")
     ax.set_title(title)
 
-    if external_axes is None:
-        theme.visualize_output()
+    return theme.visualize_output(force_tight_layout=True, external_axes=external_axes)
 
 
 @log_start_end(log=logger)
@@ -591,12 +576,9 @@ def display_dd(**kwargs):
 
     alpha = get_kwarg("alpha", kwargs)
 
-    if external_axes is None:
-        _, ax = plt.subplots(
-            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-        )
-    else:
-        ax = external_axes[0]
+    _, ax = plt.subplots(
+        figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+    )
 
     nav = data.cumsum()
     ax = rp.plot_drawdown(nav=nav, w=pd.Series(weights).to_frame(), alpha=alpha, ax=ax)
@@ -623,8 +605,7 @@ def display_dd(**kwargs):
     title += ax.get_title(loc="left")
     ax.set_title(title)
 
-    if external_axes is None:
-        theme.visualize_output()
+    return theme.visualize_output(force_tight_layout=True, external_axes=external_axes)
 
 
 @log_start_end(log=logger)
@@ -661,12 +642,9 @@ def display_pie(**kwargs):
     total_size = np.sum(sizes)
     colors = theme.get_colors()
 
-    if external_axes is None:
-        _, ax = plt.subplots(
-            figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
-        )
-    else:
-        ax = external_axes[0]
+    _, ax = plt.subplots(
+        figsize=plot_autoscale(), dpi=get_current_user().preferences.PLOT_DPI
+    )
 
     if math.isclose(sum(sizes), 1, rel_tol=0.1):
         _, _, autotexts = ax.pie(
@@ -731,8 +709,7 @@ def display_pie(**kwargs):
     title += "Portfolio Composition"
     ax.set_title(title)
 
-    if external_axes is None:
-        theme.visualize_output()
+    return theme.visualize_output(force_tight_layout=True, external_axes=external_axes)
 
 
 @log_start_end(log=logger)


### PR DESCRIPTION
# Description

Updating the menu `/portfolio/po` to return a `plotly.graph_objs._figure.Figure` instead of a of displaying a `matplotlib` chart.

The `plotly.graph_objs._figure.Figure` is just an image of the `matplotlib` chart.

Example:
```python
from openbb_terminal.sdk import openbb
d = {
            "SECTOR": {
                "AAPL": "INFORMATION TECHNOLOGY",
                "MSFT": "INFORMATION TECHNOLOGY",
                "AMZN": "CONSUMER DISCRETIONARY",
            },
            "CURRENT_INVESTED_AMOUNT": {
                "AAPL": "100000.0",
                "MSFT": "200000.0",
                "AMZN": "300000.0",
            },
            "CURRENCY": {
                "AAPL": "USD",
                "MSFT": "USD",
                "AMZN": "USD",
            },
        }
p = openbb.portfolio.po.load(symbols_categories=d)
fig = openbb.portfolio.po.ef_chart(portfolio_engine=p, external_axes=True)
fig.show()
```