### PR TITLE
Fix `exe --file` choices on login

### DIFF
--- a/openbb_terminal/core/session/session_model.py
+++ b/openbb_terminal/core/session/session_model.py
@@ -28,7 +28,7 @@ from openbb_terminal.core.session.sources_handler import get_updated_hub_sources
 from openbb_terminal.core.session.utils import run_thread
 from openbb_terminal.helper_funcs import system_clear
 from openbb_terminal.loggers import setup_logging
-from openbb_terminal.rich_config import console
+from openbb_terminal.rich_config import console, optional_rich_track
 
 # pylint: disable=consider-using-f-string
 
@@ -105,7 +105,7 @@ def login(session: dict) -> LoginStatus:
             set_current_user(hub_user)
 
             auth_header = hub_user.profile.get_auth_header()
-            run_thread(download_and_save_routines, {"auth_header": auth_header})
+            download_and_save_routines(auth_header)
             run_thread(
                 update_backend_sources, {"auth_header": auth_header, "configs": configs}
             )
@@ -119,21 +119,23 @@ def login(session: dict) -> LoginStatus:
     return LoginStatus.NO_RESPONSE
 
 
-def download_and_save_routines(auth_header: str, silent: bool = True):
+def download_and_save_routines(auth_header: str):
     """Download and save routines.
 
     Parameters
     ----------
     auth_header : str
         The authorization header, e.g. "Bearer <token>".
-    silent : bool
-        Whether to silence the console output, by default True
     """
-    routines = download_routines(auth_header=auth_header, silent=silent)
-    for name, content in routines.items():
-        save_routine(
-            file_name=f"{name}.openbb", routine=content, force=True, silent=silent
-        )
+    try:
+        console.print("Downloading routines...")
+        routines = download_routines(auth_header=auth_header)
+        for name, content in optional_rich_track(
+            routines.items(), desc="Saving routines"
+        ):
+            save_routine(file_name=f"{name}.openbb", routine=content, force=True)
+    except Exception:
+        console.print("[red]Failed to download and save routines.[/red]")
 
 
 def update_backend_sources(auth_header, configs, silent: bool = True):

--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -1654,7 +1654,7 @@ def handle_error_code(requests_obj, error_code_map):
 
 def prefill_form(ticket_type, menu, path, command, message):
     """Pre-fill Google Form and open it in the browser."""
-    form_url = "https://openbb.co/support?"
+    form_url = "https://my.openbb.dev/app/terminal/support?"
 
     params = {
         "type": ticket_type,

--- a/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/openbb_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -1637,15 +1637,23 @@ class FundamentalAnalysisController(StockBaseController):
                 return
 
             if self.ticker:
-                dcf = dcf_view.CreateExcelFA(
-                    symbol=self.ticker,
-                    beta=ns_parser.beta,
-                    audit=ns_parser.audit,
-                    ratios=ns_parser.ratios,
-                    len_pred=ns_parser.prediction,
-                    max_similars=ns_parser.similar,
-                    growth=ns_parser.growth,
-                )
+                try:
+                    dcf = dcf_view.CreateExcelFA(
+                        symbol=self.ticker,
+                        beta=ns_parser.beta,
+                        audit=ns_parser.audit,
+                        ratios=ns_parser.ratios,
+                        len_pred=ns_parser.prediction,
+                        max_similars=ns_parser.similar,
+                        growth=ns_parser.growth,
+                    )
+                except Exception as e:
+                    logger.exception(e)
+                    console.print(
+                        "[red]Could not properly create the DCF, please make sure you are"
+                        " using a valid, US listed ticker.[/red]"
+                    )
+                    return
                 if dcf and dcf.data:
                     dcf.create_workbook()
             else:


### PR DESCRIPTION
* Makes sure that `exe --file` choices are updated right after login

Test:
* login with `openbb --login` and `account/login` and check that `exe --file` command on `home` menu displays the hub routines (default and personal)

