### PR TITLE
Add version featflag

### DIFF
--- a/openbb_terminal/core/models/preferences_model.py
+++ b/openbb_terminal/core/models/preferences_model.py
@@ -36,6 +36,7 @@ class PreferencesModel:
     # FEATURE FLAGS
     SYNC_ENABLED: bool = True
     FILE_OVERWRITE: bool = False
+    SHOW_VERSION: bool = True
     RETRY_WITH_LOAD: bool = False
     USE_TABULATE_DF: bool = True
     # Use interactive window to display dataframes with options to sort, filter, etc.

--- a/openbb_terminal/featflags_controller.py
+++ b/openbb_terminal/featflags_controller.py
@@ -42,6 +42,7 @@ class FeatureFlagsController(BaseController):
         "richpanel",
         "tbhint",
         "overwrite",
+        "version",
     ]
     PATH = "/featflags/"
 
@@ -76,6 +77,7 @@ class FeatureFlagsController(BaseController):
         mt.add_setting("cmdloc", current_user.preferences.USE_CMD_LOCATION_FIGURE)
         mt.add_setting("tbhint", current_user.preferences.TOOLBAR_HINT)
         mt.add_setting("overwrite", current_user.preferences.FILE_OVERWRITE)
+        mt.add_setting("version", current_user.preferences.SHOW_VERSION)
 
         console.print(text=mt.menu_text, menu="Feature Flags")
 
@@ -83,6 +85,12 @@ class FeatureFlagsController(BaseController):
         """Process overwrite command"""
         set_preference(
             "FILE_OVERWITE", not get_current_user().preferences.FILE_OVERWRITE
+        )
+
+    def call_version(self, _):
+        """Process version command"""
+        set_preference(
+            "OPENBB_SHOW_VERSION", not get_current_user().preferences.SHOW_VERSION
         )
 
     def call_retryload(self, _):

--- a/openbb_terminal/featflags_controller.py
+++ b/openbb_terminal/featflags_controller.py
@@ -89,9 +89,7 @@ class FeatureFlagsController(BaseController):
 
     def call_version(self, _):
         """Process version command"""
-        set_preference(
-            "OPENBB_SHOW_VERSION", not get_current_user().preferences.SHOW_VERSION
-        )
+        set_preference("SHOW_VERSION", not get_current_user().preferences.SHOW_VERSION)
 
     def call_retryload(self, _):
         """Process retryload command"""

--- a/openbb_terminal/miscellaneous/i18n/en.yml
+++ b/openbb_terminal/miscellaneous/i18n/en.yml
@@ -59,6 +59,8 @@ en:
   featflags/ion: interactive matplotlib mode
   featflags/watermark: watermark in figures
   featflags/cmdloc: command location displayed in figures
+  featflags/overwrite: whether to overwrite Excel files if they already exists
+  featflags/version: whether to show the version in the bottom right corner
   featflags/tbhint: displays usage hints in the bottom toolbar
   settings/_info_: Settings through environment variables
   settings/colors: set your own terminal colors

--- a/openbb_terminal/rich_config.py
+++ b/openbb_terminal/rich_config.py
@@ -297,7 +297,10 @@ class ConsoleAndPanel:
         if kwargs and "text" in list(kwargs) and "menu" in list(kwargs):
             if not os.getenv("TEST_MODE"):
                 if current_user.preferences.ENABLE_RICH_PANEL:
-                    version = f"[param]OpenBB Terminal v{cfg.VERSION}[/param] (https://openbb.co)"
+                    if current_user.preferences.SHOW_VERSION:
+                        version = f"[param]OpenBB Terminal v{cfg.VERSION}[/param] (https://openbb.co)"
+                    else:
+                        version = "[param]OpenBB Terminal[/param] (https://openbb.co)"
                     self.console.print(
                         panel.Panel(
                             "\n" + kwargs["text"],

--- a/openbb_terminal/stocks/technical_analysis/ta_controller.py
+++ b/openbb_terminal/stocks/technical_analysis/ta_controller.py
@@ -1,6 +1,6 @@
 """Technical Analysis Controller Module"""
 __docformat__ = "numpy"
-# pylint:disable=too-many-lines,R0904,C0201
+# pylint:disable=too-many-lines,R0904,C0201,C0302
 
 import argparse
 import logging


### PR DESCRIPTION
This flag is meant so that I can make screenshots for guides and similar without constantly needing to adjust the code. This removes the version in the bottom right corner.

The whole purpose of this is that because the terminal doesn't change everywhere all the time and images are there for illustration purposes. If it shows the version number it can confuse by assuming documentation is outdated in general. We don't have the resources to have someone constantly update the docs in that manner.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/46355364/225153801-e00949f8-72e3-4aed-af5f-2b6d6c60212f.png">