### PR TITLE
Updates api-keys.md title to be, 'API Keys'.

### DIFF
--- a/website/content/terminal/usage/guides/api-keys.md
+++ b/website/content/terminal/usage/guides/api-keys.md
@@ -1,5 +1,5 @@
 ---
-title: Settings & API Keys
+title: API Keys
 sidebar_position: 1
 description: API (Application Programming Interface) keys are access credentials for accessing data from a particular source. They are a string of random characters assigned, by the data provider, to an individual account. Most vendors offer a free tier requiring only a valid email address. Each key is entered into the Terminal from the `/keys` menu, using the syntax described below. The `--help` dialogue for each source will also display the expected inputs.
 keywords: [api, keys, api keys, data provider, data, free, alpha vantage, fred, iex, twitter, degiro, binance, coinglass, polygon, intrinio, openbb terminal]


### PR DESCRIPTION
This change clarifies the title of this documentation page by removing the word, "Settings".  This page is specific to API Keys, 

This is for demonstration purposes only and is not intended to be merged.

