### PR TITLE
Hotfix - `get_monitors()` error when no enumerators available

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -1213,7 +1213,11 @@ def str_to_bool(value) -> bool:
 
 def get_screeninfo():
     """Get screeninfo."""
-    screens = get_monitors()  # Get all available monitors
+    try:
+        screens = get_monitors()  # Get all available monitors
+    except Exception:
+        return None
+
     if screens:
         current_user = get_current_user()
         if (
@@ -1228,6 +1232,7 @@ def get_screeninfo():
         main_screen = screens[monitor]  # Choose what monitor to get
 
         return (main_screen.width, main_screen.height)
+
     return None
 
 


### PR DESCRIPTION
# Fixes Terminal crash at boot
![image](https://user-images.githubusercontent.com/61340027/225807177-908067a0-04b1-4925-8623-b6ea9ecc0c72.png)
