### PR TITLE
Feature/integration marker

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 test_locations = [
     "openbb_sdk/tests",
-    "openbb_sdk/sdk/core/tests",
+    "openbb_sdk/sdk",
     "openbb_sdk/providers",
 ]
 

--- a/openbb_sdk/extensions/crypto/integration/test_crypto_api.py
+++ b/openbb_sdk/extensions/crypto/integration/test_crypto_api.py
@@ -87,6 +87,7 @@ def headers():
         ),
     ],
 )
+@pytest.mark.integration
 def test_crypto_load(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/crypto/integration/test_crypto_python.py
+++ b/openbb_sdk/extensions/crypto/integration/test_crypto_python.py
@@ -81,6 +81,7 @@ from openbb_core.app.model.obbject import OBBject
         ),
     ],
 )
+@pytest.mark.integration
 def test_crypto_load(params):
     result = obb.crypto.load(**params)
     assert result

--- a/openbb_sdk/extensions/econometrics/integration/test_econometrics_api.py
+++ b/openbb_sdk/extensions/econometrics/integration/test_econometrics_api.py
@@ -21,6 +21,7 @@ def headers():
     "params",
     [({"data": ""})],
 )
+@pytest.mark.integration
 def test_econometrics_corr(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -35,6 +36,7 @@ def test_econometrics_corr(params, headers):
     "params",
     [({"data": "", "y_column": "", "x_columns": ""})],
 )
+@pytest.mark.integration
 def test_econometrics_ols_summary(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -49,6 +51,7 @@ def test_econometrics_ols_summary(params, headers):
     "params",
     [({"data": "", "y_column": "", "x_columns": ""})],
 )
+@pytest.mark.integration
 def test_econometrics_dwat(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -63,6 +66,7 @@ def test_econometrics_dwat(params, headers):
     "params",
     [({"data": "", "y_column": "", "x_columns": "", "lags": ""})],
 )
+@pytest.mark.integration
 def test_econometrics_bgot(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -77,6 +81,7 @@ def test_econometrics_bgot(params, headers):
     "params",
     [({"data": "", "columns": ""})],
 )
+@pytest.mark.integration
 def test_econometrics_coint(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -91,6 +96,7 @@ def test_econometrics_coint(params, headers):
     "params",
     [({"data": "", "y_column": "", "x_column": "", "lag": ""})],
 )
+@pytest.mark.integration
 def test_econometrics_granger(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -105,6 +111,7 @@ def test_econometrics_granger(params, headers):
     "params",
     [({"data": "", "column": "", "regression": ""})],
 )
+@pytest.mark.integration
 def test_econometrics_unitroot(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/economy/integration/test_economy_api.py
+++ b/openbb_sdk/extensions/economy/integration/test_economy_api.py
@@ -21,6 +21,7 @@ def headers():
     "params",
     [({"index": "dowjones"})],
 )
