### PR TITLE
Fixes #4638 usrates export file had blank data in value column

### DIFF
--- a/openbb_terminal/fixedincome/fred_view.py
+++ b/openbb_terminal/fixedincome/fred_view.py
@@ -1083,7 +1083,7 @@ def plot_usrates(
 
     if raw:
         # was a -iloc so we need to flip the index as we use head
-        df = pd.DataFrame(df, columns=[parameter])
+        df = pd.DataFrame(df, columns=[series_id])
         df = df.sort_index(ascending=False)
         print_rich_table(
             df,
@@ -1098,7 +1098,7 @@ def plot_usrates(
         export,
         os.path.dirname(os.path.abspath(__file__)),
         series_id,
-        pd.DataFrame(df, columns=[parameter]) / 100,
+        pd.DataFrame(df, columns=[series_id]) / 100,
         sheet_name,
         fig,
     )


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/41910672/229829830-a85a69d5-5837-4320-abe9-8eb7b9360d0c.png)

The contributing doc mentions to point to main
_All feature/feature-name related branches can only have PRs pointing to develop branch. hotfix/hotfix-name and release/2.1.0 or release/2.1.0rc0 branches can only have PRs pointing to main branch._

Seems it has been updated recently.

But I see the latest hotfix merged PRs being targeted to develop, so have opened to develop
