### PR TITLE
Anonymize logged in users flair in logs

### DIFF
--- a/openbb_terminal/core/log/generation/formatter_with_exceptions.py
+++ b/openbb_terminal/core/log/generation/formatter_with_exceptions.py
@@ -66,6 +66,14 @@ class FormatterWithExceptions(logging.Formatter):
         return text_mocked
 
     @staticmethod
+    def mock_flair(text: str) -> str:
+        pattern = r"\[(.*?)\]"
+        replacement = " FILTERED_FLAIR "
+        text_mocked = re.sub(pattern, replacement, text)
+
+        return text_mocked
+
+    @staticmethod
     def mock_home_directory(text: str) -> str:
         user_home_directory = str(HOME_DIRECTORY)
         text_mocked = text.replace(user_home_directory, "MOCKING_USER_PATH")
@@ -85,6 +93,7 @@ class FormatterWithExceptions(logging.Formatter):
         text_filtered = cls.mock_email(text=text_filtered)
         text_filtered = cls.mock_password(text=text_filtered)
         text_filtered = cls.mock_home_directory(text=text_filtered)
+        text_filtered = cls.mock_flair(text=text_filtered)
 
         return text_filtered
 


### PR DESCRIPTION
# Description
Anonymizes logged in users flair in the logs with FILTERED_FLAIR by matching pattern of all non whitespace characters enclosed in brackets. Fixes #4838

See screenshots of before & after:

<img width="933" alt="Screenshot 2023-04-21 at 19 24 54" src="https://user-images.githubusercontent.com/125876072/233708838-5d35ac85-bb17-4f54-811d-ab1d10d06d0f.png">

<img width="933" alt="Screenshot 2023-04-21 at 19 23 54" src="https://user-images.githubusercontent.com/125876072/233708860-1862725d-5f81-45cd-ae0e-55faf3b30566.png">

- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [x] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context.
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [ ] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [ ] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
