### PR TITLE
hotfix/fa-yfinance-plot - makes `stocks/fa/income --plot` output match everything else.

### DIFF
--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
@@ -358,11 +358,11 @@ def get_financials(symbol: str, statement: str, ratios: bool = False) -> pd.Data
     df = df.replace("k", "", regex=True)
     df = df.astype("float")
 
-    not_skipped = ~df.reset_index()["Breakdown"].str.contains("EPS", case = False)
-    skipped = df.reset_index()["Breakdown"].str.contains("EPS", case = False)
+    not_skipped = ~df.reset_index()["Breakdown"].str.contains("EPS", case=False)
+    skipped = df.reset_index()["Breakdown"].str.contains("EPS", case=False)
     skipped_df = df.reset_index()[skipped].set_index("Breakdown")
     transformed = df.reset_index()[not_skipped].set_index("Breakdown") * 1000
-    df = pd.concat([transformed,skipped_df])
+    df = pd.concat([transformed, skipped_df])
 
     if ratios:
         types = df.copy().applymap(lambda x: isinstance(x, (float, int)))

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_model.py
@@ -2,7 +2,6 @@
 __docformat__ = "numpy"
 
 import logging
-import re
 import ssl
 from datetime import datetime
 from typing import Optional, Tuple
@@ -15,7 +14,6 @@ from bs4 import BeautifulSoup
 
 from openbb_terminal.decorators import log_start_end
 from openbb_terminal.helper_funcs import lambda_long_number_format
-from openbb_terminal.helpers_denomination import transform as transform_by_denomination
 from openbb_terminal.rich_config import console
 from openbb_terminal.stocks.fundamental_analysis.fa_helper import clean_df_index
 

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -16,7 +16,6 @@ from openbb_terminal.helper_funcs import (
     lambda_long_number_format,
     print_rich_table,
 )
-from openbb_terminal.helpers_denomination import transform as transform_by_denomination
 from openbb_terminal.rich_config import console
 from openbb_terminal.stocks import stocks_helper
 from openbb_terminal.stocks.fundamental_analysis import yahoo_finance_model
@@ -392,8 +391,6 @@ def display_fundamentals(
             for i in [i.replace(" ", "_") for i in fundamentals.index.str.lower()]
         ]
 
-    symbol_currency = yahoo_finance_model.get_currency(symbol)
-
     if plot:
         plot = [x.lower() for x in plot]
         rows_plot = len(plot)
@@ -403,40 +400,29 @@ def display_fundamentals(
             fundamentals_plot_data = fundamentals_plot_data.drop(["ttm"])
         fundamentals_plot_data = fundamentals_plot_data.sort_index()
 
-        if not ratios:
-            maximum_value = fundamentals_plot_data[plot[0]].max()
-            (df_rounded, denomination) = transform_by_denomination(
-                fundamentals_plot_data, maxValue=maximum_value
-            )
-            if denomination == "Units":
-                denomination = ""
-        else:
-            df_rounded = fundamentals_plot_data
-            denomination = ""
-
         if rows_plot == 1:
             fig.add_scatter(
-                x=df_rounded.index,
-                y=df_rounded[plot[0]] * 1000,
+                x=fundamentals_plot_data.index,
+                y=fundamentals_plot_data[plot[0]],
                 name=plot[0].replace("_", " "),
             )
             title = (
                 f"{plot[0].replace('_', ' ').capitalize()} QoQ Growth of {symbol.upper()}"
                 if ratios
-                else f"{plot[0].replace('_', ' ').capitalize()} of {symbol.upper()} {denomination}"
+                else f"{plot[0].replace('_', ' ').capitalize()} of {symbol.upper()}"
             )
             fig.set_title(title)
         else:
             fig = OpenBBFigure.create_subplots(rows=rows_plot, cols=1)
             for i in range(rows_plot):
                 fig.scatter(
-                    x=df_rounded.index,
-                    y=df_rounded[plot[i]] * 1000,
+                    x=fundamentals_plot_data.index,
+                    y=fundamentals_plot_data[plot[i]],
                     name=plot[i].replace("_", " "),
                     row=i + 1,
                     col=1,
                 )
-                title = f"{plot[i].replace('_', ' ')} {denomination}"
+                title = f"{plot[i].replace('_', ' ')}"
                 fig.add_annotation(x=0.5, y=1, row=i + 1, col=1, text=title)
 
         fig.show(external=fig.is_image_export(export))
@@ -451,7 +437,8 @@ def display_fundamentals(
         print_rich_table(
             formatted_df.applymap(lambda x: "-" if x == "nan" else x),
             show_index=True,
-            title=f"{symbol} {title_str} Currency: {symbol_currency}",
+            index_name="Item",
+            title=f"{symbol} {title_str}",
             export=bool(export),
             limit=limit,
         )

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -415,7 +415,7 @@ def display_fundamentals(
             denomination = ""
 
         if rows_plot == 1:
-            fig.add_bar(
+            fig.add_scatter(
                 x=df_rounded.index,
                 y=df_rounded[plot[0]],
                 name=plot[0].replace("_", " "),
@@ -429,7 +429,7 @@ def display_fundamentals(
         else:
             fig = OpenBBFigure.create_subplots(rows=rows_plot, cols=1)
             for i in range(rows_plot):
-                fig.add_bar(
+                fig.scatter(
                     x=df_rounded.index,
                     y=df_rounded[plot[i]],
                     name=plot[i].replace("_", " "),

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -417,7 +417,7 @@ def display_fundamentals(
         if rows_plot == 1:
             fig.add_scatter(
                 x=df_rounded.index,
-                y=df_rounded[plot[0]],
+                y=df_rounded[plot[0]] * 1000,
                 name=plot[0].replace("_", " "),
             )
             title = (
@@ -431,7 +431,7 @@ def display_fundamentals(
             for i in range(rows_plot):
                 fig.scatter(
                     x=df_rounded.index,
-                    y=df_rounded[plot[i]],
+                    y=df_rounded[plot[i]] * 1000,
                     name=plot[i].replace("_", " "),
                     row=i + 1,
                     col=1,

--- a/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
+++ b/openbb_terminal/stocks/fundamental_analysis/yahoo_finance_view.py
@@ -415,7 +415,7 @@ def display_fundamentals(
         else:
             fig = OpenBBFigure.create_subplots(rows=rows_plot, cols=1)
             for i in range(rows_plot):
-                fig.scatter(
+                fig.add_scatter(
                     x=fundamentals_plot_data.index,
                     y=fundamentals_plot_data[plot[i]],
                     name=plot[i].replace("_", " "),


### PR DESCRIPTION
This PR fixes #5088, making it the same as all the other sources.

Before:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/e291e523-fa2e-4863-834c-702002dc760b)

After:

<img width="1479" alt="Screenshot 2023-06-02 at 2 06 27 PM" src="https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/71f0936a-7a9a-410f-97d7-35c7a057abd1">

<img width="1319" alt="Screenshot 2023-06-02 at 2 06 54 PM" src="https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/34155e6a-be00-4b6c-b28c-90de0fc35b9a">

