### PR TITLE
hotfix/fix-stocks-search-sdk3: Fixes the stocks search so that it doesn't `print_rich_table()` for SDK.

### DIFF
--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -274,12 +274,21 @@ class StocksController(StockBaseController):
                 all_exchanges=ns_parser.all_exchanges,
                 limit=ns_parser.limit,
             )
-            stocks_helper.print_rich_table(
-                df,
-                show_index=False,
-                headers=df.columns,
-                title="Stock Search Results",
-            )
+            if ns_parser.export:
+                export_data(
+                    ns_parser.export,
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "search",
+                    df,
+                    " ".join(ns_parser.sheet_name) if ns_parser.sheet_name else None,
+                )
+            if not ns_parser.export:
+                stocks_helper.print_rich_table(
+                    df,
+                    show_index=False,
+                    headers=df.columns,
+                    title="Stock Search Results",
+                )
 
     @log_start_end(log=logger)
     def call_tob(self, other_args: List[str]):

--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -263,7 +263,7 @@ class StocksController(StockBaseController):
                 list(stocks_helper.market_coverage_suffix.keys())
             )[ns_parser.exchange_country]
 
-            stocks_helper.search(
+            df = stocks_helper.search(
                 query=" ".join(ns_parser.query),
                 country=ns_parser.country,
                 sector=sector,
@@ -273,6 +273,12 @@ class StocksController(StockBaseController):
                 exchange_country=exchange_country,
                 all_exchanges=ns_parser.all_exchanges,
                 limit=ns_parser.limit,
+            )
+            stocks_helper.print_rich_table(
+                df,
+                show_index=False,
+                headers=df.columns,
+                title="Stock Search Results",
             )
 
     @log_start_end(log=logger)

--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -246,7 +246,7 @@ class StocksController(StockBaseController):
             parser,
             other_args,
             EXPORT_ONLY_RAW_DATA_ALLOWED,
-            limit=10,
+            limit=0,
         ):
             # Mapping
             sector = stocks_helper.map_parse_choices(self.sector)[ns_parser.sector]
@@ -272,7 +272,6 @@ class StocksController(StockBaseController):
                 exchange=exchange,
                 exchange_country=exchange_country,
                 all_exchanges=ns_parser.all_exchanges,