+@pytest.mark.integration
 def test_economy_const(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -46,6 +47,7 @@ def test_economy_const(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_economy_cpi(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -148,6 +150,7 @@ def test_economy_cpi(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_index(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -182,6 +185,7 @@ def test_economy_index(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_european_index(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -196,6 +200,7 @@ def test_economy_european_index(params, headers):
     "params",
     [({"symbol": "BUKBUS"})],
 )
+@pytest.mark.integration
 def test_economy_european_index_constituents(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -210,6 +215,7 @@ def test_economy_european_index_constituents(params, headers):
     "params",
     [({}), ({"europe": True, "provider": "cboe"})],
 )
+@pytest.mark.integration
 def test_economy_available_indices(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -224,6 +230,7 @@ def test_economy_available_indices(params, headers):
     "params",
     [({})],
 )
+@pytest.mark.integration
 def test_economy_risk(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -248,6 +255,7 @@ def test_economy_risk(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_index_search(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -262,6 +270,7 @@ def test_economy_index_search(params, headers):
     "params",
     [({"region": "US"})],
 )
+@pytest.mark.integration
 def test_economy_index_snapshots(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -276,6 +285,7 @@ def test_economy_index_snapshots(params, headers):
     "params",
     [({"query": "grain"})],
 )
+@pytest.mark.integration
 def test_economy_cot_search(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -305,6 +315,7 @@ def test_economy_cot_search(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_cot(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -329,6 +340,7 @@ def test_economy_cot(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_economy_sp500_multiples(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/economy/integration/test_economy_python.py
+++ b/openbb_sdk/extensions/economy/integration/test_economy_python.py
@@ -11,6 +11,7 @@ from openbb_core.app.model.obbject import OBBject
         ({"index": "dowjones"}),
     ],
 )
+@pytest.mark.integration
 def test_economy_const(params):
     result = obb.economy.const(**params)
     assert result
@@ -33,6 +34,7 @@ def test_economy_const(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_cpi(params):
     result = obb.economy.cpi(**params)
     assert result
@@ -138,6 +140,7 @@ def test_economy_cpi(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_index(params):
     result = obb.economy.index(**params)
     assert result
@@ -175,6 +178,7 @@ def test_economy_index(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_european_index(params):
     result = obb.economy.european_index(**params)
     assert result
@@ -188,6 +192,7 @@ def test_economy_european_index(params):
         ({"symbol": "BUKBUS"}),
     ],
 )
+@pytest.mark.integration
 def test_economy_european_index_constituents(params):
     result = obb.economy.european_index_constituents(**params)
     assert result
@@ -202,6 +207,7 @@ def test_economy_european_index_constituents(params):
         ({"europe": True, "provider": "cboe"}),
     ],
 )
+@pytest.mark.integration
 def test_economy_available_indices(params):
     result = obb.economy.available_indices(**params)
     assert result
@@ -215,6 +221,7 @@ def test_economy_available_indices(params):
         ({}),
     ],
 )
+@pytest.mark.integration
 def test_economy_risk(params):
     result = obb.economy.risk(**params)
     assert result
@@ -236,6 +243,7 @@ def test_economy_risk(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_index_search(params):
     result = obb.economy.index_search(**params)
     assert result
@@ -249,6 +257,7 @@ def test_economy_index_search(params):
         ({"region": "US"}),
     ],
 )
+@pytest.mark.integration
 def test_economy_index_snapshots(params):
     result = obb.economy.index_snapshots(**params)
     assert result
@@ -262,6 +271,7 @@ def test_economy_index_snapshots(params):
         ({"query": "grain"}),
     ],
 )
+@pytest.mark.integration
 def test_economy_cot_search(params):
     result = obb.economy.cot_search(**params)
     assert result
@@ -288,6 +298,7 @@ def test_economy_cot_search(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_cot(params):
     result = obb.economy.cot(**params)
     assert result
@@ -309,6 +320,7 @@ def test_economy_cot(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_economy_sp500_multiples(params):
     result = obb.economy.sp500_multiples(**params)
     assert result

--- a/openbb_sdk/extensions/fixedincome/integration/test_fixedincome_api.py
+++ b/openbb_sdk/extensions/fixedincome/integration/test_fixedincome_api.py
@@ -21,6 +21,7 @@ def headers():
     "params",
     [({"start_date": "2023-01-01", "end_date": "2023-06-06"})],
 )
+@pytest.mark.integration
 def test_fixedincome_treasury(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -35,6 +36,7 @@ def test_fixedincome_treasury(params, headers):
     "params",
     [({"date": "2023-01-01", "inflation_adjusted": True})],
 )
+@pytest.mark.integration
 def test_fixedincome_ycrv(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -59,6 +61,7 @@ def test_fixedincome_ycrv(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_sofr(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -83,6 +86,7 @@ def test_fixedincome_sofr(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_estr(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -107,6 +111,7 @@ def test_fixedincome_estr(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_sonia(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -131,6 +136,7 @@ def test_fixedincome_sonia(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_ameribor(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -155,6 +161,7 @@ def test_fixedincome_ameribor(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_fed(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -169,6 +176,7 @@ def test_fixedincome_fed(params, headers):
     "params",
     [({}), ({"long_run": True, "provider": "fred"})],
 )
+@pytest.mark.integration
 def test_fixedincome_projections(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -183,6 +191,7 @@ def test_fixedincome_projections(params, headers):
     "params",
     [({"start_date": "2023-01-01", "end_date": "2023-06-06"})],
 )
+@pytest.mark.integration
 def test_fixedincome_iorb(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/fixedincome/integration/test_fixedincome_python.py
+++ b/openbb_sdk/extensions/fixedincome/integration/test_fixedincome_python.py
@@ -10,6 +10,7 @@ from openbb_core.app.model.obbject import OBBject
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_treasury(params):
     result = obb.fixedincome.treasury(**params)
     assert result
@@ -23,6 +24,7 @@ def test_fixedincome_treasury(params):
         ({"date": "2023-01-01", "inflation_adjusted": True}),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_ycrv(params):
     result = obb.fixedincome.ycrv(**params)
     assert result
@@ -44,6 +46,7 @@ def test_fixedincome_ycrv(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_sofr(params):
     result = obb.fixedincome.sofr(**params)
     assert result
@@ -65,6 +68,7 @@ def test_fixedincome_sofr(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_estr(params):
     result = obb.fixedincome.estr(**params)
     assert result
@@ -86,6 +90,7 @@ def test_fixedincome_estr(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_sonia(params):
     result = obb.fixedincome.sonia(**params)
     assert result
@@ -107,6 +112,7 @@ def test_fixedincome_sonia(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_ameribor(params):
     result = obb.fixedincome.ameribor(**params)
     assert result
@@ -128,6 +134,7 @@ def test_fixedincome_ameribor(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_fed(params):
     result = obb.fixedincome.fed(**params)
     assert result
@@ -142,6 +149,7 @@ def test_fixedincome_fed(params):
         ({"long_run": True, "provider": "fred"}),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_projections(params):
     result = obb.fixedincome.projections(**params)
     assert result
@@ -155,6 +163,7 @@ def test_fixedincome_projections(params):
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
     ],
 )
+@pytest.mark.integration
 def test_fixedincome_iorb(params):
     result = obb.fixedincome.iorb(**params)
     assert result

--- a/openbb_sdk/extensions/forex/integration/test_forex_api.py
+++ b/openbb_sdk/extensions/forex/integration/test_forex_api.py
@@ -35,6 +35,7 @@ def headers():
         ),
     ],
 )
+@pytest.mark.integration
 def test_forex_pairs(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -115,6 +116,7 @@ def test_forex_pairs(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_forex_load(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/forex/integration/test_forex_python.py
+++ b/openbb_sdk/extensions/forex/integration/test_forex_python.py
@@ -24,6 +24,7 @@ from openbb_core.app.model.obbject import OBBject
         ),
     ],
 )
+@pytest.mark.integration
 def test_forex_pairs(params):
     result = obb.forex.pairs(**params)
     assert result
@@ -107,6 +108,7 @@ def test_forex_pairs(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_forex_load(params):
     result = obb.forex.load(**params)
     assert result

--- a/openbb_sdk/extensions/futures/integration/test_futures_api.py
+++ b/openbb_sdk/extensions/futures/integration/test_futures_api.py
@@ -44,6 +44,7 @@ def headers():
         ),
     ],
 )
+@pytest.mark.integration
 def test_futures_load(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -58,6 +59,7 @@ def test_futures_load(params, headers):
     "params",
     [({"symbol": "AAPL", "date": "2023-01-01"})],
 )
+@pytest.mark.integration
 def test_futures_curve(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/futures/integration/test_futures_python.py
+++ b/openbb_sdk/extensions/futures/integration/test_futures_python.py
@@ -31,6 +31,7 @@ from openbb_core.app.model.obbject import OBBject
         ),
     ],
 )
+@pytest.mark.integration
 def test_futures_load(params):
     result = obb.futures.load(**params)
     assert result
@@ -44,6 +45,7 @@ def test_futures_load(params):
         ({"symbol": "AAPL", "date": "2023-01-01"}),
     ],
 )
+@pytest.mark.integration
 def test_futures_curve(params):
     result = obb.futures.curve(**params)
     assert result

--- a/openbb_sdk/extensions/news/integration/test_news_api.py
+++ b/openbb_sdk/extensions/news/integration/test_news_api.py
@@ -43,6 +43,7 @@ def headers():
         ),
     ],
 )
+@pytest.mark.integration
 def test_news_globalnews(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/news/integration/test_news_python.py
+++ b/openbb_sdk/extensions/news/integration/test_news_python.py
@@ -31,6 +31,7 @@ from openbb_core.app.model.obbject import OBBject
         ),
     ],
 )
+@pytest.mark.integration
 def test_news_globalnews(params):
     result = obb.news.globalnews(**params)
     assert result

--- a/openbb_sdk/extensions/qa/integration/test_qa_api.py
+++ b/openbb_sdk/extensions/qa/integration/test_qa_api.py
@@ -21,6 +21,7 @@ def headers():
     "params",
     [({"data": "", "target": ""})],
 )
+@pytest.mark.integration
 def test_qa_normality(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -35,6 +36,7 @@ def test_qa_normality(params, headers):
     "params",
     [({"data": "", "target": ""})],
 )
+@pytest.mark.integration
 def test_qa_capm(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -49,6 +51,7 @@ def test_qa_capm(params, headers):
     "params",
     [({"data": "", "target": "", "threshold_start": "", "threshold_end": ""})],
 )
+@pytest.mark.integration
 def test_qa_om(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -63,6 +66,7 @@ def test_qa_om(params, headers):
     "params",
     [({"data": "", "target": "", "window": ""})],
 )
+@pytest.mark.integration
 def test_qa_kurtosis(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -77,6 +81,7 @@ def test_qa_kurtosis(params, headers):
     "params",
     [({"data": "", "target": "", "fuller_reg": "", "kpss_reg": ""})],
 )
+@pytest.mark.integration
 def test_qa_unitroot(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -91,6 +96,7 @@ def test_qa_unitroot(params, headers):
     "params",
     [({"data": "", "target": "", "rfr": "", "window": ""})],
 )
+@pytest.mark.integration
 def test_qa_sh(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -105,6 +111,7 @@ def test_qa_sh(params, headers):
     "params",
     [({"data": "", "target": "", "target_return": "", "window": "", "adjusted": ""})],
 )
+@pytest.mark.integration
 def test_qa_so(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -119,6 +126,7 @@ def test_qa_so(params, headers):
     "params",
     [({"data": "", "target": "", "window": ""})],
 )
+@pytest.mark.integration
 def test_qa_skew(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -133,6 +141,7 @@ def test_qa_skew(params, headers):
     "params",
     [({"data": "", "target": "", "window": "", "quantile_pct": ""})],
 )
+@pytest.mark.integration
 def test_qa_quantile(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -147,6 +156,7 @@ def test_qa_quantile(params, headers):
     "params",
     [({"data": "", "target": ""})],
 )
+@pytest.mark.integration
 def test_qa_summary(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/stocks/integration/test_stocks_api.py
+++ b/openbb_sdk/extensions/stocks/integration/test_stocks_api.py
@@ -47,6 +47,7 @@ def headers():
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_balance(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -61,6 +62,7 @@ def test_stocks_fa_balance(params, headers):
     "params",
     [({"symbol": "AAPL", "limit": 10})],
 )
+@pytest.mark.integration
 def test_stocks_fa_balance_growth(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -75,6 +77,7 @@ def test_stocks_fa_balance_growth(params, headers):
     "params",
     [({"start_date": "2023-01-01", "end_date": "2023-06-06"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_cal(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -115,6 +118,7 @@ def test_stocks_fa_cal(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_cash(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -129,6 +133,7 @@ def test_stocks_fa_cash(params, headers):
     "params",
     [({"symbol": "AAPL", "limit": 10})],
 )
+@pytest.mark.integration
 def test_stocks_fa_cash_growth(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -143,6 +148,7 @@ def test_stocks_fa_cash_growth(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_comp(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -157,6 +163,7 @@ def test_stocks_fa_comp(params, headers):
     "params",
     [({"start_date": "2023-01-01", "end_date": "2023-06-06"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_comsplit(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -171,6 +178,7 @@ def test_stocks_fa_comsplit(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_divs(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -185,6 +193,7 @@ def test_stocks_fa_divs(params, headers):
     "params",
     [({"symbol": "AAPL", "limit": 50})],
 )
+@pytest.mark.integration
 def test_stocks_fa_earning(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -199,6 +208,7 @@ def test_stocks_fa_earning(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_emp(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -213,6 +223,7 @@ def test_stocks_fa_emp(params, headers):
     "params",
     [({"symbol": "AAPL", "period": "annual", "limit": 30})],
 )
+@pytest.mark.integration
 def test_stocks_fa_est(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -253,6 +264,7 @@ def test_stocks_fa_est(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_income(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -267,6 +279,7 @@ def test_stocks_fa_income(params, headers):
     "params",
     [({"symbol": "AAPL", "limit": 10, "period": "annual"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_income_growth(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -291,6 +304,7 @@ def test_stocks_fa_income_growth(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_ins(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -305,6 +319,7 @@ def test_stocks_fa_ins(params, headers):
     "params",
     [({"symbol": "AAPL", "include_current_quarter": True, "date": "2023-01-01"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_ins_own(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -319,6 +334,7 @@ def test_stocks_fa_ins_own(params, headers):
     "params",
     [({"symbol": "AAPL", "period": "annual", "limit": 100})],
 )
+@pytest.mark.integration
 def test_stocks_fa_metrics(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -333,6 +349,7 @@ def test_stocks_fa_metrics(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_mgmt(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -347,6 +364,7 @@ def test_stocks_fa_mgmt(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_overview(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -361,6 +379,7 @@ def test_stocks_fa_overview(params, headers):
     "params",
     [({"symbol": "AAPL", "date": "2023-01-01", "page": 1})],
 )
+@pytest.mark.integration
 def test_stocks_fa_own(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -375,6 +394,7 @@ def test_stocks_fa_own(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_pt(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -389,6 +409,7 @@ def test_stocks_fa_pt(params, headers):
     "params",
     [({"symbol": "AAPL"}), ({"with_grade": True, "provider": "fmp", "symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_pta(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -403,6 +424,7 @@ def test_stocks_fa_pta(params, headers):
     "params",
     [({"symbol": "AAPL", "period": "annual", "limit": 12})],
 )
+@pytest.mark.integration
 def test_stocks_fa_ratios(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -417,6 +439,7 @@ def test_stocks_fa_ratios(params, headers):
     "params",
     [({"symbol": "AAPL", "period": "annual", "structure": "flat"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_revgeo(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -431,6 +454,7 @@ def test_stocks_fa_revgeo(params, headers):
     "params",
     [({"symbol": "AAPL", "period": "annual", "structure": "flat"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_revseg(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -445,6 +469,7 @@ def test_stocks_fa_revseg(params, headers):
     "params",
     [({"symbol": "AAPL", "type": "1", "page": 1, "limit": 100})],
 )
+@pytest.mark.integration
 def test_stocks_fa_sec(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -459,6 +484,7 @@ def test_stocks_fa_sec(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_shrs(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -473,6 +499,7 @@ def test_stocks_fa_shrs(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_fa_split(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -487,6 +514,7 @@ def test_stocks_fa_split(params, headers):
     "params",
     [({"symbol": "AAPL", "year": 2023, "quarter": 1})],
 )
+@pytest.mark.integration
 def test_stocks_fa_transcript(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -501,6 +529,7 @@ def test_stocks_fa_transcript(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_ca_peers(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -518,6 +547,7 @@ def test_stocks_ca_peers(params, headers):
         ({"date": "2023-01-01", "provider": "intrinio", "symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_options_chains(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -671,6 +701,7 @@ def test_stocks_options_chains(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_load(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -717,6 +748,7 @@ def test_stocks_load(params, headers):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_news(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -731,6 +763,7 @@ def test_stocks_news(params, headers):
     "params",
     [({"symbol": "AAPL", "limit": 100})],
 )
+@pytest.mark.integration
 def test_stocks_multiples(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -745,6 +778,7 @@ def test_stocks_multiples(params, headers):
     "params",
     [({"query": "AAPl", "ticker": True})],
 )
+@pytest.mark.integration
 def test_stocks_search(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -762,6 +796,7 @@ def test_stocks_search(params, headers):
         ({"source": "iex", "provider": "intrinio", "symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_quote(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -776,6 +811,7 @@ def test_stocks_quote(params, headers):
     "params",
     [({"symbol": "AAPL"})],
 )
+@pytest.mark.integration
 def test_stocks_info(params, headers):
     params = {p: v for p, v in params.items() if v}
 

--- a/openbb_sdk/extensions/stocks/integration/test_stocks_python.py
+++ b/openbb_sdk/extensions/stocks/integration/test_stocks_python.py
@@ -34,6 +34,7 @@ from openbb_core.app.model.obbject import OBBject
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_balance(params):
     result = obb.stocks.fa.balance(**params)
     assert result
@@ -47,6 +48,7 @@ def test_stocks_fa_balance(params):
         ({"symbol": "AAPL", "limit": 10}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_balance_growth(params):
     result = obb.stocks.fa.balance_growth(**params)
     assert result
@@ -65,6 +67,7 @@ def test_stocks_fa_balance_growth(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_cal(params):
     result = obb.stocks.fa.cal(**params)
     assert result
@@ -102,6 +105,7 @@ def test_stocks_fa_cal(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_cash(params):
     result = obb.stocks.fa.cash(**params)
     assert result
@@ -115,6 +119,7 @@ def test_stocks_fa_cash(params):
         ({"symbol": "AAPL", "limit": 10}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_cash_growth(params):
     result = obb.stocks.fa.cash_growth(**params)
     assert result
@@ -128,6 +133,7 @@ def test_stocks_fa_cash_growth(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_comp(params):
     result = obb.stocks.fa.comp(**params)
     assert result
@@ -146,6 +152,7 @@ def test_stocks_fa_comp(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_comsplit(params):
     result = obb.stocks.fa.comsplit(**params)
     assert result
@@ -159,6 +166,7 @@ def test_stocks_fa_comsplit(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_divs(params):
     result = obb.stocks.fa.divs(**params)
     assert result
@@ -172,6 +180,7 @@ def test_stocks_fa_divs(params):
         ({"symbol": "AAPL", "limit": 50}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_earning(params):
     result = obb.stocks.fa.earning(**params)
     assert result
@@ -185,6 +194,7 @@ def test_stocks_fa_earning(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_emp(params):
     result = obb.stocks.fa.emp(**params)
     assert result
@@ -198,6 +208,7 @@ def test_stocks_fa_emp(params):
         ({"symbol": "AAPL", "period": "annual", "limit": 30}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_est(params):
     result = obb.stocks.fa.est(**params)
     assert result
@@ -235,6 +246,7 @@ def test_stocks_fa_est(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_income(params):
     result = obb.stocks.fa.income(**params)
     assert result
@@ -248,6 +260,7 @@ def test_stocks_fa_income(params):
         ({"symbol": "AAPL", "limit": 10, "period": "annual"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_income_growth(params):
     result = obb.stocks.fa.income_growth(**params)
     assert result
@@ -269,6 +282,7 @@ def test_stocks_fa_income_growth(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_ins(params):
     result = obb.stocks.fa.ins(**params)
     assert result
@@ -288,6 +302,7 @@ def test_stocks_fa_ins(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_ins_own(params):
     result = obb.stocks.fa.ins_own(**params)
     assert result
@@ -301,6 +316,7 @@ def test_stocks_fa_ins_own(params):
         ({"symbol": "AAPL", "period": "annual", "limit": 100}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_metrics(params):
     result = obb.stocks.fa.metrics(**params)
     assert result
@@ -314,6 +330,7 @@ def test_stocks_fa_metrics(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_mgmt(params):
     result = obb.stocks.fa.mgmt(**params)
     assert result
@@ -327,6 +344,7 @@ def test_stocks_fa_mgmt(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_overview(params):
     result = obb.stocks.fa.overview(**params)
     assert result
@@ -340,6 +358,7 @@ def test_stocks_fa_overview(params):
         ({"symbol": "AAPL", "date": "2023-01-01", "page": 1}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_own(params):
     result = obb.stocks.fa.own(**params)
     assert result
@@ -353,6 +372,7 @@ def test_stocks_fa_own(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_pt(params):
     result = obb.stocks.fa.pt(**params)
     assert result
@@ -367,6 +387,7 @@ def test_stocks_fa_pt(params):
         ({"with_grade": True, "provider": "fmp", "symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_pta(params):
     result = obb.stocks.fa.pta(**params)
     assert result
@@ -380,6 +401,7 @@ def test_stocks_fa_pta(params):
         ({"symbol": "AAPL", "period": "annual", "limit": 12}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_ratios(params):
     result = obb.stocks.fa.ratios(**params)
     assert result
@@ -393,6 +415,7 @@ def test_stocks_fa_ratios(params):
         ({"symbol": "AAPL", "period": "annual", "structure": "flat"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_revgeo(params):
     result = obb.stocks.fa.revgeo(**params)
     assert result
@@ -406,6 +429,7 @@ def test_stocks_fa_revgeo(params):
         ({"symbol": "AAPL", "period": "annual", "structure": "flat"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_revseg(params):
     result = obb.stocks.fa.revseg(**params)
     assert result
@@ -419,6 +443,7 @@ def test_stocks_fa_revseg(params):
         ({"symbol": "AAPL", "type": "1", "page": 1, "limit": 100}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_sec(params):
     result = obb.stocks.fa.sec(**params)
     assert result
@@ -432,6 +457,7 @@ def test_stocks_fa_sec(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_shrs(params):
     result = obb.stocks.fa.shrs(**params)
     assert result
@@ -445,6 +471,7 @@ def test_stocks_fa_shrs(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_split(params):
     result = obb.stocks.fa.split(**params)
     assert result
@@ -458,6 +485,7 @@ def test_stocks_fa_split(params):
         ({"symbol": "AAPL", "year": 2023, "quarter": 1}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_fa_transcript(params):
     result = obb.stocks.fa.transcript(**params)
     assert result
@@ -471,6 +499,7 @@ def test_stocks_fa_transcript(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_ca_peers(params):
     result = obb.stocks.ca.peers(**params)
     assert result
@@ -485,6 +514,7 @@ def test_stocks_ca_peers(params):
         ({"date": "2023-01-01", "provider": "intrinio", "symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_options_chains(params):
     result = obb.stocks.options.chains(**params)
     assert result
@@ -641,6 +671,7 @@ def test_stocks_options_chains(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_load(params):
     result = obb.stocks.load(**params)
     assert result
@@ -684,6 +715,7 @@ def test_stocks_load(params):
         ),
     ],
 )
+@pytest.mark.integration
 def test_stocks_news(params):
     result = obb.stocks.news(**params)
     assert result
@@ -696,6 +728,7 @@ def test_stocks_news(params):
         ({"symbol": "AAPL", "limit": 100}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_multiples(params):
     result = obb.stocks.multiples(**params)
     assert result
@@ -709,6 +742,7 @@ def test_stocks_multiples(params):
         ({"query": "AAPL", "ticker": True}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_search(params):
     result = obb.stocks.search(**params)
     assert result
@@ -723,6 +757,7 @@ def test_stocks_search(params):
         ({"source": "iex", "provider": "intrinio", "symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_quote(params):
     result = obb.stocks.quote(**params)
     assert result
@@ -736,6 +771,7 @@ def test_stocks_quote(params):
         ({"symbol": "AAPL"}),
     ],
 )
+@pytest.mark.integration
 def test_stocks_info(params):
     result = obb.stocks.info(**params)
     assert result

--- a/openbb_sdk/extensions/ta/integration/test_ta_api.py
+++ b/openbb_sdk/extensions/ta/integration/test_ta_api.py
@@ -32,6 +32,7 @@ def headers():
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_atr(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -57,6 +58,7 @@ def test_ta_atr(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_fib(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -71,6 +73,7 @@ def test_ta_fib(params, headers):
     "params",
     [({"data": "", "index": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_obv(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -85,6 +88,7 @@ def test_ta_obv(params, headers):
     "params",
     [({"data": "", "index": "", "length": "", "signal": ""})],
 )
+@pytest.mark.integration
 def test_ta_fisher(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -99,6 +103,7 @@ def test_ta_fisher(params, headers):
     "params",
     [({"data": "", "index": "", "fast": "", "slow": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_adosc(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -125,6 +130,7 @@ def test_ta_adosc(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_bbands(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -139,6 +145,7 @@ def test_ta_bbands(params, headers):
     "params",
     [({"data": "", "target": "", "index": "", "length": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_zlma(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -153,6 +160,7 @@ def test_ta_zlma(params, headers):
     "params",
     [({"data": "", "index": "", "length": "", "scalar": ""})],
 )
+@pytest.mark.integration
 def test_ta_aroon(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -167,6 +175,7 @@ def test_ta_aroon(params, headers):
     "params",
     [({"data": "", "target": "", "index": "", "length": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_sma(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -192,6 +201,7 @@ def test_ta_sma(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_demark(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -206,6 +216,7 @@ def test_ta_demark(params, headers):
     "params",
     [({"data": "", "index": "", "anchor": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_vwap(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -220,6 +231,7 @@ def test_ta_vwap(params, headers):
     "params",
     [({"data": "", "target": "", "index": "", "fast": "", "slow": "", "signal": ""})],
 )
+@pytest.mark.integration
 def test_ta_macd(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -234,6 +246,7 @@ def test_ta_macd(params, headers):
     "params",
     [({"data": "", "target": "", "index": "", "length": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_hma(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -248,6 +261,7 @@ def test_ta_hma(params, headers):
     "params",
     [({"data": "", "index": "", "lower_length": "", "upper_length": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_donchian(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -274,6 +288,7 @@ def test_ta_donchian(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_ichimoku(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -288,6 +303,7 @@ def test_ta_ichimoku(params, headers):
     "params",
     [({"data": "", "index": "", "target": "", "period": ""})],
 )
+@pytest.mark.integration
 def test_ta_clenow(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -302,6 +318,7 @@ def test_ta_clenow(params, headers):
     "params",
     [({"data": "", "index": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_ad(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -316,6 +333,7 @@ def test_ta_ad(params, headers):
     "params",
     [({"data": "", "index": "", "length": "", "scalar": "", "drift": ""})],
 )
+@pytest.mark.integration
 def test_ta_adx(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -330,6 +348,7 @@ def test_ta_adx(params, headers):
     "params",
     [({"data": "", "target": "", "index": "", "length": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_wma(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -344,6 +363,7 @@ def test_ta_wma(params, headers):
     "params",
     [({"data": "", "index": "", "length": "", "scalar": ""})],
 )
+@pytest.mark.integration
 def test_ta_cci(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -369,6 +389,7 @@ def test_ta_cci(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_rsi(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -393,6 +414,7 @@ def test_ta_rsi(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_stoch(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -418,6 +440,7 @@ def test_ta_stoch(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_kc(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -432,6 +455,7 @@ def test_ta_kc(params, headers):
     "params",
     [({"data": "", "index": "", "length": ""})],
 )
+@pytest.mark.integration
 def test_ta_cg(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -457,6 +481,7 @@ def test_ta_cg(params, headers):
         )
     ],
 )
+@pytest.mark.integration
 def test_ta_cones(params, headers):
     params = {p: v for p, v in params.items() if v}
 
@@ -471,6 +496,7 @@ def test_ta_cones(params, headers):
     "params",
     [({"data": "", "target": "", "index": "", "length": "", "offset": ""})],
 )
+@pytest.mark.integration
 def test_ta_ema(params, headers):
     params = {p: v for p, v in params.items() if v}
 


### PR DESCRIPTION
Adding `@pytest.mark.integration` to integration tests, so we can leverage `pytest` to easily run:
 - unit + integration : `pytest`
 - unit : `pytest -m "not integration"`
 - integration : `pytest -m integration`

Note that, for the CI, we don't rely on this since we specify the directories directly.