### PR TITLE
Removed Cell 11 - `long_summary` from `equity.py`

### DIFF
--- a/openbb_terminal/reports/templates/equity.ipynb
+++ b/openbb_terminal/reports/templates/equity.ipynb
@@ -136,26 +136,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e3b15d6f-dc9e-4f97-aa07-37d949a4e4bb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "info = openbb.stocks.fa.info(symbol=symbol).transpose()\n",
-    "\n",
-    "long_summary = \"Long business summary\"\n",
-    "long_name = \"Long name\"\n",
-    "\n",
-    "if long_summary in info and info[long_summary][0] != \"NA\":\n",
-    "    overview = info[long_summary][0]\n",
-    "elif long_name in info:\n",
-    "    overview = info[long_name][0]\n",
-    "else:\n",
-    "    overview = \"\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "f8a0d747",
    "metadata": {},


### PR DESCRIPTION
# Description
Fixes #4759 by removing Cell 11 as `yFinance` does not return the `long_summary`.
