### PR TITLE
move debug_mode out of system settings

### DIFF
--- a/openbb_sdk/sdk/core/openbb_core/app/command_runner.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/command_runner.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, U
 from pydantic import BaseConfig, Extra, create_model
 
 from openbb_core.app.charting_manager import ChartingManager
+from openbb_core.app.env import Env
 from openbb_core.app.logs.logging_manager import LoggingManager
 from openbb_core.app.model.abstract.error import OpenBBError
 from openbb_core.app.model.abstract.warning import cast_warning
@@ -189,13 +190,11 @@ class StaticCommandRunner:
     charting_manager: ChartingManager = ChartingManager()
 
     @classmethod
-    def __command(
-        cls, system_settings: SystemSettings, func: Callable, kwargs: Dict[str, Any]
-    ) -> OBBject:
+    def __command(cls, func: Callable, kwargs: Dict[str, Any]) -> OBBject:
         """Run a command and return the output"""
         context_manager: Union[warnings.catch_warnings, ContextManager[None]] = (
             warnings.catch_warnings(record=True)
-            if not system_settings.debug_mode
+            if not Env().DEBUG_MODE
             else nullcontext()
         )
 
@@ -265,7 +264,6 @@ class StaticCommandRunner:
 
         try:
             obbject = cls.__command(
-                system_settings=system_settings,
                 func=func,
                 kwargs=kwargs,
             )

--- a/openbb_sdk/sdk/core/openbb_core/app/env.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/env.py
@@ -1,0 +1,31 @@
+import os
+from os import _Environ
+from pathlib import Path
+
+import dotenv
+
+from openbb_core.app.model.abstract.singleton import SingletonMeta
+
+
+class Env(metaclass=SingletonMeta):
+    _environ: _Environ
+
+    def __init__(self) -> None:
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        dotenv.load_dotenv(Path(current_dir, ".env"))
+        self._environ = os.environ
+
+    @property
+    def DEBUG_MODE(self) -> bool:
+        return self.str_to_bool(self._environ.get("DEBUG_MODE", False))
+
+    @staticmethod
+    def str_to_bool(value) -> bool:
+        """Match a string to a boolean value."""
+        if isinstance(value, bool):
+            return value
+        if value.lower() in {"false", "f", "0", "no", "n"}:
+            return False
+        if value.lower() in {"true", "t", "1", "yes", "y"}:
+            return True
+        raise ValueError(f"Failed to cast {value} to bool.")

--- a/openbb_sdk/sdk/core/openbb_core/app/model/charts/charting_settings.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/model/charts/charting_settings.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Optional
 
+from openbb_core.app.env import Env
 from openbb_core.app.logs.utils.utils import get_app_id
 from openbb_core.app.model.system_settings import SystemSettings
 from openbb_core.app.model.user_settings import UserSettings
@@ -28,7 +29,7 @@ class ChartingSettings:
         self.python_version: str = system_settings.python_version
         self.test_mode = system_settings.test_mode
         self.app_id: str = get_app_id(user_data_directory)
-        self.debug_mode: bool = system_settings.debug_mode
+        self.debug_mode: bool = Env().DEBUG_MODE
         self.headless: bool = system_settings.headless
         # User
         self.plot_enable_pywry: bool = user_settings.preferences.plot_enable_pywry

--- a/openbb_sdk/sdk/core/openbb_core/app/model/system_settings.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/model/system_settings.py
@@ -45,7 +45,6 @@ class SystemSettings(Tagged):
 
     # Others
     test_mode: bool = False
-    debug_mode: bool = False
     headless: bool = False
 
     class Config:

--- a/openbb_sdk/sdk/core/openbb_core/app/router.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/router.py
@@ -242,7 +242,8 @@ class SignatureInspector:
                 if Env().DEBUG_MODE:
                     warnings.warn(
                         message=f"\nSkipping api route '/{func.__name__}'.\n"
-                        f"Model '{model}' not found.\n\n",
+                        f"Model '{model}' not found.\n\n"
+                        "Check available models in ProviderInterface().models",
                         category=OpenBBWarning,
                     )
                 return None

--- a/openbb_sdk/sdk/core/openbb_core/app/router.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/router.py
@@ -22,6 +22,7 @@ from pydantic.config import BaseConfig
 from pydantic.validators import find_validators
 from typing_extensions import Annotated, ParamSpec, _AnnotatedAlias
 
+from openbb_core.app.env import Env
 from openbb_core.app.model.abstract.warning import OpenBBWarning
 from openbb_core.app.model.command_context import CommandContext
 from openbb_core.app.model.obbject import OBBject
@@ -238,12 +239,12 @@ class SignatureInspector:
 
         if model:
             if model not in provider_interface.models:
-                warnings.warn(
-                    message=f"\nSkipping api route '/{func.__name__}'.\n"
-                    f"Model '{model}' not found.\n\n"
-                    "Check available models in ProviderInterface().models",
-                    category=OpenBBWarning,
-                )
+                if Env().DEBUG_MODE:
+                    warnings.warn(
+                        message=f"\nSkipping api route '/{func.__name__}'.\n"
+                        f"Model '{model}' not found.\n\n",
+                        category=OpenBBWarning,
+                    )
                 return None
 
             cls.validate_signature(

--- a/openbb_sdk/sdk/core/openbb_core/app/service/system_service.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/service/system_service.py
@@ -14,7 +14,6 @@ class SystemService:
         "log_collect",
         "test_mode",
         "headless",
-        "debug_mode",
         "dbms_uri",
     }
 

--- a/openbb_sdk/sdk/core/tests/app/model/charts/test_chart_settings.py
+++ b/openbb_sdk/sdk/core/tests/app/model/charts/test_chart_settings.py
@@ -19,7 +19,6 @@ mock_system_settings.log_collect = True
 mock_system_settings.version = "mock_version"
 mock_system_settings.python_version = "mock_python_version"
 mock_system_settings.test_mode = True
-mock_system_settings.debug_mode = True
 mock_system_settings.headless = True
 
 
@@ -36,7 +35,6 @@ def test_charting_settings():
     assert charting_settings.python_version == "mock_python_version"
     assert charting_settings.test_mode is True
     assert charting_settings.app_id == "mock_app_id"
-    assert charting_settings.debug_mode is True
     assert charting_settings.headless is True
     assert charting_settings.plot_enable_pywry is True
     assert charting_settings.plot_pywry_width == 100


### PR DESCRIPTION
This allow setting `debug_mode` before loading `SystemSettings` from `os.environ` or `.env` file.

It is useful for example to suppress import time warnings, like missing models in the routers.