### PR TITLE
Change `SessionId` to uuid-like format

### DIFF
--- a/openbb_terminal/loggers.py
+++ b/openbb_terminal/loggers.py
@@ -5,6 +5,7 @@ __docformat__ = "numpy"
 import logging
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -47,8 +48,6 @@ logging.getLogger("urllib3").setLevel(LOGGING_VERBOSITY)
 
 logger = logging.getLogger(__name__)
 
-START_TIMESTAMP = int(time.time())
-
 
 def get_app_id() -> str:
     """UUID of the current installation."""
@@ -67,6 +66,12 @@ def get_app_id() -> str:
         raise e
 
     return app_id
+
+
+def get_session_id() -> str:
+    """UUID of the current session."""
+    session_id = str(uuid.uuid4()) + "-" + str(int(time.time()))
+    return session_id
 
 
 def get_commit_hash(use_env=True) -> str:
@@ -157,7 +162,6 @@ def setup_handlers(settings: Settings):
 def setup_logging(
     app_name: Optional[str] = None,
     frequency: Optional[str] = None,
-    session_id: Optional[str] = None,
     verbosity: Optional[int] = None,
 ) -> None:
     """Setup Logging"""
@@ -166,7 +170,7 @@ def setup_logging(
     commit_hash = get_commit_hash()
     name = app_name or LOGGING_APP_NAME
     identifier = get_app_id()
-    session_id = session_id or str(START_TIMESTAMP)
+    session_id = get_session_id()
     user_id = get_user_uuid()
 
     # AWSSettings


### PR DESCRIPTION
^

**Benefit** of having the SessionId as a UUID instead of the UNIX timestamp: avoid having users with the same UserId/AppId with the same SessionId - this would happen in the case of the user launching two terminal instances **exactly** at the same time.

**Side effect**: log files names change from `gst_1678795847.2023-03-14_12.log` to `gst_5b698cdc-4d4d-4b2f-983a-2660cba0ea97-1678795471.2023-03-14_12.log` - this comes with no other consequences, since for the logging etl we're filtering those files using `LastModified` S3 param.

> Decided to add a time based component in the `get_session_id` function to double ensure uniqueness.