### PR TITLE
Adds type to the version on the SystemModel

### DIFF
--- a/openbb_terminal/core/models/system_model.py
+++ b/openbb_terminal/core/models/system_model.py
@@ -27,7 +27,7 @@ class SystemModel(BaseModel):
     PLATFORM: str = str(platform.platform())
 
     # OpenBB section
-    VERSION = "3.0.0"
+    VERSION: str = "3.0.0"
 
     # Logging section
     LOGGING_APP_ID: str = "REPLACE_ME"


### PR DESCRIPTION
^

So that version shows up no the logs.

Before:
```
SYSTEM: {"OS": "Linux", "PYTHON_VERSION": "3.9.13", "PLATFORM": "my-platform", "LOGGING_APP_ID": "my-app-id", "LOGGING_APP_NAME": "gst", "LOGGING_COMMIT_HASH": "REPLACE_ME", "LOGGING_FREQUENCY": "H", "LOGGING_HANDLERS": "file", "LOGGING_ROLLING_CLOCK": false, "LOGGING_VERBOSITY": 20, "LOGGING_SUB_APP": "terminal", "LOGGING_SUPPRESS": false, "LOG_COLLECT": false, "DISABLE_STREAMLIT_WARNING": true, "DISABLE_FORECASTING_WARNING": true, "DISABLE_OPTIMIZATION_WARNING": true, "TEST_MODE": false, "DEBUG_MODE": false, "ENABLE_AUTHENTICATION": true, "HEADLESS": false} 
```

After:
```
SYSTEM: {"OS": "Linux", "PYTHON_VERSION": "3.9.13", "PLATFORM": "my-platform", "VERSION": "3.0.0", "LOGGING_APP_ID": "my-app-id", "LOGGING_APP_NAME": "gst", "LOGGING_COMMIT_HASH": "REPLACE_ME", "LOGGING_FREQUENCY": "H", "LOGGING_HANDLERS": "file", "LOGGING_ROLLING_CLOCK": false, "LOGGING_VERBOSITY": 20, "LOGGING_SUB_APP": "terminal", "LOGGING_SUPPRESS": false, "LOG_COLLECT": false, "DISABLE_STREAMLIT_WARNING": true, "DISABLE_FORECASTING_WARNING": true, "DISABLE_OPTIMIZATION_WARNING": true, "TEST_MODE": false, "DEBUG_MODE": false, "ENABLE_AUTHENTICATION": true, "HEADLESS": false} 
```