### PR TITLE
Install Page: adds reference to the YAML files for Python 3.8 and 3.10

### DIFF
--- a/website/content/terminal/installation/pypi.md
+++ b/website/content/terminal/installation/pypi.md
@@ -197,6 +197,10 @@ Copy and paste these commands into the terminal/command prompt:
 conda env create -n obb --file https://raw.githubusercontent.com/OpenBB-finance/OpenBBTerminal/main/build/conda/conda-3-9-env.yaml
 ```
 
+:::note
+Additional `YAML` files provide support for Python versions 3.8 and 3.10.  Substitute the `9`, in the command above, with the desired version.
+:::
+
 Agree to the prompts if there are any.
 
 After the obb environment is created, activate it by entering:

--- a/website/content/terminal/installation/source.md
+++ b/website/content/terminal/installation/source.md
@@ -209,6 +209,10 @@ Create the environment by copying the code below into the command line and agree
 conda env create -n obb --file build/conda/conda-3-9-env.yaml
 ```
 
+:::note
+Additional `YAML` files provide support for Python versions 3.8 and 3.10.  Substitute the `9`, in the command above, with the desired version.
+:::
+
 After the obb environment is created, activate it by entering:
 
 ```shell


### PR DESCRIPTION
This PR adds a note to the source and PyPI installation pages that references the `yaml` files for Python 3.8 and 3.10. 

resolves #5062

