### PR TITLE
Add @classproperty to fetcher for nested return types

### DIFF
--- a/openbb_sdk/providers/fred/openbb_fred/models/ameribor_rates.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/ameribor_rates.py
@@ -62,8 +62,12 @@ class FREDAMERIBORData(AMERIBORData):
             return float("nan")
 
 
-class FREDAMERIBORFetcher(Fetcher[FREDAMERIBORQueryParams, FREDAMERIBORData]):
+class FREDAMERIBORFetcher(
+    Fetcher[FREDAMERIBORQueryParams, List[Dict[str, List[FREDAMERIBORData]]]]
+):
     """FRED AMERIBOR Fetcher."""
+
+    data_type = FREDAMERIBORData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDAMERIBORQueryParams:
@@ -74,7 +78,7 @@ class FREDAMERIBORFetcher(Fetcher[FREDAMERIBORQueryParams, FREDAMERIBORData]):
         query: FREDAMERIBORQueryParams,
         credentials: Optional[Dict[str, str]],
         **kwargs: Any
-    ) -> list:
+    ) -> dict:
         key = credentials.get("fred_api_key") if credentials else ""
         fred_series = AMERIBOR_PARAMETER_TO_FRED_ID[query.parameter]
         fred = Fred(key)
@@ -82,6 +86,6 @@ class FREDAMERIBORFetcher(Fetcher[FREDAMERIBORQueryParams, FREDAMERIBORData]):
         return data
 
     @staticmethod
-    def transform_data(data: list) -> List[Dict[str, List[FREDAMERIBORData]]]:
+    def transform_data(data: dict) -> List[Dict[str, List[FREDAMERIBORData]]]:
         keys = ["date", "value"]
         return [FREDAMERIBORData(**{k: x[k] for k in keys}) for x in data]

--- a/openbb_sdk/providers/fred/openbb_fred/models/cpi.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/cpi.py
@@ -5,26 +5,22 @@ from typing import Any, Dict, List, Optional
 
 from openbb_fred.utils.fred_base import Fred
 from openbb_fred.utils.fred_helpers import all_cpi_options
-from openbb_provider.abstract.data import Data
 from openbb_provider.abstract.fetcher import Fetcher
 from openbb_provider.standard_models.cpi import CPIData, CPIQueryParams
-from pydantic import Field
 
 
 class FREDCPIQueryParams(CPIQueryParams):
     """CPI query."""
 
 
-class FREDCPIData(Data):
+class FREDCPIData(CPIData):
     """CPI data."""
 
-    country_unit_freq: Optional[List[CPIData]] = Field(
-        description="CPI data for a country, units, and frequency combination."
-    )
 
-
-class FREDCPIFetcher(Fetcher[FREDCPIQueryParams, List[FREDCPIData]]):
+class FREDCPIFetcher(Fetcher[FREDCPIQueryParams, List[Dict[str, List[FREDCPIData]]]]):
     """FRED CPI Fetcher."""
+
+    data_type = FREDCPIData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDCPIQueryParams:

--- a/openbb_sdk/providers/fred/openbb_fred/models/estr_rates.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/estr_rates.py
@@ -53,8 +53,12 @@ class FREDESTRData(ESTRData):
             return float("nan")
 
 
-class FREDESTRFetcher(Fetcher[FREDESTRQueryParams, FREDESTRData]):
+class FREDESTRFetcher(
+    Fetcher[FREDESTRQueryParams, List[Dict[str, List[FREDESTRData]]]]
+):
     """FRED ESTR Fetcher."""
+
+    data_type = FREDESTRData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDESTRQueryParams:
@@ -63,7 +67,7 @@ class FREDESTRFetcher(Fetcher[FREDESTRQueryParams, FREDESTRData]):
     @staticmethod
     def extract_data(
         query: FREDESTRQueryParams, credentials: Optional[Dict[str, str]], **kwargs: Any
-    ) -> list:
+    ) -> dict:
         key = credentials.get("fred_api_key") if credentials else ""
         fred_series = ESTR_PARAMETER_TO_ID[query.parameter]
         fred = Fred(key)
@@ -71,6 +75,6 @@ class FREDESTRFetcher(Fetcher[FREDESTRQueryParams, FREDESTRData]):
         return data
 
     @staticmethod
-    def transform_data(data: list) -> List[Dict[str, List[FREDESTRData]]]:
+    def transform_data(data: dict) -> List[Dict[str, List[FREDESTRData]]]:
         keys = ["date", "value"]
         return [FREDESTRData(**{k: x[k] for k in keys}) for x in data]

