### PR TITLE
refactor: reviewpad configuration

### DIFF
--- a/reviewpad.yaml
+++ b/reviewpad.yaml
@@ -1,64 +1,75 @@
 groups:
   - name: ignored-patterns
     spec: '["*.lock","*.csv","*.yaml","*.txt"]'
+  - name: ignored-prs
+    description: |
+      List of PRs numbers that should be ignored by Reviewpad
+      Reviewpad will not run on these PRs
+    spec: '["5225"]'
 
 rules:
   - name: changes-requirements
-    spec: $hasFileName("requirements.txt") && $hasFileName("requirements-full.txt")
+    spec: $containsFileName("requirements.txt") && $containsFileName("requirements-full.txt")
+  - name: should-run-reviewpad
+    spec: $isElementOf($selectFromContext("$.number"), $group("ignored-prs")) == false
 
 workflows:
   - name: label-pull-request-with-size
     description: Label pull request based on the number of lines changed
-    always-run: true
-    if:
-        # Calculate size while ignoring patterns in the "ignored-patterns" group
-        # For more details about size follow https://docs.reviewpad.com/guides/built-ins/#size
-        - rule: $size($group("ignored-patterns")) <= 100
-          extra-actions:
+    run:
+      - if: $rule("should-run-reviewpad")
+        then:
+          # Calculate size while ignoring patterns in the "ignored-patterns" group
+          # For more details about size follow https://docs.reviewpad.com/guides/built-ins/#size
+          - if: $getSize($group("ignored-patterns")) <= 100
+            then:
               - $removeLabels(["feat S", "feat M", "feat L", "feat XL"])
               - $addLabel("feat XS")
-        - rule: $size($group("ignored-patterns")) > 100 && $size($group("ignored-patterns")) <= 300
-          extra-actions:
-              - $removeLabels(["feat XS", "feat M", "feat L", "feat XL"])
-              - $addLabel("feat S")
-        - rule: $size($group("ignored-patterns")) > 300 && $size($group("ignored-patterns")) <= 900
-          extra-actions:
-              - $removeLabels(["feat XS", "feat S", "feat L", "feat XL"])
-              - $addLabel("feat M")
-        - rule: $size($group("ignored-patterns")) > 900 && $size($group("ignored-patterns")) <= 1800
-          extra-actions:
-              - $removeLabels(["feat XS", "feat S", "feat M", "feat XL"])
-              - $addLabel("feat L")
-        - rule: $size($group("ignored-patterns")) > 1800
-          extra-actions:
-              - $removeLabels(["feat XS", "feat S", "feat M", "feat L"])
-              - $addLabel("feat XL")
+          - if: $getSize($group("ignored-patterns")) > 100 && $getSize($group("ignored-patterns")) <= 300
+            then:
+                - $removeLabels(["feat XS", "feat M", "feat L", "feat XL"])
+                - $addLabel("feat S")
+          - if: $getSize($group("ignored-patterns")) > 300 && $getSize($group("ignored-patterns")) <= 900
+            then:
+                - $removeLabels(["feat XS", "feat S", "feat L", "feat XL"])
+                - $addLabel("feat M")
+          - if: $getSize($group("ignored-patterns")) > 900 && $getSize($group("ignored-patterns")) <= 1800
+            then:
+                - $removeLabels(["feat XS", "feat S", "feat M", "feat XL"])
+                - $addLabel("feat L")
+          - if: $getSize($group("ignored-patterns")) > 1800
+            then:
+                - $removeLabels(["feat XS", "feat S", "feat M", "feat L"])
+                - $addLabel("feat XL")
   - name: sanity
     description: Verify pull request sanity
