### PR TITLE
Hotfix/run to private

### DIFF
--- a/openbb_sdk/openbb/package/crypto.py
+++ b/openbb_sdk/openbb/package/crypto.py
@@ -129,7 +129,7 @@ class ROUTER_crypto(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/crypto/load",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/economy.py
+++ b/openbb_sdk/openbb/package/economy.py
@@ -72,7 +72,7 @@ class ROUTER_economy(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/economy/available_indices",
             **inputs,
         )
@@ -143,7 +143,7 @@ class ROUTER_economy(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/economy/const",
             **inputs,
         )
@@ -293,7 +293,7 @@ class ROUTER_economy(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/economy/cpi",
             **inputs,
         )
@@ -379,7 +379,7 @@ class ROUTER_economy(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/economy/fred_index",
             **inputs,
         )
@@ -491,7 +491,7 @@ class ROUTER_economy(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/economy/index",
             **inputs,
         )
@@ -542,7 +542,7 @@ class ROUTER_economy(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/economy/risk",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/fixedincome.py
+++ b/openbb_sdk/openbb/package/fixedincome.py
@@ -96,7 +96,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/ameribor",
             **inputs,
         )
@@ -170,7 +170,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/estr",
             **inputs,
         )
@@ -244,7 +244,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/fed",
             **inputs,
         )
@@ -316,7 +316,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/iorb",
             **inputs,
         )
@@ -381,7 +381,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/projections",
             **inputs,
         )
@@ -451,7 +451,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/sofr",
             **inputs,
         )
@@ -524,7 +524,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/sonia",
             **inputs,
         )
@@ -614,7 +614,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/treasury",
             **inputs,
         )
@@ -680,7 +680,7 @@ class ROUTER_fixedincome(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/fixedincome/ycrv",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/forex.py
+++ b/openbb_sdk/openbb/package/forex.py
@@ -128,7 +128,7 @@ class ROUTER_forex(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/forex/load",
             **inputs,
         )
@@ -219,7 +219,7 @@ class ROUTER_forex(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/forex/pairs",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/news.py
+++ b/openbb_sdk/openbb/package/news.py
@@ -124,7 +124,7 @@ class ROUTER_news(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/news/globalnews",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/stocks.py
+++ b/openbb_sdk/openbb/package/stocks.py
@@ -164,7 +164,7 @@ class ROUTER_stocks(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/load",
             **inputs,
         )
@@ -344,7 +344,7 @@ class ROUTER_stocks(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/multiples",
             **inputs,
         )
@@ -473,7 +473,7 @@ class ROUTER_stocks(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/news",
             **inputs,
         )
@@ -622,7 +622,7 @@ class ROUTER_stocks(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/quote",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/stocks_ca.py
+++ b/openbb_sdk/openbb/package/stocks_ca.py
@@ -71,7 +71,7 @@ class ROUTER_stocks_ca(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/ca/peers",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/stocks_fa.py
+++ b/openbb_sdk/openbb/package/stocks_fa.py
@@ -261,7 +261,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/balance",
             **inputs,
         )
@@ -405,7 +405,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/balance_growth",
             **inputs,
         )
@@ -485,7 +485,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/cal",
             **inputs,
         )
@@ -684,7 +684,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/cash",
             **inputs,
         )
@@ -810,7 +810,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/cash_growth",
             **inputs,
         )
@@ -889,7 +889,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/comp",
             **inputs,
         )
@@ -963,7 +963,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/comsplit",
             **inputs,
         )
@@ -1030,7 +1030,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/divs",
             **inputs,
         )
@@ -1108,7 +1108,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/earning",
             **inputs,
         )
@@ -1179,7 +1179,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/emp",
             **inputs,
         )
@@ -1290,7 +1290,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/est",
             **inputs,
         )
@@ -1489,7 +1489,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/income",
             **inputs,
         )
@@ -1614,7 +1614,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/income_growth",
             **inputs,
         )
@@ -1736,7 +1736,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/ins",
             **inputs,
         )
@@ -1876,7 +1876,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/ins_own",
             **inputs,
         )
@@ -2065,7 +2065,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/metrics",
             **inputs,
         )
@@ -2132,7 +2132,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/mgmt",
             **inputs,
         )
@@ -2257,7 +2257,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/overview",
             **inputs,
         )
@@ -2402,7 +2402,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/own",
             **inputs,
         )
@@ -2465,7 +2465,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/pt",
             **inputs,
         )
@@ -2548,7 +2548,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/pta",
             **inputs,
         )
@@ -2731,7 +2731,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/ratios",
             **inputs,
         )
@@ -2812,7 +2812,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/revgeo",
             **inputs,
         )
@@ -2883,7 +2883,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/revseg",
             **inputs,
         )
@@ -3075,7 +3075,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/sec",
             **inputs,
         )
@@ -3140,7 +3140,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/shrs",
             **inputs,
         )
@@ -3201,7 +3201,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/split",
             **inputs,
         )
@@ -3280,7 +3280,7 @@ class ROUTER_stocks_fa(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/fa/transcript",
             **inputs,
         )

--- a/openbb_sdk/openbb/package/stocks_options.py
+++ b/openbb_sdk/openbb/package/stocks_options.py
@@ -121,7 +121,7 @@ class ROUTER_stocks_options(Container):
             extra_params=kwargs,
         )
 
-        return self.run(
+        return self._run(
             "/stocks/options/chains",
             **inputs,
         )

--- a/openbb_sdk/sdk/core/openbb_core/app/static/container.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/static/container.py
@@ -13,7 +13,7 @@ class Container:
     def __init__(self, command_runner: CommandRunner) -> None:
         self._command_runner = command_runner
 
-    def run(self, *args, **kwargs) -> Union[OBBject, pd.DataFrame, dict]:
+    def _run(self, *args, **kwargs) -> Union[OBBject, pd.DataFrame, dict]:
         """Run a command in the container."""
         obbject = self._command_runner.run(*args, **kwargs)
         output_type = self._command_runner.user_settings.preferences.output_type

--- a/openbb_sdk/sdk/core/openbb_core/app/static/package_builder.py
+++ b/openbb_sdk/sdk/core/openbb_core/app/static/package_builder.py
@@ -781,7 +781,7 @@ class MethodDefinition:
             else:
                 code += f"            {name}={name},\n"
         code += "        )\n\n"
-        code += "        return self.run(\n"
+        code += "        return self._run(\n"
         code += f"""            "{path}",\n"""
         code += "            **inputs,\n"
         code += "        )\n"


### PR DESCRIPTION
Change the `Container`'s run method to private instead, so it doesn't show up on autocompletion.