### PR TITLE
Print message if yahoo finance load fails

### DIFF
--- a/openbb_terminal/stocks/stocks_helper.py
+++ b/openbb_terminal/stocks/stocks_helper.py
@@ -411,6 +411,7 @@ def load(
 
             # Check that loading a stock was not successful
             if df_stock_candidate.empty:
+                console.print("[red]No results found in yahoo finance reply.[/red]")
                 return pd.DataFrame()
 
             df_stock_candidate.index = pd.to_datetime(

--- a/openbb_terminal/stocks/stocks_model.py
+++ b/openbb_terminal/stocks/stocks_model.py
@@ -182,6 +182,7 @@ def load_stock_yf(
 
     # Check that loading a stock was not successful
     if df_stock_candidate.empty:
+        console.print("[red]No results found in yahoo finance reply.[/red]")
         return pd.DataFrame()
     df_stock_candidate_cols = [
         "Open",


### PR DESCRIPTION
Fixes #5392

Currently, in the /stocks/load command, if yahoo finance does not find data it doesn't print any indication to the user.


This PR adds a message if yahoo finance does not find data：

![Screenshot 2023-09-19 at 2 43 11 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/68739569/f4f62a64-26f4-41ac-a19d-5f7803b990f4)
