### PR TITLE
hotfix/docs-sdk-basics-headTitle: fix headTitle

### DIFF
--- a/website/content/sdk/usage/basics/index.md
+++ b/website/content/sdk/usage/basics/index.md
@@ -6,7 +6,7 @@ keywords: [basics, installation, commands, menus, your own data, introduction, o
 ---
 import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
-`<HeadTitle title="Basics - SDK | OpenBB Docs" />`
+<HeadTitle title="Basics - SDK | OpenBB Docs" />
 
 ## Overview
 


### PR DESCRIPTION
Issue where a formatting property was in a code block:

<img width="479" alt="Screenshot 2023-07-24 at 10 12 45 PM" src="https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/e4088056-cc63-4426-afd3-e8432e75a35c">
