### PR TITLE
hotfix/economy-index-list: Adds Six Indices to the `economy/index` List

### DIFF
--- a/openbb_terminal/economy/yfinance_model.py
+++ b/openbb_terminal/economy/yfinance_model.py
@@ -232,6 +232,9 @@ INDICES = {
     "cn_szse_comp": {"name": "SZSE Component Index (CNY)", "ticker": "399001.SZ"},
     "cn_szse_a": {"name": "SZSE A-Shares Index (CNY)", "ticker": "399107.SZ"},
     "tw_twii": {"name": "TSEC Weighted Index (TWD)", "ticker": "^TWII"},
+    "tw_tcii": {"name": "TSEC Cement and Ceramics Subindex (TWD)", "ticker": "^TCII"},
+    "tw_tfii": {"name": "TSEC Foods Subindex (TWD)", "ticker": "^TFII"},
+    "tw_tfni": {"name": "TSEC Finance Subindex (TWD)", "ticker": "^TFNI"},
     "tw_tpai": {"name": "TSEC Paper and Pulp Subindex (TWD)", "ticker": "^TPAI"},
     "hk_hsi": {"name": "Hang Seng Index (HKD)", "ticker": "^HSI"},
     "hk_utilities": {
@@ -248,6 +251,10 @@ INDICES = {
         "ticker": "^HSNP",
     },
     "hk_hko": {"name": "NYSE ARCA Hong Kong Options Index (USD)", "ticker": "^HKO"},
+    "hk_titans30": {
+        "name": "Dow Jones Hong Kong Titans 30 Index (HKD)",
+        "ticker": "^XLHK",
+    },
     "id_jkse": {"name": "Jakarta Composite Index (IDR)", "ticker": "^JKSE"},
     "id_lq45": {
         "name": "Indonesia Stock Exchange LQ45 Index (IDR)",
@@ -539,6 +546,7 @@ INDICES = {
     "nyse_nyl": {"name": "NYSE World Leaders Index", "ticker": "^NYL"},
     "nyse_nyi": {"name": "NYSE International 100 Index", "ticker": "^NYI"},
     "nyse_nyy": {"name": "NYSE TMT Index", "ticker": "^NYY"},
+    "nyse_fang": {"name": "NYSE FANG+TM index", "ticker": "^NYFANG"},
     "arca_xmi": {"name": "NYSE ARCA Major Market Index", "ticker": "^XMI"},
     "arca_xbd": {"name": "NYSE ARCA Securities Broker/Dealer Index", "ticker": "^XBD"},
     "arca_xii": {"name": "NYSE ARCA Institutional Index", "ticker": "^XII"},
@@ -585,6 +593,7 @@ INDICES = {
     "cboe_tyx": {"name": "CBOE 30 year Treasury Yields", "ticker": "^TYX"},
     "cboe_irx": {"name": "CBOE 13 Week Treasury Bill", "ticker": "^IRX"},
     "cboe_evz": {"name": "CBOE Euro Currency Volatility Index", "ticker": "^EVZ"},
+    "cboe_rvx": {"name": "CBOE Russell 2000 Volatility Index", "ticker": "^RVX"},
     "move": {"name": "ICE BofAML Move Index", "ticker": "^MOVE"},
     "dxy": {"name": "US Dollar Index", "ticker": "DX-Y.NYB"},
     "crypto200": {"name": "CMC Crypto 200 Index by Solacti", "ticker": "^CMC200"},

--- a/tests/openbb_terminal/economy/txt/test_economy_controller/test_show_indices.txt
+++ b/tests/openbb_terminal/economy/txt/test_economy_controller/test_show_indices.txt
@@ -123,6 +123,9 @@ cn_sse_a                                                                        
 cn_szse_comp                                                                            SZSE Component Index (CNY)      399001.SZ
 cn_szse_a                                                                                SZSE A-Shares Index (CNY)      399107.SZ
 tw_twii                                                                                  TSEC Weighted Index (TWD)          ^TWII
+tw_tcii                                                                    TSEC Cement and Ceramics Subindex (TWD)          ^TCII
+tw_tfii                                                                                  TSEC Foods Subindex (TWD)          ^TFII
+tw_tfni                                                                                TSEC Finance Subindex (TWD)          ^TFNI
 tw_tpai                                                                         TSEC Paper and Pulp Subindex (TWD)          ^TPAI
 hk_hsi                                                                                       Hang Seng Index (HKD)           ^HSI
 hk_utilities                                                                Hang Seng Utilities Sector Index (HKD)          ^HSNU
@@ -130,6 +133,7 @@ hk_china                                                       Hang Seng China-A
 hk_finance                                                                    Hang Seng Finance Sector Index (HKD)          ^HSNF
 hk_properties                                                              Hang Seng Properties Sector Index (HKD)          ^HSNP
 hk_hko                                                                     NYSE ARCA Hong Kong Options Index (USD)           ^HKO
+hk_titans30                                                              Dow Jones Hong Kong Titans 30 Index (HKD)          ^XLHK
 id_jkse                                                                              Jakarta Composite Index (IDR)          ^JKSE
 id_lq45                                                                  Indonesia Stock Exchange LQ45 Index (IDR)        ^JKLQ45
 my_klci                                                                    FTSE Kuala Lumpur Composite Index (MYR)          ^KLSE
@@ -223,6 +227,7 @@ ice_comm                                                           ICE FactSet G
 nyse_nyl                                                                                  NYSE World Leaders Index           ^NYL
 nyse_nyi                                                                              NYSE International 100 Index           ^NYI
 nyse_nyy                                                                                            NYSE TMT Index           ^NYY
+nyse_fang                                                                                       NYSE FANG+TM index        ^NYFANG
 arca_xmi                                                                              NYSE ARCA Major Market Index           ^XMI
 arca_xbd                                                                  NYSE ARCA Securities Broker/Dealer Index           ^XBD
 arca_xii                                                                             NYSE ARCA Institutional Index           ^XII
@@ -263,6 +268,7 @@ cboe_tnx                                                                        
 cboe_tyx                                                                              CBOE 30 year Treasury Yields           ^TYX
 cboe_irx                                                                                CBOE 13 Week Treasury Bill           ^IRX
 cboe_evz                                                                       CBOE Euro Currency Volatility Index           ^EVZ
+cboe_rvx                                                                        CBOE Russell 2000 Volatility Index           ^RVX
 move                                                                                         ICE BofAML Move Index          ^MOVE
 dxy                                                                                                US Dollar Index       DX-Y.NYB
 crypto200                                                                          CMC Crypto 200 Index by Solacti        ^CMC200


### PR DESCRIPTION
This PR adds six more entries to the curated index list in `/economy/yfinance_model.py`

![Screenshot 2023-06-26 at 7 09 09 AM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/34da1f8d-3a29-4b60-900a-c68f55cdaadc)
