### PR TITLE
Add missing wraps decorator in filter_call

### DIFF
--- a/openbb_sdk/sdk/core/openbb_core/app/static/filters.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/static/filters.py
@@ -1,4 +1,5 @@
 import builtins
+from functools import wraps
 
 import pandas as pd
 from pydantic import ValidationError
@@ -9,6 +10,7 @@ from openbb_core.app.utils import df_to_basemodel
 
 
 def filter_call(func):
+    @wraps(wrapped=func)
     def inner(*args, **kwargs):
         self = args[0]
         debug_mode = (


### PR DESCRIPTION

# Description

The ``filter_call`` decorator was missing the ``functools.wraps`` decorator on the inner function. The result of this is that the decorated method can't be inspected properly at runtime as it only has the generic signature from the inner funciton.

# How has this been tested?

Before:

```
>>> help(obb.stocks.load)
Help on method inner in module openbb_core.app.static.filters:

inner(*args, **kwargs) method of openbb_core.app.static.package.stocks.CLASS_stocks instance
```

After:

```
>>> help(obb.stocks.load)
Help on method load in module openbb_core.app.static.package.stocks:

load(symbol: str, start_date: Union[datetime.date, NoneType, str] = None, end_date: Union[datetime.date, NoneType, str] = None, chart: bool = False, provider: Optional[Literal['fmp', 'polygon']] = None, **kwargs) -> openbb_core.app.static.package.stocks.CommandOutput[List] method of openbb_core.app.static.package.stocks.CLASS_stocks instance
    Load stock data for a specific ticker.
....
```

# Checklist:

- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [x] (N/A) Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [x] (N/A) Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).

# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
