### PR TITLE
Revert UltimaInsights from default data source on stocks/news

### DIFF
--- a/openbb_terminal/miscellaneous/sources/openbb_default.json
+++ b/openbb_terminal/miscellaneous/sources/openbb_default.json
@@ -186,8 +186,7 @@
         "SeekingAlpha"
       ],
       "cnews": [
-        "SeekingAlpha",
-        "UltimaInsights"
+        "SeekingAlpha"
       ],
       "lowfloat": [
         "Fidelity"

--- a/openbb_terminal/miscellaneous/sources/openbb_default.json
+++ b/openbb_terminal/miscellaneous/sources/openbb_default.json
@@ -14,9 +14,9 @@
       "Polygon"
     ],
     "news": [
-      "UltimaInsights",
       "Feedparser",
-      "NewsApi"
+      "NewsApi",
+      "UltimaInsights"
     ],
     "load": [
       "YahooFinance",
@@ -186,8 +186,8 @@
         "SeekingAlpha"
       ],
       "cnews": [
-        "UltimaInsights",
-        "SeekingAlpha"
+        "SeekingAlpha",
+        "UltimaInsights"
       ],
       "lowfloat": [
         "Fidelity"

--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -547,7 +547,7 @@ class StocksController(StockBaseController):
             help="Show news only from the sources specified (e.g bloomberg,reuters)",
         )
         if other_args and "-" not in other_args[0][0]:
-            other_args.insert(0, "-l")
+            other_args.insert(0, "-t")
         ns_parser = self.parse_known_args_and_warn(
             parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED, limit=10
         )
@@ -556,28 +556,7 @@ class StocksController(StockBaseController):
                 self.ticker = ns_parser.ticker
                 self.custom_load_wrapper([self.ticker])
             if self.ticker:
-                if ns_parser.source == "UltimaInsights":
-                    query = str(self.ticker).upper()
-                    if query not in ultima_newsmonitor_view.supported_terms():
-                        console.print(
-                            "[red]Ticker not supported by Ultima Insights News Monitor[/red]"
-                        )
-                        feedparser_view.display_news(
-                            term=query,
-                            sources=ns_parser.sources,
-                            limit=ns_parser.limit,
-                            export=ns_parser.export,
-                            sheet_name=ns_parser.sheet_name,
-                        )
-                    else:
-                        ultima_newsmonitor_view.display_news(
-                            term=query,
-                            sources=ns_parser.sources,
-                            limit=ns_parser.limit,
-                            export=ns_parser.export,
-                            sheet_name=ns_parser.sheet_name,
-                        )
-                elif ns_parser.source == "NewsApi":
+                if ns_parser.source == "NewsApi":
                     newsapi_view.display_news(
                         query=self.ticker,
                         limit=ns_parser.limit,
@@ -595,6 +574,20 @@ class StocksController(StockBaseController):
                         if ns_parser.sheet_name
                         else None,
                     )
+                elif ns_parser.source == "UltimaInsights":
+                    query = str(self.ticker).upper()
+                    if query not in ultima_newsmonitor_view.supported_terms():
+                        console.print(
+                            "[red]Ticker not supported by Ultima Insights News Monitor[/red]"
+                        )
+                    else:
+                        ultima_newsmonitor_view.display_news(
+                            term=query,
+                            sources=ns_parser.sources,
+                            limit=ns_parser.limit,
+                            export=ns_parser.export,
+                            sheet_name=ns_parser.sheet_name,
+                        )
             else:
                 console.print("Use 'load <ticker>' prior to this command!")
 

--- a/openbb_terminal/terminal_controller.py
+++ b/openbb_terminal/terminal_controller.py
@@ -28,7 +28,7 @@ from openbb_terminal.account.account_model import (
     get_login_called,
     set_login_called,
 )
-from openbb_terminal.common import feedparser_view, ultima_newsmonitor_view
+from openbb_terminal.common import feedparser_view
 from openbb_terminal.core.config.paths import (
     HOME_DIRECTORY,
     MISCELLANEOUS_DIRECTORY,
@@ -244,26 +244,14 @@ class TerminalController(BaseController):
             parse, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED, limit=5
         )
         if news_parser:
-            query = " ".join(news_parser.term).upper()
-            if query not in ultima_newsmonitor_view.supported_terms():
-                console.print(
-                    "[red]Ticker not supported by Ultima Insights News Monitor[/red]"
-                )
-                feedparser_view.display_news(
-                    term=query,
-                    sources=news_parser.sources,
-                    limit=news_parser.limit,
-                    export=news_parser.export,
-                    sheet_name=news_parser.sheet_name,
-                )
-            else:
-                ultima_newsmonitor_view.display_news(
-                    term=query,
-                    sources=news_parser.sources,
-                    limit=news_parser.limit,
-                    export=news_parser.export,
-                    sheet_name=news_parser.sheet_name,
-                )
+            query = " ".join(news_parser.term)
+            feedparser_view.display_news(
+                term=query,
+                sources=news_parser.sources,
+                limit=news_parser.limit,
+                export=news_parser.export,
+                sheet_name=news_parser.sheet_name,
+            )
 
     def call_guess(self, other_args: List[str]) -> None:
         """Process guess command."""


### PR DESCRIPTION
This PR does 2 things:
* Reverts UltimaInsights from default data provider for `stocks/news`, as this would break current user workflows.
* Remove UltimaInsights from `news` commands which is meant to display news for anything and not necessarily `stock` related

CC: @AdiSai @jmaslek 