--- a/openbb_sdk/providers/fred/openbb_fred/models/fed_projections.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/fed_projections.py
@@ -35,8 +35,12 @@ class FREDPROJECTIONData(PROJECTIONData):
     """PROJECTION data."""
 
 
-class FREDPROJECTIONFetcher(Fetcher[FREDPROJECTIONQueryParams, FREDPROJECTIONData]):
+class FREDPROJECTIONFetcher(
+    Fetcher[FREDPROJECTIONQueryParams, List[Dict[str, List[FREDPROJECTIONData]]]]
+):
     """FRED PROJECTION Fetcher."""
+
+    data_type = FREDPROJECTIONData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDPROJECTIONQueryParams:

--- a/openbb_sdk/providers/fred/openbb_fred/models/fed_rates.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/fed_rates.py
@@ -54,8 +54,10 @@ class FREDFEDData(FEDData):
             return float("nan")
 
 
-class FREDFEDFetcher(Fetcher[FREDFEDQueryParams, FREDFEDData]):
+class FREDFEDFetcher(Fetcher[FREDFEDQueryParams, List[Dict[str, List[FREDFEDData]]]]):
     """FRED FED Fetcher."""
+
+    data_type = FREDFEDData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDFEDQueryParams:
@@ -64,7 +66,7 @@ class FREDFEDFetcher(Fetcher[FREDFEDQueryParams, FREDFEDData]):
     @staticmethod
     def extract_data(
         query: FREDFEDQueryParams, credentials: Optional[Dict[str, str]], **kwargs: Any
-    ) -> list:
+    ) -> dict:
         key = credentials.get("fred_api_key") if credentials else ""
         fred_series = FED_PARAMETER_TO_FRED_ID[query.parameter]
         fred = Fred(key)
@@ -72,6 +74,6 @@ class FREDFEDFetcher(Fetcher[FREDFEDQueryParams, FREDFEDData]):
         return data
 
     @staticmethod
-    def transform_data(data: list) -> List[Dict[str, List[FREDFEDData]]]:
+    def transform_data(data: dict) -> List[Dict[str, List[FREDFEDData]]]:
         keys = ["date", "value"]
         return [FREDFEDData(**{k: x[k] for k in keys}) for x in data]

--- a/openbb_sdk/providers/fred/openbb_fred/models/iorb_rates.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/iorb_rates.py
@@ -34,8 +34,12 @@ class FREDIORBData(IORBData):
             return float("nan")
 
 
-class FREDIORBFetcher(Fetcher[FREDIORBQueryParams, FREDIORBData]):
+class FREDIORBFetcher(
+    Fetcher[FREDIORBQueryParams, List[Dict[str, List[FREDIORBData]]]]
+):
     """FRED IORB Fetcher."""
+
+    data_type = FREDIORBData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDIORBQueryParams:
@@ -44,7 +48,7 @@ class FREDIORBFetcher(Fetcher[FREDIORBQueryParams, FREDIORBData]):
     @staticmethod
     def extract_data(
         query: FREDIORBQueryParams, credentials: Optional[Dict[str, str]], **kwargs: Any
-    ) -> list:
+    ) -> dict:
         key = credentials.get("fred_api_key") if credentials else ""
         fred_series = "IORB"
         fred = Fred(key)
@@ -52,6 +56,6 @@ class FREDIORBFetcher(Fetcher[FREDIORBQueryParams, FREDIORBData]):
         return data
 
     @staticmethod
-    def transform_data(data: list) -> List[Dict[str, List[FREDIORBData]]]:
+    def transform_data(data: dict) -> List[Dict[str, List[FREDIORBData]]]:
         keys = ["date", "value"]
         return [FREDIORBData(**{k: x[k] for k in keys}) for x in data]

--- a/openbb_sdk/providers/fred/openbb_fred/models/sofr_rates.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/sofr_rates.py
@@ -43,8 +43,12 @@ class FREDSOFRData(SOFRData):
             return float("nan")
 
 
-class FREDSOFRFetcher(Fetcher[FREDSOFRQueryParams, FREDSOFRData]):
+class FREDSOFRFetcher(
+    Fetcher[FREDSOFRQueryParams, List[Dict[str, List[FREDSOFRData]]]]
+):
     """FRED SOFR Fetcher."""
+
+    data_type = FREDSOFRData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDSOFRQueryParams:
@@ -53,7 +57,7 @@ class FREDSOFRFetcher(Fetcher[FREDSOFRQueryParams, FREDSOFRData]):
     @staticmethod
     def extract_data(
         query: FREDSOFRQueryParams, credentials: Optional[Dict[str, str]], **kwargs: Any
-    ) -> list:
+    ) -> dict:
         key = credentials.get("fred_api_key") if credentials else ""
         fred_series = SOFR_PARAMETER_TO_FRED_ID[query.period]
         fred = Fred(key)
