### PR TITLE
Fix/provider-bugs-intrinio: fix bad API key response for options symbols

### DIFF
--- a/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
+++ b/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
@@ -37,213 +37,13 @@ intrinio_session = requests_cache.CachedSession(
 )
 
 
-def get_options_tickers(api_key: str) -> List[str]:
-    """Returns all tickers that have existing options contracts.
-
-    Parameters
-    ----------
-    api_key: str
-        Intrinio API key.
-
-    Returns
-    -------
-    List[str]
-        List of tickers
-    """
-
-    url = f"https://api-v2.intrinio.com/options/tickers?api_key={api_key}"
-
-    r = intrinio_session.get(url, timeout=10)
-
-    if r.status_code != 200:
-        raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
-
-    return r.json()["tickers"]
-
-
-def get_options_expirations(
-    symbol: str,
-    api_key: str,
-    after: Optional[Union[datetime, str]] = datetime.now().strftime("%Y-%m-%d"),
-    before: Optional[str] = "",
-) -> List:
-    """Returns a list of all current and upcoming option contract expiration dates for a particular symbol.
-
-    Parameters
-    ----------
-    symbol: str
-        The options symbol, corresponding to the underlying security.
-    api_key: str
-        Intrinio API key.
-    after: str
-        Return option contract expiration dates after this date. Format: YYYY-MM-DD
-    before: str
-        Return option contract expiration dates before this date. Format: YYYY-MM-DD
-    """
-
-    url = f"https://api-v2.intrinio.com/options/expirations/{symbol}/eod?before={before}&after={after}&api_key={api_key}"
-
-    r = make_request(url)
-
-    if r.status_code != 200:
-        raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
-
-    expirations = pd.DatetimeIndex(sorted(list(r.json()["expirations"])))
-    return list(filter(lambda x: x > pd.to_datetime(after), expirations))
-
-
-def generate_url(symbol, expiration, date, api_key):
-    return f"https://api-v2.intrinio.com/options/chain/{symbol}/{expiration}/eod?date={date}&api_key={api_key}"
-
-
-def download_json_files(urls):
-    results = []  # List to store the downloaded JSON data
-
-    def download_single_file(url):
-        response = make_request(url)
-        json_data = response.json()
-        results.append(json_data["chain"])
-
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(download_single_file, urls)
-
-    return results
-
-
-def get_historical_chain_with_greeks(
-    symbol: str, date: Optional[Union[str, dateType]] = "", api_key: str = ""
-):
-    symbol = symbol.upper()
-    SYMBOLS = get_options_tickers(api_key)
-    if symbol not in SYMBOLS:
-        raise RuntimeError(f"{symbol}", "is not supported by Intrinio.")
-
-    if not date:
-        date = datetime.now().strftime("%Y-%m-%d")
-
-    # If the symbol is an index, it needs to be preceded with, $.
-    if symbol in TICKER_EXCEPTIONS:
-        symbol = "$" + symbol
-
-    expirations = get_options_expirations(symbol=symbol, api_key=api_key, after=date)
-    urls = []
-
-    for expiration in expirations:
-        urls.append(generate_url(symbol, expiration, date, api_key))
-
-    results = download_json_files(urls)
-
-    if len(results) == 0:
-        date = pd.to_datetime(date) + timedelta(days=-1)
-        for expiration in expirations:
-            urls.append(generate_url(symbol, expiration, date, api_key))
-        results = download_json_files(urls)
-
-    df = pd.DataFrame()
-
-    for i in range(0, len(results)):
-        chains = results[i]
-
-        contract_symbol: List[str] = []
-        expiry: List[str] = []
-        strikes: List[float] = []
-        option_type: List[str] = []
-        close: List[float] = []
-        close_bid: List[float] = []
-        close_ask: List[float] = []
-        volume: List[int] = []
-        open: List[float] = []
-        open_bid: List[float] = []
-        open_ask: List[float] = []
-        open_interest: List[int] = []
-        high: List[float] = []
-        low: List[float] = []
-        mark: List[float] = []
-        ask_high: List[float] = []
-        ask_low: List[float] = []
-        bid_high: List[float] = []
-        bid_low: List[float] = []
-        implied_volatility: List[float] = []
-        delta: List[float] = []
-        gamma: List[float] = []
-        theta: List[float] = []
-        vega: List[float] = []
-        eod_date: List[str] = []
-
-        for item in chains:
-            contract_symbol.append(item["option"]["code"])
-            expiry.append(item["option"]["expiration"])
-            strikes.append(item["option"]["strike"])
-            option_type.append(item["option"]["type"])
-            close.append(item["prices"]["close"])
-            close_bid.append(item["prices"]["close_bid"])
-            close_ask.append(item["prices"]["close_ask"])
-            volume.append(item["prices"]["volume"])
-            open.append(item["prices"]["open"])
-            open_bid.append(item["prices"]["open_bid"])
-            open_ask.append(item["prices"]["open_ask"])
-            open_interest.append(item["prices"]["open_interest"])
-            high.append(item["prices"]["high"])
-            low.append(item["prices"]["low"])
-            mark.append(item["prices"]["mark"])
-            ask_high.append(item["prices"]["ask_high"])
-            ask_low.append(item["prices"]["ask_low"])
-            bid_high.append(item["prices"]["bid_high"])
-            bid_low.append(item["prices"]["bid_low"])
-            implied_volatility.append(item["prices"]["implied_volatility"])
-            delta.append(item["prices"]["delta"])
-            gamma.append(item["prices"]["gamma"])
-            theta.append(item["prices"]["theta"])
-            vega.append(item["prices"]["vega"])
-            eod_date.append(item["prices"]["date"])
-
-        data = pd.DataFrame()
-        data["contract_symbol"] = contract_symbol
-        data["expiration"] = expiry
-        data["strike"] = strikes
-        data["option_type"] = option_type
-        data["close"] = close
-        data["close_bid"] = close_bid
-        data["close_ask"] = close_ask
-        data["volume"] = volume
-        data["open"] = open
-        data["open_bid"] = open_bid
-        data["open_ask"] = open_ask
-        data["open_interest"] = open_interest
-        data["high"] = high
-        data["low"] = low
-        data["mark"] = mark
-        data["bid_high"] = bid_high
-        data["ask_high"] = ask_high
-        data["bid_low"] = bid_low
-        data["ask_low"] = ask_low
-        data["implied_volatility"] = implied_volatility
-        data["delta"] = delta
-        data["gamma"] = gamma
-        data["theta"] = theta
-        data["vega"] = vega
-        data["eod_date"] = eod_date
-
-        data = data.set_index(["expiration", "strike", "option_type"]).sort_index()
-
-        df = pd.concat([df, data])
-
-    df = df.sort_index().reset_index()
-    now = pd.DatetimeIndex(df["eod_date"])
-    temp = pd.DatetimeIndex(df["expiration"])
-    temp_ = (temp - now).days
-    df["dte"] = temp_
-
-    return df
-
-
 class IntrinioOptionsChainsQueryParams(OptionsChainsQueryParams):
     """Get the complete options chains (Historical) for a ticker from Intrinio.
 
     source: https://docs.intrinio.com/documentation/web_api/get_options_chain_eod_v2
     """
 