-    always-run: true
-    if:
-      - rule: $hasFileExtensions([".py"]) && $size() > 1000
-        extra-actions:
-          - $fail("This PR is very large and hard to review. Please split PR into multiple")
-      - rule: $hasBinaryFile()
-        extra-actions:
-          - $fail("Images are not allowed in the repository, please remove images from the PR")
+    run:
+      - if: $rule("should-run-reviewpad")
+        then:
+          - if: $containsOnlyFileExtensions([".py"]) && $getSize() > 1000
+            then:
+              - $failCheckStatus("This PR is very large and hard to review. Please split PR into multiple")
+          - if: $containsBinaryFiles()
+            then:
+              - $failCheckStatus("Images are not allowed in the repository, please remove images from the PR")
   - name: dependencies
     description: Verify pull request dependency changes
-    always-run: true
-    if:
-      - rule: '!$isDraft() && $hasFileName("poetry.lock") && !$rule("changes-requirements")'
-        extra-actions:
-          - $review("REQUEST_CHANGES", "The `poetry.lock` file has been changed. Please update both `requirements.txt` and `requirements-full.txt` files")
-      - rule: '!$isDraft() && $hasFileName("pyproject.toml") && !$rule("changes-requirements")'
-        extra-actions:
-          - $warn("The `pyproject.toml` file has been changed. Please make sure that the files `requirements.txt` and `requirements-full.txt` do not need to be updated")
+    run:
+      - if: $rule("should-run-reviewpad")
+        then:
+          - if: '!$isDraft() && $containsFileName("poetry.lock") && !$rule("changes-requirements")'
+            then:
+              - $review("REQUEST_CHANGES", "The `poetry.lock` file has been changed. Please update both `requirements.txt` and `requirements-full.txt` files")
+          - if: '!$isDraft() && $containsFileName("pyproject.toml") && !$rule("changes-requirements")'
+            then:
+              - $reportWarning("The `pyproject.toml` file has been changed. Please make sure that the files `requirements.txt` and `requirements-full.txt` do not need to be updated")
   - name: EOF
     description: Verify files EOF
-    always-run: true
-    if:
-      # By default, Reviewpad splits each file in the patch using the line feed character (\n or LF). 
-      # This means that if a file has a carriage return character (\r) at the end, it indicates that the file has CRLF line endings instead.
-      - rule: $hasCodePattern("\r$$")
-        extra-actions:
-          - $warn("It looks like you have files with `CRLF` line endings. Please make sure that all files have `LF` line endings")
+    run:
+      - if: $rule("should-run-reviewpad")
+        then:
+          # By default, Reviewpad splits each file in the patch using the line feed character (\n or LF). 
+          # This means that if a file has a carriage return character (\r) at the end, it indicates that the file has CRLF line endings instead.
+          - if: $containsCodePattern("\r$$")
+            then:
+              - $reportWarning("It looks like you have files with `CRLF` line endings. Please make sure that all files have `LF` line endings")

--- a/reviewpad.yaml
+++ b/reviewpad.yaml
@@ -1,17 +1,12 @@
 groups:
   - name: ignored-patterns
     spec: '["*.lock","*.csv","*.yaml","*.txt"]'
-  - name: ignored-prs
-    description: |
-      List of PRs numbers that should be ignored by Reviewpad
-      Reviewpad will not run on these PRs
-    spec: '["5225"]'
 
 rules:
   - name: changes-requirements
     spec: $containsFileName("requirements.txt") && $containsFileName("requirements-full.txt")
   - name: should-run-reviewpad
-    spec: $isElementOf($selectFromContext("$.number"), $group("ignored-prs")) == false
+    spec: '!$isElementOf("reviewpad-ignore", $getLabels())'
 
 workflows:
   - name: label-pull-request-with-size


### PR DESCRIPTION
# Description

This pull request introduces two changes:
- A refactor to the Reviewpad configuration to follow the latest releases of [Reviewpad](https://reviewpad.com/).
- A new rule called `should-run-reviewpad` that ignores a pull request if it contains the label `reviewpad-ignore`.

- [x] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [x] Relevant motivation and context.
- [ ] List any dependencies that are required for this change.


# How has this been tested?

This was tested using [Reviewpad playground](https://reviewpad.com/playground).

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [ ] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
