### PR TITLE
hotfix/economy-controller-sort-filter: Fwd P/E regex fix

### DIFF
--- a/openbb_terminal/economy/economy_controller.py
+++ b/openbb_terminal/economy/economy_controller.py
@@ -269,7 +269,7 @@ class EconomyController(BaseController):
         See `BaseController.parse_input()` for details.
         """
         # Filtering out sorting parameters with forward slashes like P/E
-        sort_filter = r"((\ -s |\ --sortby ).*?(P\/E|Fwd P\/E|P\/S|P\/B|P\/C|P\/FCF)*)"
+        sort_filter = r"((\ -s |\ --sortby ).*?(P\/E|Fwd|P\/E|P\/S|P\/B|P\/C|P\/FCF)*)"
 
         custom_filters = [sort_filter]
 


### PR DESCRIPTION
Quick fix for the sorting parameter in the Economy valuation parameter. 

Before:

```
(🦋) /economy/ $ valuation -g country --sortby FwdP/E

(🦋) /economy/ $ valuation -g country --sortby FwdP

usage: valuation
                 [-g {sector,industry,basic_materials,communication_services,consumer_cyclical,consumer_defensive,energy,financial,healthcare,industrials,real_Estate,technology,utilities,country,capitalization}]
                 [-s {Name,MarketCap,P/E,FwdP/E,PEG,P/S,P/B,P/C,P/FCF,EPSpast5Y,EPSnext5Y,Salespast5Y,Change,Volume}] [-r] [-h] [--export EXPORT] [--sheet-name SHEET_NAME [SHEET_NAME ...]]
valuation: error: argument -s/--sortby: invalid choice: 'FwdP' (choose from 'Name', 'MarketCap', 'P/E', 'FwdP/E', 'PEG', 'P/S', 'P/B', 'P/C', 'P/FCF', 'EPSpast5Y', 'EPSnext5Y', 'Salespast5Y', 'Change', 'Volume')


The command 'E' doesn't exist on the /economy/ menu.
```

After:

![Screenshot 2023-08-02 at 8 27 33 AM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/17360a41-3bcd-41c8-81cd-8b7d4effe83c)