-    date: Optional[Union[str, dateType]] = Field(
+    date: Optional[dateType] = Field(
         description="Date for which the options chains are returned.",
         default="",
     )
@@ -309,6 +109,217 @@ class IntrinioOptionsChainsFetcher(
     """Transform the query, extract and transform the data from the Intrinio endpoints"""
 
     @staticmethod
+    def get_options_tickers(api_key: str) -> List[str]:
+        """Returns all tickers that have existing options contracts.
+
+        Parameters
+        ----------
+        api_key: str
+            Intrinio API key.
+
+        Returns
+        -------
+        List[str]
+            List of tickers
+        """
+
+        url = f"https://api-v2.intrinio.com/options/tickers?api_key={api_key}"
+
+        r = intrinio_session.get(url, timeout=10)
+
+        if r.status_code != 200:
+            raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
+
+        return r.json()["tickers"]
+
+    @staticmethod
+    def get_options_expirations(
+        symbol: str,
+        api_key: str,
+        after: Optional[Union[datetime, str]] = datetime.now().strftime("%Y-%m-%d"),
+        before: Optional[str] = "",
+    ) -> List:
+        """Returns a list of all current and upcoming option contract expiration dates for a particular symbol.
+
+        Parameters
+        ----------
+        symbol: str
+            The options symbol, corresponding to the underlying security.
+        api_key: str
+            Intrinio API key.
+        after: str
+            Return option contract expiration dates after this date. Format: YYYY-MM-DD
+        before: str
+            Return option contract expiration dates before this date. Format: YYYY-MM-DD
+        """
+
+        url = f"https://api-v2.intrinio.com/options/expirations/{symbol}/eod?before={before}&after={after}&api_key={api_key}"
+
+        r = make_request(url)
+
+        if r.status_code != 200:
+            raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
+
+        expirations = pd.DatetimeIndex(sorted(list(r.json()["expirations"])))
+        return list(filter(lambda x: x > pd.to_datetime(after), expirations))
+
+    @staticmethod
+    def generate_url(symbol, expiration, date, api_key):
+        return f"https://api-v2.intrinio.com/options/chain/{symbol}/{expiration}/eod?date={date}&api_key={api_key}"
+
+    @staticmethod
+    def download_json_files(urls):
+        results = []  # List to store the downloaded JSON data
+
+        def download_single_file(url):
+            response = make_request(url)
+            json_data = response.json()
+            results.append(json_data["chain"])
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            executor.map(download_single_file, urls)
+
+        return results
+
+    @staticmethod
+    def get_historical_chain_with_greeks(
+        symbol: str, date: Optional[Union[str, dateType]] = "", api_key: str = ""
+    ):
+        symbol = symbol.upper()
+        SYMBOLS = IntrinioOptionsChainsFetcher.get_options_tickers(api_key)
+        if symbol not in SYMBOLS:
+            raise RuntimeError(f"{symbol}", "is not supported by Intrinio.")
+
+        if not date:
+            date = datetime.now().strftime("%Y-%m-%d")
+
+        # If the symbol is an index, it needs to be preceded with, $.
+        if symbol in TICKER_EXCEPTIONS:
+            symbol = "$" + symbol
+
+        expirations = IntrinioOptionsChainsFetcher.get_options_expirations(
+            symbol=symbol, api_key=api_key, after=date
+        )
+        urls = []
+
+        for expiration in expirations:
+            urls.append(
+                IntrinioOptionsChainsFetcher.generate_url(
+                    symbol, expiration, date, api_key
+                )
+            )
+
+        results = IntrinioOptionsChainsFetcher.download_json_files(urls)
+
+        # Error handling for when data from the current date is not available yet.
+        if len(results) == 0:
+            date = pd.to_datetime(date) + timedelta(days=-1)
+            for expiration in expirations:
+                urls.append(
+                    IntrinioOptionsChainsFetcher.generate_url(
+                        symbol, expiration, date, api_key
+                    )
+                )
+            results = IntrinioOptionsChainsFetcher.download_json_files(urls)
+
+        df = pd.DataFrame()
+
+        for i in range(0, len(results)):
+            chains = results[i]
+
+            contract_symbol: List[str] = []
+            expiry: List[str] = []
+            strikes: List[float] = []
+            option_type: List[str] = []
+            close: List[float] = []
+            close_bid: List[float] = []
+            close_ask: List[float] = []
+            volume: List[int] = []
+            open: List[float] = []
+            open_bid: List[float] = []
+            open_ask: List[float] = []
+            open_interest: List[int] = []
+            high: List[float] = []
+            low: List[float] = []
+            mark: List[float] = []
+            ask_high: List[float] = []
+            ask_low: List[float] = []
+            bid_high: List[float] = []
+            bid_low: List[float] = []
+            implied_volatility: List[float] = []
+            delta: List[float] = []
+            gamma: List[float] = []
+            theta: List[float] = []
+            vega: List[float] = []
+            eod_date: List[str] = []
+
+            for item in chains:
+                contract_symbol.append(item["option"]["code"])
+                expiry.append(item["option"]["expiration"])
+                strikes.append(item["option"]["strike"])
+                option_type.append(item["option"]["type"])
+                close.append(item["prices"]["close"])
+                close_bid.append(item["prices"]["close_bid"])
+                close_ask.append(item["prices"]["close_ask"])
+                volume.append(item["prices"]["volume"])
+                open.append(item["prices"]["open"])
+                open_bid.append(item["prices"]["open_bid"])
+                open_ask.append(item["prices"]["open_ask"])
+                open_interest.append(item["prices"]["open_interest"])
+                high.append(item["prices"]["high"])
+                low.append(item["prices"]["low"])
+                mark.append(item["prices"]["mark"])
+                ask_high.append(item["prices"]["ask_high"])
+                ask_low.append(item["prices"]["ask_low"])
+                bid_high.append(item["prices"]["bid_high"])
+                bid_low.append(item["prices"]["bid_low"])
+                implied_volatility.append(item["prices"]["implied_volatility"])
+                delta.append(item["prices"]["delta"])
+                gamma.append(item["prices"]["gamma"])
+                theta.append(item["prices"]["theta"])
+                vega.append(item["prices"]["vega"])
+                eod_date.append(item["prices"]["date"])
+
+            data = pd.DataFrame()
+            data["contract_symbol"] = contract_symbol
+            data["expiration"] = expiry
+            data["strike"] = strikes
+            data["option_type"] = option_type
+            data["close"] = close
+            data["close_bid"] = close_bid
+            data["close_ask"] = close_ask
+            data["volume"] = volume
+            data["open"] = open
+            data["open_bid"] = open_bid
+            data["open_ask"] = open_ask
+            data["open_interest"] = open_interest
+            data["high"] = high
+            data["low"] = low
+            data["mark"] = mark
+            data["bid_high"] = bid_high
+            data["ask_high"] = ask_high
+            data["bid_low"] = bid_low
+            data["ask_low"] = ask_low
+            data["implied_volatility"] = implied_volatility
+            data["delta"] = delta
+            data["gamma"] = gamma
+            data["theta"] = theta
+            data["vega"] = vega
+            data["eod_date"] = eod_date
+
+            data = data.set_index(["expiration", "strike", "option_type"]).sort_index()
+
+            df = pd.concat([df, data])
+
+        df = df.sort_index().reset_index()
+        now = pd.DatetimeIndex(df["eod_date"])
+        temp = pd.DatetimeIndex(df["expiration"])
+        temp_ = (temp - now).days
+        df["dte"] = temp_
+
+        return df
+
+    @staticmethod
     def transform_query(params: Dict[str, Any]) -> IntrinioOptionsChainsQueryParams:
         """Transform the query"""
         return IntrinioOptionsChainsQueryParams(**params)
@@ -322,7 +333,7 @@ class IntrinioOptionsChainsFetcher(
         """Return the raw data from the Intrinio endpoint."""
 
         api_key = credentials.get("intrinio_api_key") if credentials else ""
-        data = get_historical_chain_with_greeks(
+        data = IntrinioOptionsChainsFetcher.get_historical_chain_with_greeks(
             symbol=query.symbol, date=query.date, api_key=api_key  # type: ignore
         )
 

--- a/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
+++ b/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
@@ -62,10 +62,10 @@ class IntrinioOptionsChainsData(OptionsChainsData):
         description="The mid-price between the latest bid-ask spread."
     )
     open_bid: Optional[float] = Field(
-        description="The lowest bid price for the option that day."
+        description="The opening bid price for the option that day."
     )
     open_ask: Optional[float] = Field(
-        description="The lowest ask price for the option that day."
+        description="The opening ask price for the option that day."
     )
     bid_low: Optional[float] = Field(
         description="The lowest bid price for the option that day."

--- a/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
+++ b/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
@@ -55,6 +55,9 @@ def get_options_tickers(api_key: str) -> List[str]:
 
     r = intrinio_session.get(url, timeout=10)
 
+    if r.status_code != 200:
+        raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
+
     return r.json()["tickers"]
 
 
@@ -63,7 +66,7 @@ def get_options_expirations(
     api_key: str,
     after: Optional[Union[datetime, str]] = datetime.now().strftime("%Y-%m-%d"),
     before: Optional[str] = "",
-) -> list:
+) -> List:
     """Returns a list of all current and upcoming option contract expiration dates for a particular symbol.
 
     Parameters
@@ -81,6 +84,9 @@ def get_options_expirations(
     url = f"https://api-v2.intrinio.com/options/expirations/{symbol}/eod?before={before}&after={after}&api_key={api_key}"
 
     r = make_request(url)
+
+    if r.status_code != 200:
+        raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
 
     expirations = pd.DatetimeIndex(sorted(list(r.json()["expirations"])))
     return list(filter(lambda x: x > pd.to_datetime(after), expirations))
@@ -225,7 +231,7 @@ def get_historical_chain_with_greeks(
     df = df.sort_index().reset_index()
     now = pd.DatetimeIndex(df["eod_date"])
     temp = pd.DatetimeIndex(df["expiration"])
-    temp_ = (temp - now).days + 1
+    temp_ = (temp - now).days
     df["dte"] = temp_
 
     return df

--- a/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
+++ b/openbb_sdk/providers/intrinio/openbb_intrinio/models/options_chains.py
@@ -153,8 +153,10 @@ class IntrinioOptionsChainsFetcher(
             Return option contract expiration dates before this date. Format: YYYY-MM-DD
         """
 
-        url = f"https://api-v2.intrinio.com/options/expirations/{symbol}/eod?before={before}&after={after}&api_key={api_key}"
-
+        url = (
+            f"https://api-v2.intrinio.com/options/expirations/{symbol}/"
+            f"eod?before={before}&after={after}&api_key={api_key}"
+        )
         r = make_request(url)
 
         if r.status_code != 200:

--- a/openbb_sdk/providers/intrinio/openbb_intrinio/utils/helpers.py
+++ b/openbb_sdk/providers/intrinio/openbb_intrinio/utils/helpers.py
@@ -1,10 +1,13 @@
 """Intrinio Helpers Module."""
 
 import json
+from datetime import datetime, timedelta
 from io import StringIO
 from typing import Any, List, Optional, TypeVar, Union
 
+import pandas as pd
 import requests
+import requests_cache
 from openbb_provider import helpers
 from pydantic import BaseModel
 from requests.exceptions import SSLError
@@ -113,3 +116,68 @@ def get_data_one(url: str, **kwargs: Any) -> dict:
             raise ValueError("Expected dict, got list of dicts") from e
 
     return data
+
+
+class Options:
+    """Intrinio Options Helper Class."""
+
+    intrinio_session = requests_cache.CachedSession(
+        "OpenBB_Intrinio", expire_after=timedelta(days=5), use_cache_dir=True
+    )
+
+    @staticmethod
+    def get_options_tickers(api_key: str) -> List[str]:
+        """Returns all tickers that have existing options contracts.
+
+        Parameters
+        ----------
+        api_key: str
+            Intrinio API key.
+
+        Returns
+        -------
+        List[str]
+            List of tickers
+        """
+
+        url = f"https://api-v2.intrinio.com/options/tickers?api_key={api_key}"
+
+        r = Options.intrinio_session.get(url, timeout=10)
+
+        if r.status_code != 200:
+            raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
+
+        return r.json()["tickers"]
+
+    @staticmethod
+    def get_options_expirations(
+        symbol: str,
+        api_key: str,
+        after: Optional[Union[datetime, str]] = datetime.now().strftime("%Y-%m-%d"),
+        before: Optional[str] = "",
+    ) -> List:
+        """Returns a list of all current and upcoming option contract expiration dates for a particular symbol.
+
+        Parameters
+        ----------
+        symbol: str
+            The options symbol, corresponding to the underlying security.
+        api_key: str
+            Intrinio API key.
+        after: str
+            Return option contract expiration dates after this date. Format: YYYY-MM-DD
+        before: str
+            Return option contract expiration dates before this date. Format: YYYY-MM-DD
+        """
+
+        url = (
+            f"https://api-v2.intrinio.com/options/expirations/{symbol}/"
+            f"eod?before={before}&after={after}&api_key={api_key}"
+        )
+        r = helpers.make_request(url)
+
+        if r.status_code != 200:
+            raise RuntimeError("HTTP Error -> Status Code: " + str(r.status_code))
+
+        expirations = pd.DatetimeIndex(sorted(list(r.json()["expirations"])))
+        return list(filter(lambda x: x > pd.to_datetime(after), expirations))

--- a/openbb_sdk/providers/intrinio/openbb_intrinio/utils/helpers.py
+++ b/openbb_sdk/providers/intrinio/openbb_intrinio/utils/helpers.py
@@ -1,71 +1,15 @@
 """Intrinio Helpers Module."""
 
 import json
-from datetime import datetime, timedelta
 from io import StringIO
 from typing import Any, List, Optional, TypeVar, Union
 
 import requests
-import requests_cache
 from openbb_provider import helpers
-from openbb_provider.utils.helpers import make_request
 from pydantic import BaseModel
 from requests.exceptions import SSLError
 
 T = TypeVar("T", bound=BaseModel)
-
-
-# This will cache the symbol directory requests for 5 days.
-intrinio_session = requests_cache.CachedSession(
-    "OpenBB_Intrinio", expire_after=timedelta(days=5), use_cache_dir=True
-)
-
-
-def get_options_tickers(api_key: str = "") -> List[str]:
-    """Returns all tickers that have existing options contracts.
-
-    Parameters
-    ----------
-    api_key: str
-        Intrinio API key.
-
-    Returns
-    -------
-    List[str]
-        List of tickers
-    """
-    url = f"https://api-v2.intrinio.com/options/tickers?api_key={api_key}"
-
-    r = intrinio_session.get(url, timeout=10)
-
-    return r.json()["tickers"]
-
-
-def get_options_expirations(
-    symbol: str,
-    after: Optional[str] = datetime.now().date().strftime("%Y-%m-%d"),
-    before: Optional[str] = "",
-    api_key: str = "",
-) -> list:
-    """Returns a list of all current and upcoming option contract expiration dates for a particular symbol.
-
-    Parameters
-    ----------
-    symbol: str
-        The options symbol, corresponding to the underlying security.
-    after: str
-        Return option contract expiration dates after this date. Format: YYYY-MM-DD
-    before: str
-        Return option contract expiration dates before this date. Format: YYYY-MM-DD
-    api_key: str
-        Intrinio API key.
-    """
-
-    url = f"https://api-v2.intrinio.com/options/expirations/{symbol}/eod?before={before}&after={after}&api_key={api_key}"
-
-    r = make_request(url)
-
-    return sorted(list(r.json()["expirations"]))
 
 
 class BasicResponse:


### PR DESCRIPTION
Two small fixes:

- Bad API key response for querying symbol directory
- Correct DTE calculation because `now` is within the `date` field, +1 is for when `now` == datetime.now()

Then removes the functions in `helpers` that were moved from `helpers` to `options_chains`