### PR TITLE
hotfix/economy-report-duplicate-table: fixes duplicate tables.

### DIFF
--- a/openbb_terminal/reports/templates/economy.ipynb
+++ b/openbb_terminal/reports/templates/economy.ipynb
@@ -659,7 +659,7 @@
     "    [widgets.h(3, \"Valuation (source: Finviz)\") + valuation.to_html()]\n",
     ")\n",
     "htmlcode += widgets.row(\n",
-    "    [widgets.h(3, \"Performance (source: Finviz)\") + valuation.to_html()]\n",
+    "    [widgets.h(3, \"Performance (source: Finviz)\") + performance.to_html()]\n",
     ")\n",
     "htmlcode += widgets.row([widgets.h(3, \"US markets (source: YahooFinance)\") + eqty_0])\n",
     "htmlcode += widgets.row(\n",
@@ -711,7 +711,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
This PR fixes a duplicated table in the economy report.