### PR TITLE
Fix stocks/ta/fib datetime plotting

### DIFF
--- a/openbb_terminal/common/technical_analysis/custom_indicators_model.py
+++ b/openbb_terminal/common/technical_analysis/custom_indicators_model.py
@@ -51,12 +51,12 @@ def calculate_fib_levels(
         return pd.DataFrame(), pd.Timestamp(), pd.Timestamp(), 0, 0, ""
     if start_date and end_date:
         if start_date not in data.index:
-            date0 = data.index[data.index.get_loc(start_date, method="nearest")]
+            date0 = data.index[data.index.get_indexer([end_date], method="nearest")[0]]
             console.print(f"Start date not in data.  Using nearest: {date0}")
         else:
             date0 = start_date
         if end_date not in data.index:
-            date1 = data.index[data.index.get_loc(end_date, method="nearest")]
+            date1 = data.index[data.index.get_indexer([end_date], method="nearest")[0]]
             console.print(f"End date not in data.  Using nearest: {date1}")
         else:
             date1 = end_date

--- a/openbb_terminal/core/plots/plotly_ta/plugins/custom_indicators_plugin.py
+++ b/openbb_terminal/core/plots/plotly_ta/plugins/custom_indicators_plugin.py
@@ -146,8 +146,8 @@ class Custom(PltTA):
             "<b>0.65</b>",
             "<b>1</b>",
         ]
-        min_date = min_date.to_pydatetime()
-        max_date = max_date.to_pydatetime()
+        min_date = pd.to_datetime(min_date).to_pydatetime()
+        max_date = pd.to_datetime(max_date).to_pydatetime()
         self.df_fib = df_fib
 
         fig.add_scatter(


### PR DESCRIPTION
# Description
Fixes #4862. 

Updates `data.index.get_loc` to `data.index.get_indexer`. Converts datetime object to pandas datetime object before calling `to_pydatetime` in fib plotting.

- [x] Summary of the change / bug fix.
- [x] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context.
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [x] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [ ] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
