### PR TITLE
fixes stocks/fa integration test file

### DIFF
--- a/openbb_terminal/miscellaneous/integration_tests_scripts/stocks/test_fa.openbb
+++ b/openbb_terminal/miscellaneous/integration_tests_scripts/stocks/test_fa.openbb
@@ -1,53 +1,46 @@
 stocks
-load ${ticker=aapl}
+load aapl
 fa
-income -l 2 --source YahooFinance
-income -l 2 --source Polygon --quarter
-income -l 2 --source AlphaVantage --ratios
-income -l 2 --source FinancialModelingPrep
-income -l 2 --ticker AMZN --source EODHD
-balance -l 2 --source YahooFinance --ratios
-balance -l 2 --source Polygon --quarter
-balance -l 2 --ticker DDS --source AlphaVantage
-balance -l 2 --source FinancialModelingPrep
-balance -l 2 --source EODHD
-cash -l 2 --source YahooFinance
-cash -l 2 --source Polygon --quarter
-cash -l 2 --source AlphaVantage --ratios
-cash -l 2 --source FinancialModelingPrep
-cash -l 2 --ticker GOOG --source EODHD
-income -l 2 --source YahooFinance --plot gross_profit
-income -l 2 --source Polygon --plot gross_profit
-income -l 2 --source AlphaVantage --plot gross_profit
-income -l 2 --source FinancialModelingPrep --plot gross_profit
-income -l 2 --source EODHD --plot gross_profit
-balance -l 2 --source YahooFinance --plot total_assets
-balance -l 2 --source Polygon --plot total_assets
-balance -l 2 --source AlphaVantage --plot total_assets
-balance -l 2 --source FinancialModelingPrep --plot total_assets
-balance -l 2 --source EODHD --plot total_assets
-cash -l 2 --source YahooFinance --plot operating_cash_flow
-cash -l 2 --source Polygon --plot operating_cash_flow
-cash -l 2 --source AlphaVantage --plot operating_cash_flow
-cash -l 2 --source FinancialModelingPrep --plot operating_cash_flow
-cash -l 2 --source EODHD --plot operating_cash_flow
+income --source YahooFinance
+income --source Polygon --quarter
+income --source AlphaVantage --ratios
+income --source FinancialModelingPrep
+income --ticker AMZN --source EODHD
+balance --source YahooFinance --ratios
+balance --source Polygon --quarter
+balance --ticker DDS --source AlphaVantage
+balance --source FinancialModelingPrep
+balance --source EODHD
+cash --source YahooFinance
+cash --source Polygon --quarter
+cash --source AlphaVantage --ratios
+cash --source FinancialModelingPrep
+cash --ticker GOOG --source EODHD
+income --source YahooFinance --plot gross_profit
+income --source Polygon --plot gross_profit
+income --source AlphaVantage --plot gross_profit
+income --source FinancialModelingPrep --plot gross_profit
+balance --source YahooFinance --plot total_assets
+balance --source Polygon --plot total_assets
+balance --source AlphaVantage --plot total_assets
+balance --source FinancialModelingPrep --plot total_assets
+cash --source YahooFinance --plot operating_cash_flow
+cash --source Polygon --plot operating_cash_flow
+cash --source AlphaVantage --plot operating_cash_flow
+cash --source FinancialModelingPrep --plot operating_cash_flow
 mgmt
 analysis
 score
-enterprise
-enterprise --source FinancialModelingPrep
-enterprise --source YahooFinance
 mktcap --ticker MSFT
 mktcap --method enterprise_value
-mktcap --help
 mktcap --quarter
+mktcap --source YahooFinance --start 1980-01-01 --end 2023-05-01
 metrics
 ratios
 growth
 warnings
 warnings -d
 dcfc
-mktcap --source YahooFinance --start 1980-01-01 --end 2023-05-01
 shrs
 shrs major
 shrs mutualfund
@@ -56,7 +49,7 @@ divs -p
 splits
 overview
 earnings --ticker DDS --source YahooFinance
-earnings --source AlphaVantage --quarter --limit 1
+earnings --source AlphaVantage --quarter
 fraud
 dupont
 epsfc
@@ -64,18 +57,16 @@ revfc
 analysis
 rating
 rot
-rot -l 3 --raw
+rot --raw
 pt --ticker GOOG
-pt -l 3 --raw
+pt --raw
 est
-est -e annualrevenue
-est -e annualearnings
-est -e quarterearnings
+est -e quarter_revenue
+est -e annual_earnings
+est -e quarter_earnings
 sec
 supplier
 customer
-load ${ticker=tsla}
-arktrades
 dcf -t aapl -g -a --no-filter
 help
 quit


### PR DESCRIPTION
This fixes a bunch of bad syntax that was in the `stocks/fa` integration test file.  Oddly enough, when I execute the test locally, it returns an error for an item that is not actually in the test. 

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/6c5d8b87-8132-4b9b-becb-a3be0e0f047b)

Removing any reference to `balance` and `YahooFinance` creates a new error, which again is never referenced in the test file. 

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/6126d990-5c3d-4016-9693-ecb06c7e8e3f)

Every command in the `.openbb` file works and produces an output, so this is half bug report and half PR. :P
