### PR TITLE
hotfix/docs-api-keys-title - Changes title of page from "Settings & API Keys" to "Setting API Keys"

### DIFF
--- a/website/content/terminal/usage/guides/api-keys.md
+++ b/website/content/terminal/usage/guides/api-keys.md
@@ -1,5 +1,5 @@
 ---
-title: Settings & API Keys
+title: Setting API Keys
 sidebar_position: 1
 description: API (Application Programming Interface) keys are access credentials for accessing data from a particular source. Learn how to set, manage, and access data APIs for the OpenBB Terminal.
 keywords: [api, keys, api keys, openbb terminal, data provider, data, free, alpha vantage, fred, iex, twitter, degiro, binance, coinglass, polygon, intrinio, sdk, alphavantage, bitquery, coinbase, databento, finnhub, FRED, github, glassnode, iex cloud, news API, robinhood, santiment, shroomdk, token terminal, tradier, twitter, whale alert]
@@ -7,7 +7,7 @@ keywords: [api, keys, api keys, openbb terminal, data provider, data, free, alph
 
 import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
-<HeadTitle title="Settings & API Keys - Terminal | OpenBB Docs" />
+<HeadTitle title="Setting API Keys - Terminal | OpenBB Docs" />
 
 API (Application Programming Interface) keys are access credentials for obtaining data from a particular source. They are a string of random characters assigned, by the data provider, to an individual account. Most vendors offer a free tier requiring only a valid email address, some will require an account with proper KYC (Know Your Customer). Each source is entered into the Terminal from the `/keys` menu with the syntax as described in the sections below. Adding the `-h` argument to the command will also display the expected inputs. For example,
 


### PR DESCRIPTION
This PR makes one very small change to the docs pages, changing the title of the API Keys guide.  The motivation is because the page contains only information on API keys, the title should not be "Settings & API Keys".

![Screenshot 2023-05-02 at 9 25 55 AM](https://user-images.githubusercontent.com/85772166/235726747-49028ce3-b284-4523-ad0c-b4626a33c6be.png)