@@ -61,6 +65,6 @@ class FREDSOFRFetcher(Fetcher[FREDSOFRQueryParams, FREDSOFRData]):
         return data
 
     @staticmethod
-    def transform_data(data: list) -> List[Dict[str, List[FREDSOFRData]]]:
+    def transform_data(data: dict) -> List[Dict[str, List[FREDSOFRData]]]:
         keys = ["date", "value"]
         return [FREDSOFRData(**{k: x[k] for k in keys}) for x in data]

--- a/openbb_sdk/providers/fred/openbb_fred/models/sonia_rates.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/sonia_rates.py
@@ -51,8 +51,12 @@ class FREDSONIAData(SONIAData):
             return float("nan")
 
 
-class FREDSONIAFetcher(Fetcher[FREDSONIAQueryParams, FREDSONIAData]):
+class FREDSONIAFetcher(
+    Fetcher[FREDSONIAQueryParams, List[Dict[str, List[FREDSONIAData]]]]
+):
     """FRED SONIA Fetcher."""
+
+    data_type = FREDSONIAData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDSONIAQueryParams:
@@ -63,7 +67,7 @@ class FREDSONIAFetcher(Fetcher[FREDSONIAQueryParams, FREDSONIAData]):
         query: FREDSONIAQueryParams,
         credentials: Optional[Dict[str, str]],
         **kwargs: Any
-    ) -> list:
+    ) -> dict:
         key = credentials.get("fred_api_key") if credentials else ""
         fred_series = SONIA_PARAMETER_TO_FRED_ID[query.parameter]
         fred = Fred(key)
@@ -71,6 +75,6 @@ class FREDSONIAFetcher(Fetcher[FREDSONIAQueryParams, FREDSONIAData]):
         return data
 
     @staticmethod
-    def transform_data(data: list) -> List[Dict[str, List[FREDSONIAData]]]:
+    def transform_data(data: dict) -> List[Dict[str, List[FREDSONIAData]]]:
         keys = ["date", "value"]
         return [FREDSONIAData(**{k: x[k] for k in keys}) for x in data]

--- a/openbb_sdk/providers/fred/openbb_fred/models/us_yield_curve.py
+++ b/openbb_sdk/providers/fred/openbb_fred/models/us_yield_curve.py
@@ -26,8 +26,12 @@ class FREDYieldCurveData(USYieldCurveData):
     """Fred Yield Curve data."""
 
 
-class FREDYieldCurveFetcher(Fetcher[FREDYieldCurveQueryParams, FREDYieldCurveData]):
+class FREDYieldCurveFetcher(
+    Fetcher[FREDYieldCurveQueryParams, List[Dict[str, List[FREDYieldCurveData]]]]
+):
     """FRED Yield Curve Fetcher."""
+
+    data_type = FREDYieldCurveData
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FREDYieldCurveQueryParams:

--- a/openbb_sdk/providers/fred/openbb_fred/utils/fred_helpers.py
+++ b/openbb_sdk/providers/fred/openbb_fred/utils/fred_helpers.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 YIELD_CURVE_NOMINAL_RATES = [round(1 / 12, 3), 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 30]
 YIELD_CURVE_SPOT_RATES = [0.5, 1, 2, 3, 5, 7, 10, 20, 30, 50, 75, 100]
