### PR TITLE
hotfix/docs-faq-debug-mode: Adds debug mode instructions for Terminal and SDK

### DIFF
--- a/website/content/sdk/faqs/developer_issues.md
+++ b/website/content/sdk/faqs/developer_issues.md
@@ -30,6 +30,24 @@ import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
 ## Developer Issues
 
+<details><summary>How do I launch in debug mode?</summary>
+
+The PyWry window can be run in debug mode for identifying specific issues.  Use the code block below - with the `obb` Python environment active - to import the OpenBB SDK in debug mode.
+
+```python
+import os
+from openbb_terminal.core.plots.backend import plots_backend
+
+os.environ["DEBUG_MODE"] = "True"
+plots_backend().start(True)
+
+from openbb_terminal.sdk import openbb
+```
+
+The charts and tables will now include a developer tools button, located at the top-left of the window.  
+
+</details>
+
 <details><summary>What branch on GitHub should pull requests be submitted to?</summary>
 
 Pull requests submitted to the Main branch will not be merged, please create branches from the `develop` branch.

--- a/website/content/terminal/faqs/data_sources.md
+++ b/website/content/terminal/faqs/data_sources.md
@@ -38,7 +38,13 @@ The complete list is found [here](https://docs.openbb.co/terminal/usage/guides/a
 
 </details>
 
-<details><summary>How do I load a ticker symbol from India?</summary>
+<details><summary>How do I find and load a ticker symbol from India, or any other country?</summary>
+
+Use the [`/stocks/search`](https://docs.openbb.co/terminal/usage/intros/stocks#search) command.
+
+```console
+search --country canada --industrygroup banks
+```
 
 Ticker symbols listed on exchanges outside of the US will have a suffix attached, for example, Rico Auto Industries Limited:
 

--- a/website/content/terminal/faqs/developer_issues.md
+++ b/website/content/terminal/faqs/developer_issues.md
@@ -28,6 +28,18 @@ import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
 <HeadTitle title="Developer Issues - Terminal | OpenBB Docs" />
 
+<details><summary>How do I launch in debug mode?</summary>
+
+When installed from source, the OpenBB Terminal can be launched in debug mode.  Launch the Terminal using the syntax below.
+
+```python
+python terminal.py --debug
+```
+
+Operate the Terminal normally, and errors will trigger an interrupt which prints the traceback with the error.  Charts and tables will also include a developer tools button, located at the top-left of the window, for identifying issues specific to the PyWry interactive window.  
+
+</details>
+
 <details><summary>What branch on GitHub should pull requests be submitted to?</summary>
 
 Pull requests submitted to the Main branch will not be merged, please create branches from the `develop` branch.


### PR DESCRIPTION
This PR updates the FAQ page to include debug mode instructions for both Terminal and SDK.