### PR TITLE
Improve handling for dot in ticker

### DIFF
--- a/openbb_terminal/reports/reports_controller.py
+++ b/openbb_terminal/reports/reports_controller.py
@@ -195,6 +195,11 @@ class ReportController(BaseController):
             ns_parser = self.parse_simple_args(parser, other_args)
 
             if ns_parser:
+                if report_name == "equity" and "." in ns_parser.symbol:
+                    console.print(
+                        "[red]Cannot currently handle tickers with a '.' in them[/red]\n"
+                    )
+                    return
                 cfg.LOGGING_SUPPRESS = True
                 parameters = vars(ns_parser)
                 parameters.pop("help")


### PR DESCRIPTION
# Description

Fixes #3127 

Currently the equity report has an ugly exit if there is a "." in the ticker. I added a check in the controller to make the issue more clear.


# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [ ] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [ ] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
