### PR TITLE
hotfix/v4-fix-cones - Bug fixes for ta.cones() and ta.demark()

### DIFF
--- a/openbb_platform/extensions/ta/openbb_ta/ta_helpers.py
+++ b/openbb_platform/extensions/ta/openbb_ta/ta_helpers.py
@@ -391,7 +391,7 @@ def calculate_cones(
     bottom_q = []
     realized = []
     allowed_windows = []
-    data = data.sort_index(ascending=False)
+    data = data.sort_index(ascending=True)
 
     model_functions = {
         "STD": standard_deviation,
@@ -426,14 +426,14 @@ def calculate_cones(
         index={
             0: "realized",
             1: "min",
-            2: f"lower_{lower_q_label}_%",
+            2: f"lower_{lower_q_label}%",
             3: "median",
-            4: f"upper_{upper_q_label}_%",
+            4: f"upper_{upper_q_label}%",
             5: "max",
         }
     )
     cones_df = df.copy()
-    return cones_df.transpose()
+    return cones_df.transpose().reset_index().rename(columns={"index": "window"})
 
 
 def clenow_momentum(

--- a/openbb_platform/extensions/ta/openbb_ta/ta_router.py
+++ b/openbb_platform/extensions/ta/openbb_ta/ta_router.py
@@ -518,8 +518,8 @@ def demark(
     data: List[Data],
     index: str = "date",
     target: str = "close",
-    show_all: bool = False,
-    asint: bool = False,
+    show_all: bool = True,
+    asint: bool = True,
     offset: int = 0,
 ) -> OBBject[List[Data]]:
     """
@@ -536,7 +536,7 @@ def demark(
     show_all : bool, optional
         Show 1 - 13. If set to False, show 6 - 9
     asint : bool, optional
-        If True, fill NAs with 0 and change type to int, by default False
+        If True, fill NAs with 0 and change type to int, by default True.
     offset : int, optional
         How many periods to offset the result
 
@@ -554,9 +554,8 @@ def demark(
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
     demark = ta.td_seq(df_target[target], asint=asint, show_all=show_all, offset=offset)
-    demark_df = pd.DataFrame(demark).set_index(df_target.index).dropna()
-
-    results = df_to_basemodel(df_target.join(demark_df, how="left"), index=True)
+    demark_df = df[[target]].reset_index().join(demark)
+    results = df_to_basemodel(demark_df, index="date")
 
     return OBBject(results=results)
 

--- a/openbb_platform/extensions/ta/openbb_ta/ta_router.py
+++ b/openbb_platform/extensions/ta/openbb_ta/ta_router.py
@@ -555,7 +555,7 @@ def demark(
     df_target = get_target_column(df, target).to_frame()
     demark = ta.td_seq(df_target[target], asint=asint, show_all=show_all, offset=offset)
     demark_df = df[[target]].reset_index().join(demark)
-    results = df_to_basemodel(demark_df, index="date")
+    results = df_to_basemodel(demark_df)
 
     return OBBject(results=results)
 
@@ -1357,7 +1357,7 @@ def cones(
         data=df, lower_q=lower_q, upper_q=upper_q, model=model, is_crypto=is_crypto
     )
 
-    results = df_to_basemodel(df_cones, index=True)
+    results = df_to_basemodel(df_cones)
 
     return OBBject(results=results)
 


### PR DESCRIPTION
This PR fixes two functions in the TA extension, `cones` and `demark`.

- Both were clipping the index from the response.
- Remove `dropna()` from Demark which removed the entire column if one NaN was present.
  - set `asint` and `show_all` to default as True.

![Screenshot 2023-10-03 at 1 45 36 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/33119bc2-1a41-444f-b6c9-845a09f8e485)
![Screenshot 2023-10-03 at 2 14 20 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/1558d1dd-31fe-4c37-82f2-462083254076)
