### PR TITLE
Moves logging credentials under `CredentialsModel`

### DIFF
--- a/openbb_terminal/core/models/credentials_model.py
+++ b/openbb_terminal/core/models/credentials_model.py
@@ -12,11 +12,17 @@ with open(MISCELLANEOUS_DIRECTORY / "models" / "hub_credentials.json") as f:
 with open(MISCELLANEOUS_DIRECTORY / "models" / "local_credentials.json") as f:
     LOCAL_CREDENTIALS = json.load(f)
 
+with open(MISCELLANEOUS_DIRECTORY / "models" / "logging_credentials.json") as f:
+    LOGGING_CREDENTIALS = json.load(f)
+
 
 dc = make_dataclass(
     cls_name="CredentialsModel",
     fields=[
-        (k, str, "REPLACE_ME") for k in list(HUB_CREDENTIALS) + list(LOCAL_CREDENTIALS)
+        (k, str, "REPLACE_ME")
+        for k in list(HUB_CREDENTIALS)
+        + list(LOCAL_CREDENTIALS)
+        + list(LOGGING_CREDENTIALS)
     ],
     bases=(BaseModel,),
 )

--- a/openbb_terminal/core/models/system_model.py
+++ b/openbb_terminal/core/models/system_model.py
@@ -23,8 +23,6 @@ class SystemModel(BaseModel):
 
     # Logging section
     LOGGING_APP_NAME: str = "gst"
-    LOGGING_AWS_ACCESS_KEY_ID: str = "REPLACE_ME"
-    LOGGING_AWS_SECRET_ACCESS_KEY: str = "REPLACE_ME"
     LOGGING_COMMIT_HASH: str = "REPLACE_ME"
     LOGGING_FREQUENCY: Literal["D", "H", "M", "S"] = "H"
     LOGGING_HANDLERS: Literal["stdout", "stderr", "noop", "file"] = "file"

--- a/openbb_terminal/loggers.py
+++ b/openbb_terminal/loggers.py
@@ -33,9 +33,11 @@ from openbb_terminal.core.log.generation.settings import (
 )
 from openbb_terminal.core.log.generation.user_logger import get_user_uuid
 from openbb_terminal.core.session.current_system import get_current_system
+from openbb_terminal.core.session.current_user import get_current_user
 
 logger = logging.getLogger(__name__)
 current_system = get_current_system()
+current_user = get_current_user()
 
 logging.getLogger("requests").setLevel(current_system.LOGGING_VERBOSITY)
 logging.getLogger("urllib3").setLevel(current_system.LOGGING_VERBOSITY)
@@ -166,8 +168,8 @@ def setup_logging(
     user_id = get_user_uuid()
 
     # AWSSettings
-    aws_access_key_id = current_system.LOGGING_AWS_ACCESS_KEY_ID
-    aws_secret_access_key = current_system.LOGGING_AWS_SECRET_ACCESS_KEY
+    aws_access_key_id = current_user.credentials.LOGGING_AWS_ACCESS_KEY_ID
+    aws_secret_access_key = current_user.credentials.LOGGING_AWS_SECRET_ACCESS_KEY
 
     # LogSettings
     directory = get_log_dir()

--- a/openbb_terminal/miscellaneous/models/logging_credentials.json
+++ b/openbb_terminal/miscellaneous/models/logging_credentials.json
@@ -1,0 +1,4 @@
+{
+    "LOGGING_AWS_ACCESS_KEY_ID": "",
+    "LOGGING_AWS_SECRET_ACCESS_KEY": ""
+}


### PR DESCRIPTION
Avoiding having credentials on the `SystemModel`, otherwise, those will be logged.