-YIELD_CURVE_REAL_RATES = [5, 7, 10, 20, 30]
-YIELD_CURVE_PAR_RATES = [2, 5, 10, 30]
+YIELD_CURVE_REAL_RATES = [5.0, 7, 10, 20, 30]
+YIELD_CURVE_PAR_RATES = [2.0, 5, 10, 30]
 YIELD_CURVE_SERIES_NOMINAL = {
     "1Month": "DGS1MO",
     "3Month": "DGS3MO",

--- a/openbb_sdk/sdk/core/openbb_core/app/static/package/economy.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/static/package/economy.py
@@ -405,9 +405,14 @@ class CLASS_economy(Container):
 
         CPI
         ---
-        country_unit_freq : Optional[List[CPIData]]
-            CPI data for a country, units, and frequency combination. (provider: fred)
-        """
+        date : Optional[date]
+            The date of the data.
+        realtime_start : Optional[date]
+            Date the data was updated.
+        realtime_end : Optional[date]
+            Date the data was updated.
+        value : Optional[float]
+            Value of the data."""
 
         inputs = filter_inputs(
             provider_choices={

--- a/openbb_sdk/sdk/provider/openbb_provider/abstract/fetcher.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/abstract/fetcher.py
@@ -10,6 +10,16 @@ D = TypeVar("D")  # Data
 R = TypeVar("R")  # Return, usually List[D], but can be just D for example
 
 
+class classproperty:
+    """Class property decorator."""
+
+    def __init__(self, f):
+        self.f = f
+
+    def __get__(self, obj, owner):
+        return self.f(owner)
+
+
 class Fetcher(Generic[Q, R]):
     """Abstract class for the fetcher."""
 
@@ -40,20 +50,20 @@ class Fetcher(Generic[Q, R]):
         data = cls.extract_data(query=query, credentials=credentials, **kwargs)
         return cls.transform_data(data=data)
 
-    @property
-    def query_params(self) -> Q:
+    @classproperty
+    def query_params_type(self) -> Q:
         """Get the type of query."""
         # pylint: disable=E1101
         return self.__orig_bases__[0].__args__[0]  # type: ignore
 
-    @property
+    @classproperty
     def return_type(self) -> R:
         """Get the type of return."""
         # pylint: disable=E1101
         return self.__orig_bases__[0].__args__[1]  # type: ignore
 
-    @property
-    def data(self) -> D:  # type: ignore
+    @classproperty
+    def data_type(self) -> D:  # type: ignore
         """Get the type data."""
         # pylint: disable=E1101
         return self._get_data_type(self.__orig_bases__[0].__args__[1])  # type: ignore

--- a/openbb_sdk/sdk/provider/openbb_provider/abstract/fetcher.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/abstract/fetcher.py
@@ -2,8 +2,8 @@
 
 
 from typing import Any, Dict, Generic, Optional, TypeVar, get_args, get_origin
-from openbb_provider.abstract.data import Data
 
+from openbb_provider.abstract.data import Data
 from openbb_provider.abstract.query_params import QueryParams
 
 Q = TypeVar("Q", bound=QueryParams)

--- a/openbb_sdk/sdk/provider/openbb_provider/abstract/fetcher.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/abstract/fetcher.py
@@ -2,11 +2,12 @@
 
 
 from typing import Any, Dict, Generic, Optional, TypeVar, get_args, get_origin
+from openbb_provider.abstract.data import Data
 
 from openbb_provider.abstract.query_params import QueryParams
 
 Q = TypeVar("Q", bound=QueryParams)
-D = TypeVar("D")  # Data
+D = TypeVar("D", bound=Data)
 R = TypeVar("R")  # Return, usually List[D], but can be just D for example
 
 

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -140,6 +140,6 @@ class RegistryMap:
     def validate_model(model: Any, type_: Literal["query_params", "data"]):
         if not isclass(model) or not issubclass(model, BaseModel):
             raise ValueError(
-                f"'{str(model)}' must be a subclass of 'BaseModel'."
-                f" Try specifying `{type_}_type` in the fetcher."
+                f"'{str(model)}' must be a subclass of 'BaseModel'.\n"
+                f"Try specifying `{type_}_type = <'your_data_type'>` in the fetcher."
             )

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -100,7 +100,7 @@ class RegistryMap:
         """Extract info (fields and docstring) from fetcher query params or data."""
         super_model = getattr(fetcher, f"{type_}_type")
 
-        RegistryMap.validate_model(super_model)
+        RegistryMap.validate_model(super_model, type_)
 
         skip_classes = {"object", "Representation", "BaseModel", "QueryParams", "Data"}
         inheritance_list = [
@@ -137,9 +137,9 @@ class RegistryMap:
         return getattr(fetcher, "return_type", None)
 
     @staticmethod
-    def validate_model(model: Any):
+    def validate_model(model: Any, type_: Literal["query_params", "data"]):
         if not isclass(model) or not issubclass(model, BaseModel):
             raise ValueError(
                 f"'{str(model)}' must be a subclass of 'BaseModel'."
-                " Try specifying `query_params_type` or `data_type` in the fetcher."
+                f" Try specifying `{type_}_type` in the fetcher."
             )

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -4,9 +4,9 @@ import os
 from inspect import getfile, isclass
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
-from pydantic import BaseModel
-
+from openbb_provider.abstract.data import Data
 from openbb_provider.abstract.fetcher import Fetcher
+from openbb_provider.abstract.query_params import QueryParams
 from openbb_provider.registry import Registry, RegistryLoader
 
 MapType = Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]
@@ -138,7 +138,8 @@ class RegistryMap:
 
     @staticmethod
     def validate_model(model: Any, type_: Literal["query_params", "data"]):
-        if not isclass(model) or not issubclass(model, BaseModel):
+        parent_model = QueryParams if type_ == "query_params" else Data
+        if not isclass(model) or not issubclass(model, parent_model):
             raise ValueError(
                 f"'{str(model)}' must be a subclass of 'BaseModel'.\n"
                 f"Try specifying `{type_}_type = <'your_{type_}_type'>` in the fetcher."

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -141,6 +141,6 @@ class RegistryMap:
         parent_model = QueryParams if type_ == "query_params" else Data
         if not isclass(model) or not issubclass(model, parent_model):
             raise ValueError(
-                f"'{str(model)}' must be a subclass of 'BaseModel'.\n"
+                f"'{str(model)}' must be a subclass of '{parent_model.__name__}'.\n"
                 f"Try specifying `{type_}_type = <'your_{type_}_type'>` in the fetcher."
             )

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -140,7 +140,9 @@ class RegistryMap:
     def validate_model(model: Any, type_: Literal["query_params", "data"]):
         parent_model = QueryParams if type_ == "query_params" else Data
         if not isclass(model) or not issubclass(model, parent_model):
+            model_str = str(model)
+            model_str = model_str.replace("<", "<'").replace(">", "'>")
             raise ValueError(
-                f"'{str(model)}' must be a subclass of '{parent_model.__name__}'.\n"
+                f"'{model_str}' must be a subclass of '{parent_model.__name__}'.\n"
                 f"Try specifying `{type_}_type = <'your_{type_}_type'>` in the fetcher."
             )

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -140,8 +140,7 @@ class RegistryMap:
     def validate_model(model: Any, type_: Literal["query_params", "data"]):
         parent_model = QueryParams if type_ == "query_params" else Data
         if not isclass(model) or not issubclass(model, parent_model):
-            model_str = str(model)
-            model_str = model_str.replace("<", "<'").replace(">", "'>")
+            model_str = str(model).replace("<", "<'").replace(">", "'>")
             raise ValueError(
                 f"'{model_str}' must be a subclass of '{parent_model.__name__}'.\n"
                 f"Try specifying `{type_}_type = <'your_{type_}_type'>` in the fetcher."

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -143,5 +143,6 @@ class RegistryMap:
             model_str = str(model).replace("<", "<'").replace(">", "'>")
             raise ValueError(
                 f"'{model_str}' must be a subclass of '{parent_model.__name__}'.\n"
-                f"Try specifying `{type_}_type = <'your_{type_}_type'>` in the fetcher."
+                "If you are returning a nested type, try specifying"
+                f" `{type_}_type = <'your_{type_}_type'>` in the fetcher."
             )

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -70,10 +70,9 @@ class RegistryMap:
 
         for p in registry.providers:
             for model_name, fetcher in registry.providers[p].fetcher_dict.items():
-                f = fetcher()
-                standard_query, extra_query = self.extract_info(f, "query_params")
-                standard_data, extra_data = self.extract_info(f, "data")
-                return_type = self.extract_return_type(f)
+                standard_query, extra_query = self.extract_info(fetcher, "query_params")
+                standard_data, extra_data = self.extract_info(fetcher, "data")
+                return_type = self.extract_return_type(fetcher)
 
                 if model_name not in map_:
                     map_[model_name] = {}
@@ -97,7 +96,7 @@ class RegistryMap:
     @staticmethod
     def extract_info(fetcher: Fetcher, type_: Literal["query_params", "data"]) -> tuple:
         """Extract info (fields and docstring) from fetcher query params or data."""
-        super_model = getattr(fetcher, type_)
+        super_model = getattr(fetcher, f"{type_}_type")
 
         skip_classes = {"object", "Representation", "BaseModel", "QueryParams", "Data"}
         inheritance_list = [

--- a/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
+++ b/openbb_sdk/sdk/provider/openbb_provider/registry_map.py
@@ -141,5 +141,5 @@ class RegistryMap:
         if not isclass(model) or not issubclass(model, BaseModel):
             raise ValueError(
                 f"'{str(model)}' must be a subclass of 'BaseModel'.\n"
-                f"Try specifying `{type_}_type = <'your_data_type'>` in the fetcher."
+                f"Try specifying `{type_}_type = <'your_{type_}_type'>` in the fetcher."
             )


### PR DESCRIPTION
If the developer wants to return nested return types, it should be set as a property in the fetcher `data_type` so that we don't fail to infer the data type from the second generic argument.

Usually this should not be needed, but is a more reliable way to get the data type and helps fix mypy errors.