-                limit=ns_parser.limit,
             )
             if ns_parser.export:
                 export_data(

--- a/openbb_terminal/stocks/stocks_helper.py
+++ b/openbb_terminal/stocks/stocks_helper.py
@@ -228,43 +228,11 @@ def search(
 
     df = df[["name", "country", "sector", "industry_group", "industry", "exchange"]]
     # To automate renaming columns
-    headers = [col.replace("_", " ") for col in df.columns.tolist()]
-
-    title = "Companies found"
-    if query:
-        title += f" on term {query}"
-    if exchange_country and exchange:
-        title += f" on the exchange {exchange} in {exchange_country.replace('_', ' ').title()}"
-    if exchange and not exchange_country:
-        title += f" on the exchange {exchange}"
-    if exchange_country and not exchange:
-        title += f" on an exchange in {exchange_country.replace('_', ' ').title()}"
-    if country:
-        title += f" in {country.replace('_', ' ').title()}"
-    if sector:
-        title += f" within {sector}"
-        if industry_group:
-            title += f" and {industry_group}"
-        if industry:
-            title += f" and {industry}"
-    if not sector and industry_group:
-        title += f" within {industry_group}"
-    if not sector and industry:
-        title += f" within {industry}"
-
+    df.columns = [col.replace("_", " ") for col in df.columns.tolist()]
     df = df.fillna(value=np.nan)
     df = df.iloc[df.isnull().sum(axis=1).mul(1).argsort()]
 
-    print_rich_table(
-        df,
-        show_index=True,
-        headers=headers,
-        index_name="Symbol",
-        title=title,
-        limit=limit,
-    )
-
-    return df
+    return df.reset_index()
 
 
 def load(  # pylint: disable=too-many-return-statements
@@ -1108,3 +1076,45 @@ def heikin_ashi(data: pd.DataFrame) -> pd.DataFrame:
     ]
 
     return pd.concat([data, ha], axis=1)
+
+
+def calculate_adjusted_prices(df: pd.DataFrame, column: str, dividends: bool = False):
+    """Calculates the split-adjusted prices, or split and dividend adjusted prices.
+
+    Parameters
+    ------------
+    df: pd.DataFrame
+        DataFrame with unadjusted OHLCV values + Split Factor + Dividend
+    column: str
+        The column name to adjust.
+    dividends: bool
+        Whether to adjust for both splits and dividends. Default is split-adjusted only.
+
+    Returns
+    --------
+    pd.DataFrame
+        DataFrame with adjusted prices.
+    """
+
+    df = df.copy()
+    adj_column = "Adj " + column
+
+    # Reverse the DataFrame order, sorting by date in descending order
+    df.sort_index(ascending=False, inplace=True)
+
+    price_col = df[column].values
+    split_col = df["Volume Factor"] if column == "Volume" else df["Split Factor"].values
+    dividend_col = df["Dividend"].values if dividends else np.zeros(len(price_col))
+    adj_price_col = np.zeros(len(df.index))
+    adj_price_col[0] = price_col[0]
+
+    for i in range(1, len(price_col)):
+        adj_price_col[i] = adj_price_col[i - 1] + adj_price_col[i - 1] * (
+            ((price_col[i] * split_col[i - 1]) - price_col[i - 1] - dividend_col[i - 1])
+            / price_col[i - 1]
+        )
+    df[adj_column] = adj_price_col
+
+    # Change the DataFrame order back to dates ascending
+    df.sort_index(ascending=True, inplace=True)
+    return df

--- a/openbb_terminal/stocks/stocks_helper.py
+++ b/openbb_terminal/stocks/stocks_helper.py
@@ -120,7 +120,6 @@ def search(
     exchange: str = "",
     exchange_country: str = "",
     all_exchanges: bool = False,
-    limit: int = 0,
 ) -> pd.DataFrame:
     """Search selected query for tickers.
 
@@ -142,8 +141,6 @@ def search(
         Search by exchange country to find stock matching the criteria
     all_exchanges: bool
         Whether to search all exchanges, without this option only the United States market is searched
-    limit : int
-        The limit of results shown, where 0 means all the results
 
     Returns
     -------

--- a/tests/openbb_terminal/stocks/test_stocks_controller.py
+++ b/tests/openbb_terminal/stocks/test_stocks_controller.py
@@ -266,7 +266,6 @@ def test_call_func_expect_queue(expected_queue, func, queue):
             [],
             dict(
                 query="microsoft",
-                limit=1,
                 country="",
                 sector="",
                 industry_group="",

--- a/tests/openbb_terminal/stocks/test_stocks_helper.py
+++ b/tests/openbb_terminal/stocks/test_stocks_helper.py
@@ -57,7 +57,7 @@ def test_search(mocker, use_tab):
         target="openbb_terminal.core.session.current_user.__current_user",
         new=mock_current_user,
     )
-    stocks_helper.search(
+    df = stocks_helper.search(
         query="microsoft",
         country="United_States",
         sector="",
@@ -67,6 +67,9 @@ def test_search(mocker, use_tab):
         exchange_country="",
         all_exchanges=False,
         limit=5,
+    )
+    stocks_helper.print_rich_table(
+        df, show_index=False, title="Company Search Results", headers=df.columns
     )
 
 

--- a/tests/openbb_terminal/stocks/test_stocks_helper.py
+++ b/tests/openbb_terminal/stocks/test_stocks_helper.py
@@ -66,7 +66,6 @@ def test_search(mocker, use_tab):
         exchange="",
         exchange_country="",
         all_exchanges=False,
-        limit=5,
     )
     stocks_helper.print_rich_table(
         df, show_index=False, title="Company Search Results", headers=df.columns

--- a/tests/openbb_terminal/stocks/txt/test_stocks_controller/test_print_help.txt
+++ b/tests/openbb_terminal/stocks/txt/test_stocks_controller/test_print_help.txt
@@ -1,5 +1,5 @@
     search             search a specific stock ticker for analysis                     [FinanceDatabase]
-    load               load a specific stock ticker and additional info for analysis   [YahooFinance, AlphaVantage, Polygon, EODHD, Intrinio, DataBento]
+    load               load a specific stock ticker and additional info for analysis   [YahooFinance, Polygon, AlphaVantage, EODHD, Intrinio, DataBento]
 
 Stock: 
 

--- a/tests/openbb_terminal/stocks/txt/test_stocks_controller/test_print_help.txt
+++ b/tests/openbb_terminal/stocks/txt/test_stocks_controller/test_print_help.txt
@@ -1,5 +1,5 @@
     search             search a specific stock ticker for analysis                     [FinanceDatabase]
-    load               load a specific stock ticker and additional info for analysis   [YahooFinance, Polygon, AlphaVantage, EODHD, Intrinio, DataBento]
+    load               load a specific stock ticker and additional info for analysis   [YahooFinance, AlphaVantage, Polygon, EODHD, Intrinio, DataBento]
 
 Stock: 
 

--- a/tests/openbb_terminal/stocks/txt/test_stocks_helper/test_search[False].txt
+++ b/tests/openbb_terminal/stocks/txt/test_stocks_helper/test_search[False].txt
@@ -1,3 +1,2 @@
-                         name        country                  sector       industry_group  industry exchange
-symbol                                                                                                      
-MSFT    Microsoft Corporation  United States  Information Technology  Software & Services  Software      NMS
+  symbol                   name        country                  sector       industry group  industry exchange
+0   MSFT  Microsoft Corporation  United States  Information Technology  Software & Services  Software      NMS

--- a/tests/openbb_terminal/stocks/txt/test_stocks_helper/test_search[True].txt
+++ b/tests/openbb_terminal/stocks/txt/test_stocks_helper/test_search[True].txt
@@ -1,3 +1,2 @@
-                         name        country                  sector       industry_group  industry exchange
-symbol                                                                                                      
-MSFT    Microsoft Corporation  United States  Information Technology  Software & Services  Software      NMS
+  symbol                   name        country                  sector       industry group  industry exchange
+0   MSFT  Microsoft Corporation  United States  Information Technology  Software & Services  Software      NMS


### PR DESCRIPTION
Currently, if you use the SDK and `stocks.search()`, it will open a PyWry window while simultaneously returning a DataFrame.  This takes care of that.