### PR TITLE
Fix the log collection preference name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1555,7 +1555,7 @@ def your_function() -> pd.DataFrame:
     pass
 ```
 
-> Note: if you don't want your logs to be collected, you can set the `LOG_COLLECTION` user preference to `False`.
+> Note: if you don't want your logs to be collected, you can set the `LOG_COLLECT` user preference to `False`.
 > Disclaimer: all the user paths, names, IPs, credentials and other sensitive information are anonymized, [take a look at how we do it](/openbb_terminal/core/log/generation/formatter_with_exceptions.py).
 
 ### Internationalization

--- a/openbb_terminal/core/integration_tests/integration_controller.py
+++ b/openbb_terminal/core/integration_tests/integration_controller.py
@@ -709,7 +709,7 @@ def main():
 
     current_user = get_current_user()
     current_user.preferences.ENABLE_EXIT_AUTO_HELP = False
-    current_user.preferences.LOG_COLLECTION = False
+    current_user.preferences.LOG_COLLECT = False
     current_user.preferences.USE_ION = True
     current_user.preferences.USE_PROMPT_TOOLKIT = False
     current_user.preferences.REMEMBER_CONTEXTS = False

--- a/openbb_terminal/core/log/collection/log_sender.py
+++ b/openbb_terminal/core/log/collection/log_sender.py
@@ -43,7 +43,7 @@ class LogSender(Thread):
     def start_required() -> bool:
         """Check if it makes sense to start a LogsSender instance ."""
 
-        return get_current_user().preferences.LOG_COLLECTION
+        return get_current_user().preferences.LOG_COLLECT
 
     @property
     def settings(self) -> Settings:

--- a/openbb_terminal/core/models/preferences_model.py
+++ b/openbb_terminal/core/models/preferences_model.py
@@ -56,7 +56,7 @@ class PreferencesModel:
     ENABLE_RICH: bool = True
     ENABLE_RICH_PANEL: bool = True
     ENABLE_CHECK_API: bool = True
-    LOG_COLLECTION: bool = True
+    LOG_COLLECT: bool = True
     TOOLBAR_HINT: bool = True
     TOOLBAR_TWEET_NEWS: bool = False
 


### PR DESCRIPTION
^

Change the name of the flag on the user preferences to `LOG_COLLECT` to avoid asking people to change it to the new one.