### PR TITLE
Removes `exchange` option from `stocks/load`

### DIFF
--- a/openbb_terminal/parent_classes.py
+++ b/openbb_terminal/parent_classes.py
@@ -1172,13 +1172,6 @@ class StockBaseController(BaseController, metaclass=ABCMeta):
             dest="weekly",
         )
         parser.add_argument(
-            "--exchange",
-            dest="exchange",
-            action="store_true",
-            default=False,
-            help="Show exchange information.",
-        )
-        parser.add_argument(
             "--performance",
             dest="performance",
             action="store_true",
@@ -1225,11 +1218,6 @@ class StockBaseController(BaseController, metaclass=ABCMeta):
                 or (not is_df and not df_stock_candidate)
             ):
                 self.stock = df_stock_candidate
-                if ns_parser.exchange:
-                    self.add_info = stocks_helper.additional_info_about_ticker(
-                        ns_parser.ticker
-                    )
-                    console.print(self.add_info)
                 if (
                     ns_parser.interval == 1440
                     and not ns_parser.weekly

--- a/website/content/terminal/usage/intros/stocks/index.md
+++ b/website/content/terminal/usage/intros/stocks/index.md
@@ -82,7 +82,7 @@ load -h
 Prints the dialogue on the screen:
 
 ```console
-usage: load [-t TICKER] [-s START] [-e END] [-i {1,5,15,30,60}] [-p] [-f FILEPATH] [-m] [-w] [--exchange] [--performance] [-h] [--export EXPORT]
+usage: load [-t TICKER] [-s START] [-e END] [-i {1,5,15,30,60}] [-p] [-f FILEPATH] [-m] [-w] [--performance] [-h] [--export EXPORT]
             [--sheet-name SHEET_NAME [SHEET_NAME ...]] [--source {YahooFinance,AlphaVantage,Polygon,EODHD,Intrinio}]
 
 Load stock ticker to perform analysis on. When the data source is yf, an Indian ticker can be loaded by using '.NS' at the end, e.g. 'SBIN.NS'. See available market
@@ -101,7 +101,6 @@ optional arguments:
                         Path to load custom file. (default: None)
   -m, --monthly         Load monthly data (default: False)
   -w, --weekly          Load weekly data (default: False)
-  --exchange            Show exchange information. (default: False)
   --performance         Show performance information. (default: False)
   -h, --help            show this help message (default: False)
   --export EXPORT       Export raw data into csv, json, xlsx (default: )


### PR DESCRIPTION
# Description

It looks like the yfinance does not work here, so there is no reason to provide a broken option.