### PR TITLE
Hotfix/fix-quandl-regression

### DIFF
--- a/openbb_sdk/providers/quandl/openbb_quandl/models/cot_search.py
+++ b/openbb_sdk/providers/quandl/openbb_quandl/models/cot_search.py
@@ -22,7 +22,7 @@ class QuandlCotSearchData(CotSearchData):
     """Quandl CFTC Commitment of Traders Reports Search data."""
 
 
-class QuandlCotSearchFetcher(Fetcher[CotSearchQueryParams, QuandlCotSearchData]):
+class QuandlCotSearchFetcher(Fetcher[CotSearchQueryParams, List[QuandlCotSearchData]]):
     """Quandl CFTC Commitment of Traders Reports Search Fetcher."""
 
     @staticmethod

--- a/openbb_sdk/providers/quandl/openbb_quandl/models/cot_search.py
+++ b/openbb_sdk/providers/quandl/openbb_quandl/models/cot_search.py
@@ -54,4 +54,4 @@ class QuandlCotSearchFetcher(Fetcher[CotSearchQueryParams, QuandlCotSearchData])
     def transform_data(
         data: List[Dict],
     ) -> QuandlCotSearchData:
-        return QuandlCotSearchData.parse_obj(data[0])
+        return [QuandlCotSearchData(**d) for d in data]

--- a/openbb_sdk/providers/quandl/openbb_quandl/models/cot_search.py
+++ b/openbb_sdk/providers/quandl/openbb_quandl/models/cot_search.py
@@ -53,5 +53,5 @@ class QuandlCotSearchFetcher(Fetcher[CotSearchQueryParams, QuandlCotSearchData])
     @staticmethod
     def transform_data(
         data: List[Dict],
-    ) -> QuandlCotSearchData:
+    ) -> List[QuandlCotSearchData]:
         return [QuandlCotSearchData(**d) for d in data]


### PR DESCRIPTION
`cot_search()` was edited to return only the first item in the list or results instead of the entire list.  This fixes that regression.