### PR TITLE
hotfix/forecast-make-intraday-work: An attempt to make intraday data work with forecast functions

### DIFF
--- a/openbb_terminal/forecast/timegpt_model.py
+++ b/openbb_terminal/forecast/timegpt_model.py
@@ -69,9 +69,9 @@ def get_timegpt_model(
         levels = [80, 95]
 
     if isinstance(data[time_col].values[0], pd.Timestamp):
-        data[time_col] = data[time_col].dt.strftime("%Y-%m-%d")
+        data[time_col] = data[time_col].dt.strftime("%Y-%m-%d %H:%M:%S")
     elif isinstance(data[time_col].values[0], numpy.datetime64):
-        data[time_col] = pd.to_datetime(data[time_col]).dt.strftime("%Y-%m-%d")
+        data[time_col] = pd.to_datetime(data[time_col]).dt.strftime("%Y-%m-%d %H:%M:%S")
 
     date_features_param = True if "auto" in date_features else date_features  # type: ignore
 


### PR DESCRIPTION
This might not be the *best* way to go about it, but it appears to work and would resolve a long-standing issue.  The charts are lacking range breaks when intraday, so a bit of love is needed there.

This removes the process which was formatting everything as `%Y-%m-%d`, and changes the frequency setting to default as `D` instead of `B`.

Before:

![Screenshot 2023-09-27 at 12 52 02 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/46f4a4c8-934c-4f45-b9d8-9e59036e1f5d)

After:

![Screenshot 2023-09-27 at 12 53 20 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/12fa6f9c-5ed4-497c-9b3b-6f4299bc36d3)


This does not work with TimeGPT because it doesn't use the helpers or common params the rest of the menu uses. @DidierRLopes, any insight here how we can get intraday to work there?

![Screenshot 2023-09-27 at 12 57 03 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/8b1461b8-371f-4ac9-996f-bcf3c6b777da)

Actually found a way to make it work where it resamples to Hourly:

- Format dates as `%Y-%m-%d %H%M%S` instead of stripping the time.
- Use `freq=H` for the command.
- Daily, `freq=D` for the command.

![Screenshot 2023-09-27 at 1 32 25 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/06e74135-239f-4e81-b0a5-21971086e496)

The TimeGPT command could use a bit of cleanup to make default states and parameters to be like the other models.