### PR TITLE
hotfix/fix-options-skew: Fixes columns not subtracting

### DIFF
--- a/openbb_terminal/stocks/options/options_chains_model.py
+++ b/openbb_terminal/stocks/options/options_chains_model.py
@@ -1458,26 +1458,28 @@ def calculate_skew(
             ["expiration", "optionType", "strike", "impliedVolatility"]
         ]
         call = call.set_index("expiration")
-        call["skew"] = (
-            call.impliedVolatility
-            - call.query("`strike` == @atm_call_strike")["impliedVolatility"]
-        )[0]
+        call_atm_iv = call.query("`strike` == @atm_call_strike")[
+            "impliedVolatility"
+        ].iloc[0]
+        call["ATM IV"] = call_atm_iv
+        call["Skew"] = call["impliedVolatility"] - call["ATM IV"]
         call_skew = pd.concat([call_skew, call])
         atm_put_strike = get_nearest_put_strike(options, day)  # noqa:F841
         put = puts[puts["dte"] == day][
             ["expiration", "optionType", "strike", "impliedVolatility"]
         ]
         put = put.set_index("expiration")
-        put["skew"] = (
-            put.impliedVolatility
-            - put.query("`strike` == @atm_put_strike")["impliedVolatility"]
-        )[0]
+        put_atm_iv = put.query("`strike` == @atm_put_strike")["impliedVolatility"].iloc[
+            0
+        ]
+        put["ATM IV"] = put_atm_iv
+        put["Skew"] = put["impliedVolatility"] - put["ATM IV"]
         put_skew = pd.concat([put_skew, put])
 
     call_skew = call_skew.set_index(["strike", "optionType"], append=True)
     put_skew = put_skew.set_index(["strike", "optionType"], append=True)
     skew_df = pd.concat([call_skew, put_skew]).sort_index().reset_index()
-    cols = ["Expiration", "Strike", "Option Type", "IV", "Skew"]
+    cols = ["Expiration", "Strike", "Option Type", "IV", "ATM IV", "Skew"]
     skew_df.columns = cols
     if expiration != "":
         if expiration not in options.expirations:

--- a/tests/openbb_terminal/stocks/options/json/test_options_chains_model/test_OptionsChains_9.json
+++ b/tests/openbb_terminal/stocks/options/json/test_options_chains_model/test_OptionsChains_9.json
@@ -1,1 +1,1 @@
-["Expiration", "Strike", "Option Type", "IV", "Skew"]
+["Expiration", "Strike", "Option Type", "IV", "ATM IV", "Skew"]


### PR DESCRIPTION
The column, `Skew`, in `get_skew()`, was supposed  to be a subtraction of the `(IV @ Strike) - (IV @ ATM)`, but instead of subtracting the ATM value, it was being copied.  This PR fixes that by dedicating a column to the ATM IV value prior to performing the math operation and setting the value.

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/ef946ad2-5f4f-4ecf-81c1-14956ba9d807)


![Screenshot 2023-06-22 at 11 03 00 AM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/395b58cd-338d-4389-8104-6696595457a0)
