### PR TITLE
Avoid pandas' SettingWithCopyWarning

### DIFF
--- a/openbb_terminal/helper_funcs.py
+++ b/openbb_terminal/helper_funcs.py
@@ -300,6 +300,9 @@ def print_rich_table(
         current_user.preferences.USE_INTERACTIVE_DF and plots_backend().isatty
     )
 
+    # Make a copy of the dataframe to avoid SettingWithCopyWarning
+    df = df.copy()
+
     show_index = not isinstance(df.index, pd.RangeIndex) and show_index
     #  convert non-str that are not timestamp or int into str
     # eg) praw.models.reddit.subreddit.Subreddit


### PR DESCRIPTION
When running `etf/search` the user is met with a pandas warning

<img width="902" alt="image" src="https://github.com/OpenBB-finance/OpenBBTerminal/assets/11668535/3e779e56-4166-4fe7-ac91-7db08e869852">

Apparently even if we use the pattern the warning proposes pandas still can't figure out if the operation is made on the original df or a copy.  My current understanding is that this happens because the df is passed into the function.

This PR creates a copy of the dataframe that we will manipulate explicitly so that pandas doesn't have to guess