### PR TITLE
Allow user to set what do they want the data format to be by default

### DIFF
--- a/openbb_sdk/sdk/core/openbb_core/app/command_runner.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/command_runner.py
@@ -2,6 +2,7 @@ import warnings
 from contextlib import nullcontext
 from copy import deepcopy
 from datetime import datetime
+import pandas as pd
 from inspect import Parameter, signature
 from sys import exc_info
 from time import perf_counter_ns
@@ -345,7 +346,7 @@ class StaticCommandRunner:
         /,
         *args,
         **kwargs,
-    ) -> OBBject:
+    ) -> Union[OBBject, Dict, pd.DataFrame]:
         timestamp = datetime.now()
         start_ns = perf_counter_ns()
 
@@ -372,6 +373,13 @@ class StaticCommandRunner:
                 "route": route,
                 "timestamp": timestamp,
             }
+
+        # Based on user configuration for data output
+        # we return the data in the desired format
+        if execution_context.user_settings.preferences.data_output == "df":
+            return obbject.to_dataframe()
+        if execution_context.user_settings.preferences.data_output == "dict":
+            return obbject.to_dict()
 
         return obbject
 

--- a/openbb_sdk/sdk/core/openbb_core/app/model/preferences.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/model/preferences.py
@@ -19,6 +19,7 @@ class Preferences(BaseModel):
     table_style: Literal["dark", "light"] = "dark"
     request_timeout: PositiveInt = 15
     metadata: bool = True
+    data_output: Literal["OBBject", "df", "dict"] = "df"
 
     class Config:
         validate_assignment = True


### PR DESCRIPTION
As a user, if I'm doing a research on a jupyter notebook is annoying to have to do `to_dataframe()` every single time.

There's a high chance that whichever data output a user is looking for will remain the same within that same notebook / app, hence, this PR introduces a setting that allows the user to set what data type they are interested in having as default.

I just did DataFrame and Dict as an example. 

If everyone is happy with this solution we can then integrate the others: polars, numpy, ...

CC: @the-praxs thanks for the instructions on how to point to the local lib 👊

<img width="1348" alt="Screenshot 2023-09-09 at 2 24 12 AM" src="https://github.com/OpenBB-finance/OpenBBTerminal/assets/25267873/587322d9-ddf4-4d4b-a138-f2f7917e1fa8">

