### PR TITLE
Standard convention for multi-ticker symbols 

### DIFF
--- a/openbb_platform/openbb/package/crypto.py
+++ b/openbb_platform/openbb/package/crypto.py
@@ -1,15 +1,15 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
 import datetime
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_crypto(Container):
@@ -23,23 +23,25 @@ class ROUTER_crypto(Container):
     @validate_call
     def load(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
-            OpenBBCustomParameter(description="Symbol to get data for."),
+            OpenBBCustomParameter(
+                description="Symbol Pair to get data for in CURR1-CURR2 or CURR1CURR2 format."
+            ),
         ],
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fmp", "polygon", "yfinance"]] = None,
+        provider: Union[Literal["fmp", "polygon", "yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Crypto Historical Price.
@@ -47,16 +49,16 @@ class ROUTER_crypto(Container):
         Parameters
         ----------
         symbol : str
-            Symbol to get data for.
-        start_date : Optional[datetime.date]
+            Symbol Pair to get data for in CURR1-CURR2 or CURR1CURR2 format.
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fmp', 'polygon', 'yfinance']]
+        provider : Union[Literal['fmp', 'polygon', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        timeseries : Optional[Annotated[int, Ge(ge=0)]]
+        timeseries : Optional[Union[typing_extensions.Annotated[int, Ge(ge=0)]]]
             Number of days to look back. (provider: fmp)
         interval : Optional[Union[Literal['1min', '5min', '15min', '30min', '1hour', '4hour', '1day'], Literal['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1wk', '1mo', '3mo']]]
             Data granularity. (provider: fmp, yfinance)
@@ -70,15 +72,15 @@ class ROUTER_crypto(Container):
             The number of data entries to return. (provider: polygon)
         adjusted : bool
             Whether the data is adjusted. (provider: polygon)
-        period : Optional[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]
+        period : Optional[Union[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]]
             Period of the data to return. (provider: yfinance)
 
         Returns
         -------
         OBBject
-            results : List[CryptoHistorical]
+            results : Union[List[CryptoHistorical]]
                 Serializable results.
-            provider : Optional[Literal['fmp', 'polygon', 'yfinance']]
+            provider : Union[Literal['fmp', 'polygon', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -101,21 +103,21 @@ class ROUTER_crypto(Container):
             The close price of the symbol.
         volume : float
             The volume of the symbol.
-        vwap : Optional[Annotated[float, Gt(gt=0)]]
+        vwap : Optional[Union[typing_extensions.Annotated[float, Gt(gt=0)]]]
             Volume Weighted Average Price of the symbol.
-        adj_close : Optional[float]
+        adj_close : Optional[Union[float]]
             Adjusted Close Price of the symbol. (provider: fmp)
-        unadjusted_volume : Optional[float]
+        unadjusted_volume : Optional[Union[float]]
             Unadjusted volume of the symbol. (provider: fmp)
-        change : Optional[float]
+        change : Optional[Union[float]]
             Change in the price of the symbol from the previous day. (provider: fmp)
-        change_percent : Optional[float]
+        change_percent : Optional[Union[float]]
             Change % in the price of the symbol. (provider: fmp)
-        label : Optional[str]
+        label : Optional[Union[str]]
             Human readable format of the date. (provider: fmp)
-        change_over_time : Optional[float]
+        change_over_time : Optional[Union[float]]
             Change % in the price of the symbol over a period of time. (provider: fmp)
-        transactions : Optional[Annotated[int, Gt(gt=0)]]
+        transactions : Optional[Union[typing_extensions.Annotated[int, Gt(gt=0)]]]
             Number of transactions for the symbol in the time period. (provider: polygon)
         """  # noqa: E501
 

--- a/openbb_platform/openbb/package/econometrics.py
+++ b/openbb_platform/openbb/package/econometrics.py
@@ -3,13 +3,13 @@
 from typing import Dict, List, Literal, Union
 
 import pandas
+import typing_extensions
 from annotated_types import Gt
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_econometrics(Container):
@@ -39,7 +39,7 @@ class ROUTER_econometrics(Container):
         data: Union[List[Data], pandas.DataFrame],
         y_column: str,
         x_columns: List[str],
-        lags: Annotated[int, Gt(gt=0)] = 1,
+        lags: typing_extensions.Annotated[int, Gt(gt=0)] = 1,
     ) -> OBBject[Data]:
         """Perform Breusch-Godfrey Lagrange Multiplier tests for residual autocorrelation.
 
@@ -168,7 +168,7 @@ class ROUTER_econometrics(Container):
         data: Union[List[Data], pandas.DataFrame],
         y_column: str,
         x_column: str,
-        lag: Annotated[int, Gt(gt=0)] = 3,
+        lag: typing_extensions.Annotated[int, Gt(gt=0)] = 3,
     ) -> OBBject[Data]:
         """Perform Granger causality test to determine if X "causes" y.
 

--- a/openbb_platform/openbb/package/economy.py
+++ b/openbb_platform/openbb/package/economy.py
@@ -1,15 +1,15 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
 import datetime
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_economy(Container):
@@ -34,13 +34,13 @@ class ROUTER_economy(Container):
 
     @validate_call
     def available_indices(
-        self, provider: Optional[Literal["cboe", "fmp", "yfinance"]] = None, **kwargs
+        self, provider: Union[Literal["cboe", "fmp", "yfinance"], None] = None, **kwargs
     ) -> OBBject[List[Data]]:
         """Lists of available indices from a provider.
 
         Parameters
         ----------
-        provider : Optional[Literal['cboe', 'fmp', 'yfinance']]
+        provider : Union[Literal['cboe', 'fmp', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
@@ -50,9 +50,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[AvailableIndices]
+            results : Union[List[AvailableIndices]]
                 Serializable results.
-            provider : Optional[Literal['cboe', 'fmp', 'yfinance']]
+            provider : Union[Literal['cboe', 'fmp', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -63,37 +63,37 @@ class ROUTER_economy(Container):
 
         AvailableIndices
         ----------------
-        name : Optional[str]
+        name : Optional[Union[str]]
             Name of the index.
-        currency : Optional[str]
+        currency : Optional[Union[str]]
             Currency the index is traded in.
-        isin : Optional[str]
+        isin : Optional[Union[str]]
             ISIN code for the index. Valid only for European indices. (provider: cboe)
-        region : Optional[str]
+        region : Optional[Union[str]]
             Region for the index. Valid only for European indices (provider: cboe)
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol for the index. (provider: cboe, yfinance)
-        description : Optional[str]
+        description : Optional[Union[str]]
             Description for the index. Valid only for US indices. (provider: cboe)
-        data_delay : Optional[int]
+        data_delay : Optional[Union[int]]
             Data delay for the index. Valid only for US indices. (provider: cboe)
-        open_time : Optional[datetime.time]
+        open_time : Optional[Union[datetime.time]]
             Opening time for the index. Valid only for US indices. (provider: cboe)
-        close_time : Optional[datetime.time]
+        close_time : Optional[Union[datetime.time]]
             Closing time for the index. Valid only for US indices. (provider: cboe)
-        time_zone : Optional[str]
+        time_zone : Optional[Union[str]]
             Time zone for the index. Valid only for US indices. (provider: cboe)
-        tick_days : Optional[str]
+        tick_days : Optional[Union[str]]
             The trading days for the index. Valid only for US indices. (provider: cboe)
-        tick_frequency : Optional[str]
+        tick_frequency : Optional[Union[str]]
             The frequency of the index ticks. Valid only for US indices. (provider: cboe)
-        tick_period : Optional[str]
+        tick_period : Optional[Union[str]]
             The period of the index ticks. Valid only for US indices. (provider: cboe)
-        stock_exchange : Optional[str]
+        stock_exchange : Optional[Union[str]]
             Stock exchange where the index is listed. (provider: fmp)
-        exchange_short_name : Optional[str]
+        exchange_short_name : Optional[Union[str]]
             Short name of the stock exchange where the index is listed. (provider: fmp)
-        code : Optional[str]
+        code : Optional[Union[str]]
             ID code for keying the index in the OpenBB Terminal. (provider: yfinance)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -112,13 +112,13 @@ class ROUTER_economy(Container):
     @validate_call
     def const(
         self,
-        index: Annotated[
+        index: typing_extensions.Annotated[
             Literal["nasdaq", "sp500", "dowjones"],
             OpenBBCustomParameter(
                 description="Index for which we want to fetch the constituents."
             ),
         ] = "dowjones",
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get the constituents of an index.
@@ -127,7 +127,7 @@ class ROUTER_economy(Container):
         ----------
         index : Literal['nasdaq', 'sp500', 'dowjones']
             Index for which we want to fetch the constituents.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -135,9 +135,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[MajorIndicesConstituents]
+            results : Union[List[MajorIndicesConstituents]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -154,9 +154,9 @@ class ROUTER_economy(Container):
             Name of the constituent company in the index.
         sector : str
             Sector the constituent company in the index belongs to.
-        sub_sector : Optional[str]
+        sub_sector : Optional[Union[str]]
             Sub-sector the constituent company in the index belongs to.
-        headquarter : Optional[str]
+        headquarter : Optional[Union[str]]
             Location of the headquarter of the constituent company in the index.
         date_first_added : Optional[Union[date, str]]
             Date the constituent company was added to the index.
@@ -182,13 +182,13 @@ class ROUTER_economy(Container):
 
     @validate_call
     def cot(
-        self, provider: Optional[Literal["quandl"]] = None, **kwargs
+        self, provider: Union[Literal["quandl"], None] = None, **kwargs
     ) -> OBBject[List[Data]]:
         """Lookup Commitment of Traders Reports by series ID.
 
         Parameters
         ----------
-        provider : Optional[Literal['quandl']]
+        provider : Union[Literal['quandl'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'quandl' if there is
             no default.
@@ -199,7 +199,7 @@ class ROUTER_economy(Container):
                     Certain symbols, such as "ES=F", or exact names are also valid.
                     Default report is: S&P 500 Consolidated (CME))
                      (provider: quandl)
-        data_type : Optional[Literal['F', 'FO', 'CITS']]
+        data_type : Optional[Union[Literal['F', 'FO', 'CITS']]]
 
                     The type of data to reuturn. Default is "FO".
 
@@ -209,9 +209,9 @@ class ROUTER_economy(Container):
 
                     CITS = Commodity Index Trader Supplemental. Only valid for commodities.
                  (provider: quandl)
-        legacy_format : Optional[bool]
+        legacy_format : Optional[Union[bool]]
             Returns the legacy format of report. Default is False. (provider: quandl)
-        report_type : Optional[Literal['ALL', 'CHG', 'OLD', 'OTR']]
+        report_type : Optional[Union[Literal['ALL', 'CHG', 'OLD', 'OTR']]]
 
                     The type of report to return. Default is "ALL".
 
@@ -223,7 +223,7 @@ class ROUTER_economy(Container):
 
                         OTR = Other Crop Years
                  (provider: quandl)
-        measure : Optional[Literal['CR', 'NT', 'OI', 'CHG']]
+        measure : Optional[Union[Literal['CR', 'NT', 'OI', 'CHG']]]
 
                     The measure to return. Default is None.
 
@@ -235,19 +235,19 @@ class ROUTER_economy(Container):
 
                     CHG = Change in Positions. Only valid when data_type is "CITS".
                  (provider: quandl)
-        start_date : Optional[datetime.date]
+        start_date : Optional[Union[datetime.date]]
             The start date of the time series. Defaults to all. (provider: quandl)
-        end_date : Optional[datetime.date]
+        end_date : Optional[Union[datetime.date]]
             The end date of the time series. Defaults to the most recent data. (provider: quandl)
-        transform : Optional[Literal['diff', 'rdiff', 'cumul', 'normalize']]
+        transform : Optional[Union[Literal['diff', 'rdiff', 'cumul', 'normalize']]]
             Transform the data as w/w difference, percent change, cumulative, or normalize. (provider: quandl)
 
         Returns
         -------
         OBBject
-            results : List[COT]
+            results : Union[List[COT]]
                 Serializable results.
-            provider : Optional[Literal['quandl']]
+            provider : Union[Literal['quandl'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -275,8 +275,10 @@ class ROUTER_economy(Container):
     @validate_call
     def cot_search(
         self,
-        query: Annotated[str, OpenBBCustomParameter(description="Search query.")] = "",
-        provider: Optional[Literal["quandl"]] = None,
+        query: typing_extensions.Annotated[
+            str, OpenBBCustomParameter(description="Search query.")
+        ] = "",
+        provider: Union[Literal["quandl"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Fuzzy search and list of curated Commitment of Traders Reports series information.
@@ -285,7 +287,7 @@ class ROUTER_economy(Container):
         ----------
         query : str
             Search query.
-        provider : Optional[Literal['quandl']]
+        provider : Union[Literal['quandl'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'quandl' if there is
             no default.
@@ -293,9 +295,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[COTSearch]
+            results : Union[List[COTSearch]]
                 Serializable results.
-            provider : Optional[Literal['quandl']]
+            provider : Union[Literal['quandl'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -310,13 +312,13 @@ class ROUTER_economy(Container):
             CFTC Code of the report.
         name : str
             Name of the underlying asset.
-        category : Optional[str]
+        category : Optional[Union[str]]
             Category of the underlying asset.
-        subcategory : Optional[str]
+        subcategory : Optional[Union[str]]
             Subcategory of the underlying asset.
-        units : Optional[str]
+        units : Optional[Union[str]]
             The units for one contract.
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Trading symbol representing the underlying asset."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -337,7 +339,7 @@ class ROUTER_economy(Container):
     @validate_call
     def cpi(
         self,
-        countries: Annotated[
+        countries: typing_extensions.Annotated[
             List[
                 Literal[
                     "australia",
@@ -393,33 +395,33 @@ class ROUTER_economy(Container):
             ],
             OpenBBCustomParameter(description="The country or countries to get data."),
         ],
-        units: Annotated[
+        units: typing_extensions.Annotated[
             Literal["growth_previous", "growth_same", "index_2015"],
             OpenBBCustomParameter(description="The data units."),
         ] = "growth_same",
-        frequency: Annotated[
+        frequency: typing_extensions.Annotated[
             Literal["monthly", "quarter", "annual"],
             OpenBBCustomParameter(description="The data time frequency."),
         ] = "monthly",
-        harmonized: Annotated[
+        harmonized: typing_extensions.Annotated[
             bool,
             OpenBBCustomParameter(
                 description="Whether you wish to obtain harmonized data."
             ),
         ] = False,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """CPI.
@@ -434,11 +436,11 @@ class ROUTER_economy(Container):
             The data time frequency.
         harmonized : bool
             Whether you wish to obtain harmonized data.
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -446,9 +448,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[CPI]
+            results : Union[List[CPI]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -459,9 +461,9 @@ class ROUTER_economy(Container):
 
         CPI
         ---
-        date : Optional[date]
+        date : Optional[Union[date]]
             The date of the data.
-        value : Optional[float]
+        value : Optional[Union[float]]
             CPI value on the date."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -487,23 +489,23 @@ class ROUTER_economy(Container):
     @validate_call
     def european_index(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["cboe"]] = None,
+        provider: Union[Literal["cboe"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get historical close values for select European indices.
@@ -512,23 +514,23 @@ class ROUTER_economy(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['cboe']]
+        provider : Union[Literal['cboe'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
-        interval : Optional[Literal['1d', '1m']]
+        interval : Optional[Union[Literal['1d', '1m']]]
             Data granularity. (provider: cboe)
 
         Returns
         -------
         OBBject
-            results : List[EuropeanIndexHistorical]
+            results : Union[List[EuropeanIndexHistorical]]
                 Serializable results.
-            provider : Optional[Literal['cboe']]
+            provider : Union[Literal['cboe'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -543,13 +545,13 @@ class ROUTER_economy(Container):
             The date of the data.
         close : float
             The close price of the symbol.
-        open : Optional[float]
+        open : Optional[Union[float]]
             Opening price for the interval. Only valid when interval is 1m. (provider: cboe)
-        high : Optional[float]
+        high : Optional[Union[float]]
             High price for the interval. Only valid when interval is 1m. (provider: cboe)
-        low : Optional[float]
+        low : Optional[Union[float]]
             Low price for the interval. Only valid when interval is 1m. (provider: cboe)
-        utc_datetime : Optional[datetime]
+        utc_datetime : Optional[Union[datetime]]
             UTC datetime. Only valid when interval is 1m. (provider: cboe)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -572,11 +574,11 @@ class ROUTER_economy(Container):
     @validate_call
     def european_index_constituents(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["cboe"]] = None,
+        provider: Union[Literal["cboe"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get  current levels for constituents of select European indices.
@@ -585,7 +587,7 @@ class ROUTER_economy(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['cboe']]
+        provider : Union[Literal['cboe'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
@@ -593,9 +595,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[EuropeanIndexConstituents]
+            results : Union[List[EuropeanIndexConstituents]]
                 Serializable results.
-            provider : Optional[Literal['cboe']]
+            provider : Union[Literal['cboe'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -620,21 +622,21 @@ class ROUTER_economy(Container):
             The close price of the symbol.
         volume : float
             The volume of the symbol.
-        prev_close : Optional[float]
+        prev_close : Optional[Union[float]]
             Previous closing  price. (provider: cboe)
-        change : Optional[float]
+        change : Optional[Union[float]]
             Change in price. (provider: cboe)
-        change_percent : Optional[float]
+        change_percent : Optional[Union[float]]
             Change in price as a percentage. (provider: cboe)
-        tick : Optional[str]
+        tick : Optional[Union[str]]
             Whether the last sale was an up or down tick. (provider: cboe)
-        last_trade_timestamp : Optional[datetime]
+        last_trade_timestamp : Optional[Union[datetime]]
             Last trade timestamp for the symbol. (provider: cboe)
-        exchange_id : Optional[int]
+        exchange_id : Optional[Union[int]]
             The Exchange ID number. (provider: cboe)
-        seqno : Optional[int]
+        seqno : Optional[Union[int]]
             Sequence number of the last trade on the tape. (provider: cboe)
-        asset_type : Optional[str]
+        asset_type : Optional[Union[str]]
             Type of asset. (provider: cboe)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -655,27 +657,27 @@ class ROUTER_economy(Container):
     @validate_call
     def fred_index(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        limit: Annotated[
-            Optional[int],
+        limit: typing_extensions.Annotated[
+            Union[int, None],
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 100,
-        provider: Optional[Literal["intrinio"]] = None,
+        provider: Union[Literal["intrinio"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Fred Historical.
@@ -684,27 +686,27 @@ class ROUTER_economy(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        limit : Optional[int]
+        limit : Union[int, None]
             The number of data entries to return.
-        provider : Optional[Literal['intrinio']]
+        provider : Union[Literal['intrinio'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'intrinio' if there is
             no default.
-        next_page : Optional[str]
+        next_page : Optional[Union[str]]
             Token to get the next page of data from a previous API call. (provider: intrinio)
-        all_pages : Optional[bool]
+        all_pages : Optional[Union[bool]]
             Returns all pages of data from the API call at once. (provider: intrinio)
 
         Returns
         -------
         OBBject
-            results : List[FredHistorical]
+            results : Union[List[FredHistorical]]
                 Serializable results.
-            provider : Optional[Literal['intrinio']]
+            provider : Union[Literal['intrinio'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -717,7 +719,7 @@ class ROUTER_economy(Container):
         --------------
         date : date
             The date of the data.
-        value : Optional[Annotated[float, Gt(gt=0)]]
+        value : Optional[Union[typing_extensions.Annotated[float, Gt(gt=0)]]]
             Value of the index."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -741,23 +743,23 @@ class ROUTER_economy(Container):
     @validate_call
     def index(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["cboe", "fmp", "polygon", "yfinance"]] = None,
+        provider: Union[Literal["cboe", "fmp", "polygon", "yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get historical  levels for an index.
@@ -766,17 +768,17 @@ class ROUTER_economy(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['cboe', 'fmp', 'polygon', 'yfinance']]
+        provider : Union[Literal['cboe', 'fmp', 'polygon', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
         interval : Optional[Union[Literal['1d', '1m'], Literal['1min', '5min', '15min', '30min', '1hour', '4hour', '1day'], Literal['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1wk', '1mo', '3mo']]]
             Use interval, 1m, for intraday prices during the most recent trading period. (provider: cboe); Data granularity. (provider: fmp); Data granularity. (provider: yfinance)
-        timeseries : Optional[Annotated[int, Ge(ge=0)]]
+        timeseries : Optional[Union[typing_extensions.Annotated[int, Ge(ge=0)]]]
             Number of days to look back. (provider: fmp)
         timespan : Literal['minute', 'hour', 'day', 'week', 'month', 'quarter', 'year']
             Timespan of the data. (provider: polygon)
@@ -788,7 +790,7 @@ class ROUTER_economy(Container):
             Whether the data is adjusted. (provider: polygon)
         multiplier : int
             Multiplier of the timespan. (provider: polygon)
-        period : Optional[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]
+        period : Optional[Union[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]]
             Period of the data to return. (provider: yfinance)
         prepost : bool
             Include Pre and Post market data. (provider: yfinance)
@@ -798,9 +800,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[MajorIndicesHistorical]
+            results : Union[List[MajorIndicesHistorical]]
                 Serializable results.
-            provider : Optional[Literal['cboe', 'fmp', 'polygon', 'yfinance']]
+            provider : Union[Literal['cboe', 'fmp', 'polygon', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -823,25 +825,25 @@ class ROUTER_economy(Container):
             The close price of the symbol.
         volume : Optional[int]
             The volume of the symbol.
-        calls_volume : Optional[float]
+        calls_volume : Optional[Union[float]]
             Number of calls traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
-        puts_volume : Optional[float]
+        puts_volume : Optional[Union[float]]
             Number of puts traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
-        total_options_volume : Optional[float]
+        total_options_volume : Optional[Union[float]]
             Total number of options traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
-        adj_close : Optional[float]
+        adj_close : Optional[Union[float]]
             Adjusted Close Price of the symbol. (provider: fmp)
-        unadjusted_volume : Optional[float]
+        unadjusted_volume : Optional[Union[float]]
             Unadjusted volume of the symbol. (provider: fmp)
-        change : Optional[float]
+        change : Optional[Union[float]]
             Change in the price of the symbol from the previous day. (provider: fmp)
-        change_percent : Optional[float]
+        change_percent : Optional[Union[float]]
             Change % in the price of the symbol. (provider: fmp)
-        label : Optional[str]
+        label : Optional[Union[str]]
             Human readable format of the date. (provider: fmp)
-        change_over_time : Optional[float]
+        change_over_time : Optional[Union[float]]
             Change % in the price of the symbol over a period of time. (provider: fmp)
-        transactions : Optional[Annotated[int, Gt(gt=0)]]
+        transactions : Optional[Union[typing_extensions.Annotated[int, Gt(gt=0)]]]
             Number of transactions for the symbol in the time period. (provider: polygon)
         """  # noqa: E501
 
@@ -865,12 +867,14 @@ class ROUTER_economy(Container):
     @validate_call
     def index_search(
         self,
-        query: Annotated[str, OpenBBCustomParameter(description="Search query.")] = "",
-        symbol: Annotated[
+        query: typing_extensions.Annotated[
+            str, OpenBBCustomParameter(description="Search query.")
+        ] = "",
+        symbol: typing_extensions.Annotated[
             Union[bool, List[str]],
             OpenBBCustomParameter(description="Whether to search by ticker symbol."),
         ] = False,
-        provider: Optional[Literal["cboe"]] = None,
+        provider: Union[Literal["cboe"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Search for indices.
@@ -881,7 +885,7 @@ class ROUTER_economy(Container):
             Search query.
         symbol : bool
             Whether to search by ticker symbol.
-        provider : Optional[Literal['cboe']]
+        provider : Union[Literal['cboe'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
@@ -891,9 +895,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[IndexSearch]
+            results : Union[List[IndexSearch]]
                 Serializable results.
-            provider : Optional[Literal['cboe']]
+            provider : Union[Literal['cboe'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -908,27 +912,27 @@ class ROUTER_economy(Container):
             Symbol of the index.
         name : str
             Name of the index.
-        isin : Optional[str]
+        isin : Optional[Union[str]]
             ISIN code for the index. Valid only for European indices. (provider: cboe)
-        region : Optional[str]
+        region : Optional[Union[str]]
             Region for the index. Valid only for European indices (provider: cboe)
-        description : Optional[str]
+        description : Optional[Union[str]]
             Description for the index. (provider: cboe)
-        data_delay : Optional[int]
+        data_delay : Optional[Union[int]]
             Data delay for the index. Valid only for US indices. (provider: cboe)
-        currency : Optional[str]
+        currency : Optional[Union[str]]
             Currency for the index. (provider: cboe)
-        time_zone : Optional[str]
+        time_zone : Optional[Union[str]]
             Time zone for the index. Valid only for US indices. (provider: cboe)
-        open_time : Optional[datetime.time]
+        open_time : Optional[Union[datetime.time]]
             Opening time for the index. Valid only for US indices. (provider: cboe)
-        close_time : Optional[datetime.time]
+        close_time : Optional[Union[datetime.time]]
             Closing time for the index. Valid only for US indices. (provider: cboe)
-        tick_days : Optional[str]
+        tick_days : Optional[Union[str]]
             The trading days for the index. Valid only for US indices. (provider: cboe)
-        tick_frequency : Optional[str]
+        tick_frequency : Optional[Union[str]]
             Tick frequency for the index. Valid only for US indices. (provider: cboe)
-        tick_period : Optional[str]
+        tick_period : Optional[Union[str]]
             Tick period for the index. Valid only for US indices. (provider: cboe)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -950,22 +954,22 @@ class ROUTER_economy(Container):
     @validate_call
     def index_snapshots(
         self,
-        region: Annotated[
-            Optional[Literal["US", "EU"]],
+        region: typing_extensions.Annotated[
+            Union[Literal["US", "EU"], None],
             OpenBBCustomParameter(
                 description="The region to return. Currently supports US and EU."
             ),
         ] = "US",
-        provider: Optional[Literal["cboe"]] = None,
+        provider: Union[Literal["cboe"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get current  levels for all indices from a provider.
 
         Parameters
         ----------
-        region : Optional[Literal['US', 'EU']]
+        region : Union[Literal['US', 'EU'], None]
             The region to return. Currently supports US and EU.
-        provider : Optional[Literal['cboe']]
+        provider : Union[Literal['cboe'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
@@ -973,9 +977,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[IndexSnapshots]
+            results : Union[List[IndexSnapshots]]
                 Serializable results.
-            provider : Optional[Literal['cboe']]
+            provider : Union[Literal['cboe'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -988,29 +992,29 @@ class ROUTER_economy(Container):
         --------------
         symbol : str
             Symbol of the index.
-        name : Optional[str]
+        name : Optional[Union[str]]
             Name of the index.
-        currency : Optional[str]
+        currency : Optional[Union[str]]
             Currency of the index.
-        price : Optional[float]
+        price : Optional[Union[float]]
             Current price of the index.
-        open : Optional[float]
+        open : Optional[Union[float]]
             Opening price of the index.
-        high : Optional[float]
+        high : Optional[Union[float]]
             Highest price of the index.
-        low : Optional[float]
+        low : Optional[Union[float]]
             Lowest price of the index.
-        close : Optional[float]
+        close : Optional[Union[float]]
             Closing price of the index.
-        prev_close : Optional[float]
+        prev_close : Optional[Union[float]]
             Previous closing price of the index.
-        change : Optional[float]
+        change : Optional[Union[float]]
             Change of the index.
-        change_percent : Optional[float]
+        change_percent : Optional[Union[float]]
             Change percent of the index.
-        isin : Optional[str]
+        isin : Optional[Union[str]]
             ISIN code for the index. Valid only for European indices. (provider: cboe)
-        last_trade_timestamp : Optional[datetime]
+        last_trade_timestamp : Optional[Union[datetime]]
             Last trade timestamp for the index. (provider: cboe)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -1030,13 +1034,13 @@ class ROUTER_economy(Container):
 
     @validate_call
     def risk(
-        self, provider: Optional[Literal["fmp"]] = None, **kwargs
+        self, provider: Union[Literal["fmp"], None] = None, **kwargs
     ) -> OBBject[List[Data]]:
         """Market Risk Premium.
 
         Parameters
         ----------
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -1044,9 +1048,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[RiskPremium]
+            results : Union[List[RiskPremium]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1059,11 +1063,11 @@ class ROUTER_economy(Container):
         -----------
         country : str
             Market country.
-        continent : Optional[str]
+        continent : Optional[Union[str]]
             Continent of the country.
-        total_equity_risk_premium : Optional[Annotated[float, Gt(gt=0)]]
+        total_equity_risk_premium : Optional[Union[typing_extensions.Annotated[float, Gt(gt=0)]]]
             Total equity risk premium for the country.
-        country_risk_premium : Optional[Annotated[float, Ge(ge=0)]]
+        country_risk_premium : Optional[Union[typing_extensions.Annotated[float, Ge(ge=0)]]]
             Country-specific risk premium."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -1082,7 +1086,7 @@ class ROUTER_economy(Container):
     @validate_call
     def sp500_multiples(
         self,
-        series_name: Annotated[
+        series_name: typing_extensions.Annotated[
             Literal[
                 "Shiller PE Ratio by Month",
                 "Shiller PE Ratio by Year",
@@ -1125,29 +1129,29 @@ class ROUTER_economy(Container):
                 description="The name of the series. Defaults to 'PE Ratio by Month'."
             ),
         ] = "PE Ratio by Month",
-        start_date: Annotated[
-            Optional[str],
+        start_date: typing_extensions.Annotated[
+            Union[str, None],
             OpenBBCustomParameter(
                 description="The start date of the time series. Format: YYYY-MM-DD"
             ),
         ] = "",
-        end_date: Annotated[
-            Optional[str],
+        end_date: typing_extensions.Annotated[
+            Union[str, None],
             OpenBBCustomParameter(
                 description="The end date of the time series. Format: YYYY-MM-DD"
             ),
         ] = "",
-        collapse: Annotated[
-            Optional[Literal["daily", "weekly", "monthly", "quarterly", "annual"]],
+        collapse: typing_extensions.Annotated[
+            Union[Literal["daily", "weekly", "monthly", "quarterly", "annual"], None],
             OpenBBCustomParameter(
                 description="Collapse the frequency of the time series."
             ),
         ] = "monthly",
-        transform: Annotated[
-            Optional[Literal["diff", "rdiff", "cumul", "normalize"]],
+        transform: typing_extensions.Annotated[
+            Union[Literal["diff", "rdiff", "cumul", "normalize"], None],
             OpenBBCustomParameter(description="The transformation of the time series."),
         ] = None,
-        provider: Optional[Literal["quandl"]] = None,
+        provider: Union[Literal["quandl"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Historical S&P 500 multiples and Shiller PE ratios.
@@ -1156,15 +1160,15 @@ class ROUTER_economy(Container):
         ----------
         series_name : Literal['Shiller PE Ratio by Month', 'Shiller PE Ratio by Year', 'PE Rat...
             The name of the series. Defaults to 'PE Ratio by Month'.
-        start_date : Optional[str]
+        start_date : Union[str, None]
             The start date of the time series. Format: YYYY-MM-DD
-        end_date : Optional[str]
+        end_date : Union[str, None]
             The end date of the time series. Format: YYYY-MM-DD
-        collapse : Optional[Literal['daily', 'weekly', 'monthly', 'quarterly', 'annu...
+        collapse : Union[Literal['daily', 'weekly', 'monthly', 'quarterly', 'annual'...
             Collapse the frequency of the time series.
-        transform : Optional[Literal['diff', 'rdiff', 'cumul', 'normalize']]
+        transform : Union[Literal['diff', 'rdiff', 'cumul', 'normalize'], None]
             The transformation of the time series.
-        provider : Optional[Literal['quandl']]
+        provider : Union[Literal['quandl'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'quandl' if there is
             no default.
@@ -1172,9 +1176,9 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[SP500Multiples]
+            results : Union[List[SP500Multiples]]
                 Serializable results.
-            provider : Optional[Literal['quandl']]
+            provider : Union[Literal['quandl'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.

--- a/openbb_platform/openbb/package/fixedincome.py
+++ b/openbb_platform/openbb/package/fixedincome.py
@@ -1,15 +1,15 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
 import datetime
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_fixedincome(Container):
@@ -31,19 +31,19 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def ameribor(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """
@@ -53,11 +53,11 @@ class ROUTER_fixedincome(Container):
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -67,9 +67,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[AMERIBOR]
+            results : Union[List[AMERIBOR]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -82,7 +82,7 @@ class ROUTER_fixedincome(Container):
         --------
         date : date
             The date of the data.
-        rate : Optional[float]
+        rate : Union[float]
             AMERIBOR rate."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -104,19 +104,19 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def estr(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """
@@ -127,11 +127,11 @@ class ROUTER_fixedincome(Container):
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -141,9 +141,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[ESTR]
+            results : Union[List[ESTR]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -156,7 +156,7 @@ class ROUTER_fixedincome(Container):
         ----
         date : date
             The date of the data.
-        rate : Optional[float]
+        rate : Union[float]
             ESTR rate."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -178,19 +178,19 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def fed(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """
@@ -201,11 +201,11 @@ class ROUTER_fixedincome(Container):
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -215,9 +215,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[FEDFUNDS]
+            results : Union[List[FEDFUNDS]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -230,7 +230,7 @@ class ROUTER_fixedincome(Container):
         --------
         date : date
             The date of the data.
-        rate : Optional[float]
+        rate : Union[float]
             FED rate."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -252,19 +252,19 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def iorb(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """
@@ -275,11 +275,11 @@ class ROUTER_fixedincome(Container):
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -287,9 +287,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[IORB]
+            results : Union[List[IORB]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -302,7 +302,7 @@ class ROUTER_fixedincome(Container):
         ----
         date : date
             The date of the data.
-        rate : Optional[float]
+        rate : Union[float]
             IORB rate."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -323,7 +323,7 @@ class ROUTER_fixedincome(Container):
 
     @validate_call
     def projections(
-        self, provider: Optional[Literal["fred"]] = None, **kwargs
+        self, provider: Union[Literal["fred"], None] = None, **kwargs
     ) -> OBBject[List[Data]]:
         """
             Get Effective Federal Funds Rate data. A bank rate is the interest rate a nation's central bank charges to its
@@ -333,7 +333,7 @@ class ROUTER_fixedincome(Container):
 
         Parameters
         ----------
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -343,9 +343,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[PROJECTIONS]
+            results : Union[List[PROJECTIONS]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -358,19 +358,19 @@ class ROUTER_fixedincome(Container):
         -----------
         date : date
             The date of the data.
-        range_high : Optional[float]
+        range_high : Union[float]
             High projection of rates.
-        central_tendency_high : Optional[float]
+        central_tendency_high : Union[float]
             Central tendency of high projection of rates.
-        median : Optional[float]
+        median : Union[float]
             Median projection of rates.
-        range_midpoint : Optional[float]
+        range_midpoint : Union[float]
             Midpoint projection of rates.
-        central_tendency_midpoint : Optional[float]
+        central_tendency_midpoint : Union[float]
             Central tendency of midpoint projection of rates.
-        range_low : Optional[float]
+        range_low : Union[float]
             Low projection of rates.
-        central_tendency_low : Optional[float]
+        central_tendency_low : Union[float]
             Central tendency of low projection of rates."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -389,30 +389,30 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def sofr(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get United States yield curve.
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -422,9 +422,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[SOFR]
+            results : Union[List[SOFR]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -437,7 +437,7 @@ class ROUTER_fixedincome(Container):
         ----
         date : date
             The date of the data.
-        rate : Optional[float]
+        rate : Union[float]
             SOFR rate."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -459,19 +459,19 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def sonia(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """
@@ -481,11 +481,11 @@ class ROUTER_fixedincome(Container):
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -495,9 +495,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[SONIA]
+            results : Union[List[SONIA]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -510,7 +510,7 @@ class ROUTER_fixedincome(Container):
         -----
         date : date
             The date of the data.
-        rate : Optional[float]
+        rate : Union[float]
             SONIA rate."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -532,30 +532,30 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def treasury(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get treasury rates.
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -563,9 +563,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[TreasuryRates]
+            results : Union[List[TreasuryRates]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -622,28 +622,28 @@ class ROUTER_fixedincome(Container):
     @validate_call
     def ycrv(
         self,
-        date: Annotated[
-            Optional[datetime.date],
+        date: typing_extensions.Annotated[
+            Union[datetime.date, None],
             OpenBBCustomParameter(
                 description="Date to get Yield Curve data.  Defaults to the most recent FRED entry."
             ),
         ] = None,
-        inflation_adjusted: Annotated[
-            Optional[bool],
+        inflation_adjusted: typing_extensions.Annotated[
+            Union[bool, None],
             OpenBBCustomParameter(description="Get inflation adjusted rates."),
         ] = False,
-        provider: Optional[Literal["fred"]] = None,
+        provider: Union[Literal["fred"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get United States yield curve.
 
         Parameters
         ----------
-        date : Optional[datetime.date]
+        date : Union[datetime.date, None]
             Date to get Yield Curve data.  Defaults to the most recent FRED entry.
-        inflation_adjusted : Optional[bool]
+        inflation_adjusted : Union[bool, None]
             Get inflation adjusted rates.
-        provider : Optional[Literal['fred']]
+        provider : Union[Literal['fred'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
             no default.
@@ -651,9 +651,9 @@ class ROUTER_fixedincome(Container):
         Returns
         -------
         OBBject
-            results : List[USYieldCurve]
+            results : Union[List[USYieldCurve]]
                 Serializable results.
-            provider : Optional[Literal['fred']]
+            provider : Union[Literal['fred'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.

--- a/openbb_platform/openbb/package/forex.py
+++ b/openbb_platform/openbb/package/forex.py
@@ -1,15 +1,15 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
 import datetime
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_forex(Container):
@@ -24,23 +24,25 @@ class ROUTER_forex(Container):
     @validate_call
     def load(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
-            OpenBBCustomParameter(description="Symbol to get data for."),
+            OpenBBCustomParameter(
+                description="Symbol Pair to get data for in CURR1-CURR2 or CURR1CURR2 format."
+            ),
         ],
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fmp", "polygon", "yfinance"]] = None,
+        provider: Union[Literal["fmp", "polygon", "yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Forex Intraday Price.
@@ -48,12 +50,12 @@ class ROUTER_forex(Container):
         Parameters
         ----------
         symbol : str
-            Symbol to get data for.
-        start_date : Optional[datetime.date]
+            Symbol Pair to get data for in CURR1-CURR2 or CURR1CURR2 format.
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fmp', 'polygon', 'yfinance']]
+        provider : Union[Literal['fmp', 'polygon', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -69,15 +71,15 @@ class ROUTER_forex(Container):
             The number of data entries to return. (provider: polygon)
         adjusted : bool
             Whether the data is adjusted. (provider: polygon)
-        period : Optional[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]
+        period : Optional[Union[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]]
             Period of the data to return. (provider: yfinance)
 
         Returns
         -------
         OBBject
-            results : List[ForexHistorical]
+            results : Union[List[ForexHistorical]]
                 Serializable results.
-            provider : Optional[Literal['fmp', 'polygon', 'yfinance']]
+            provider : Union[Literal['fmp', 'polygon', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -100,21 +102,21 @@ class ROUTER_forex(Container):
             The close price of the symbol.
         volume : float
             The volume of the symbol.
-        vwap : Optional[Annotated[float, Gt(gt=0)]]
+        vwap : Optional[Union[typing_extensions.Annotated[float, Gt(gt=0)]]]
             Volume Weighted Average Price of the symbol.
-        adj_close : Optional[float]
+        adj_close : Optional[Union[float]]
             Adjusted Close Price of the symbol. (provider: fmp)
-        unadjusted_volume : Optional[float]
+        unadjusted_volume : Optional[Union[float]]
             Unadjusted volume of the symbol. (provider: fmp)
-        change : Optional[float]
+        change : Optional[Union[float]]
             Change in the price of the symbol from the previous day. (provider: fmp)
-        change_percent : Optional[float]
+        change_percent : Optional[Union[float]]
             Change % in the price of the symbol. (provider: fmp)
-        label : Optional[str]
+        label : Optional[Union[str]]
             Human readable format of the date. (provider: fmp)
-        change_over_time : Optional[float]
+        change_over_time : Optional[Union[float]]
             Change % in the price of the symbol over a period of time. (provider: fmp)
-        transactions : Optional[Annotated[int, Gt(gt=0)]]
+        transactions : Optional[Union[typing_extensions.Annotated[int, Gt(gt=0)]]]
             Number of transactions for the symbol in the time period. (provider: polygon)
         """  # noqa: E501
 
@@ -137,37 +139,39 @@ class ROUTER_forex(Container):
 
     @validate_call
     def pairs(
-        self, provider: Optional[Literal["fmp", "intrinio", "polygon"]] = None, **kwargs
+        self,
+        provider: Union[Literal["fmp", "intrinio", "polygon"], None] = None,
+        **kwargs
     ) -> OBBject[List[Data]]:
         """Forex Available Pairs.
 
         Parameters
         ----------
-        provider : Optional[Literal['fmp', 'intrinio', 'polygon']]
+        provider : Union[Literal['fmp', 'intrinio', 'polygon'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol of the pair to search. (provider: polygon)
-        date : Optional[datetime.date]
+        date : Optional[Union[datetime.date]]
             A specific date to get data for. (provider: polygon)
-        search : Optional[str]
+        search : Optional[Union[str]]
             Search for terms within the ticker and/or company name. (provider: polygon)
-        active : Optional[bool]
+        active : Optional[Union[bool]]
             Specify if the tickers returned should be actively traded on the queried date. (provider: polygon)
-        order : Optional[Literal['asc', 'desc']]
+        order : Optional[Union[Literal['asc', 'desc']]]
             Order data by ascending or descending. (provider: polygon)
-        sort : Optional[Literal['ticker', 'name', 'market', 'locale', 'currency_symbol', 'currency_name', 'base_currency_symbol', 'base_currency_name', 'last_updated_utc', 'delisted_utc']]
+        sort : Optional[Union[Literal['ticker', 'name', 'market', 'locale', 'currency_symbol', 'currency_name', 'base_currency_symbol', 'base_currency_name', 'last_updated_utc', 'delisted_utc']]]
             Sort field used for ordering. (provider: polygon)
-        limit : Optional[Annotated[int, Gt(gt=0)]]
+        limit : Optional[Union[typing_extensions.Annotated[int, Gt(gt=0)]]]
             The number of data entries to return. (provider: polygon)
 
         Returns
         -------
         OBBject
-            results : List[ForexPairs]
+            results : Union[List[ForexPairs]]
                 Serializable results.
-            provider : Optional[Literal['fmp', 'intrinio', 'polygon']]
+            provider : Union[Literal['fmp', 'intrinio', 'polygon'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -180,35 +184,35 @@ class ROUTER_forex(Container):
         ----------
         name : str
             Name of the currency pair.
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol of the currency pair. (provider: fmp)
-        currency : Optional[str]
+        currency : Optional[Union[str]]
             Base currency of the currency pair. (provider: fmp)
-        stock_exchange : Optional[str]
+        stock_exchange : Optional[Union[str]]
             Stock exchange of the currency pair. (provider: fmp)
-        exchange_short_name : Optional[str]
+        exchange_short_name : Optional[Union[str]]
             Short name of the stock exchange of the currency pair. (provider: fmp)
-        code : Optional[str]
+        code : Optional[Union[str]]
             Code of the currency pair. (provider: intrinio)
-        base_currency : Optional[str]
+        base_currency : Optional[Union[str]]
             ISO 4217 currency code of the base currency. (provider: intrinio)
-        quote_currency : Optional[str]
+        quote_currency : Optional[Union[str]]
             ISO 4217 currency code of the quote currency. (provider: intrinio)
-        market : Optional[str]
+        market : Optional[Union[str]]
             Name of the trading market. Always 'fx'. (provider: polygon)
-        locale : Optional[str]
+        locale : Optional[Union[str]]
             Locale of the currency pair. (provider: polygon)
-        currency_symbol : Optional[str]
+        currency_symbol : Optional[Union[str]]
             The symbol of the quote currency. (provider: polygon)
-        currency_name : Optional[str]
+        currency_name : Optional[Union[str]]
             Name of the quote currency. (provider: polygon)
-        base_currency_symbol : Optional[str]
+        base_currency_symbol : Optional[Union[str]]
             The symbol of the base currency. (provider: polygon)
-        base_currency_name : Optional[str]
+        base_currency_name : Optional[Union[str]]
             Name of the base currency. (provider: polygon)
-        last_updated_utc : Optional[datetime]
+        last_updated_utc : Optional[Union[datetime]]
             The last updated timestamp in UTC. (provider: polygon)
-        delisted_utc : Optional[datetime]
+        delisted_utc : Optional[Union[datetime]]
             The delisted timestamp in UTC. (provider: polygon)"""  # noqa: E501
 
         inputs = filter_inputs(

--- a/openbb_platform/openbb/package/futures.py
+++ b/openbb_platform/openbb/package/futures.py
@@ -1,15 +1,15 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
 import datetime
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_futures(Container):
@@ -24,15 +24,15 @@ class ROUTER_futures(Container):
     @validate_call
     def curve(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        date: Annotated[
-            Optional[datetime.date],
+        date: typing_extensions.Annotated[
+            Union[datetime.date, None],
             OpenBBCustomParameter(description="Historical date to search curve for."),
         ] = None,
-        provider: Optional[Literal["cboe", "yfinance"]] = None,
+        provider: Union[Literal["cboe", "yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Futures Historical Price.
@@ -41,9 +41,9 @@ class ROUTER_futures(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        date : Optional[datetime.date]
+        date : Union[datetime.date, None]
             Historical date to search curve for.
-        provider : Optional[Literal['cboe', 'yfinance']]
+        provider : Union[Literal['cboe', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
@@ -51,9 +51,9 @@ class ROUTER_futures(Container):
         Returns
         -------
         OBBject
-            results : List[FuturesCurve]
+            results : Union[List[FuturesCurve]]
                 Serializable results.
-            provider : Optional[Literal['cboe', 'yfinance']]
+            provider : Union[Literal['cboe', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -66,9 +66,9 @@ class ROUTER_futures(Container):
         ------------
         expiration : str
             Futures expiration month.
-        price : Optional[float]
+        price : Optional[Union[float]]
             The close price of the symbol.
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             The trading symbol for the tenor of future. (provider: cboe)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -90,27 +90,27 @@ class ROUTER_futures(Container):
     @validate_call
     def load(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        expiration: Annotated[
-            Optional[str],
+        expiration: typing_extensions.Annotated[
+            Union[str, None],
             OpenBBCustomParameter(description="Future expiry date with format YYYY-MM"),
         ] = None,
-        provider: Optional[Literal["yfinance"]] = None,
+        provider: Union[Literal["yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Futures Historical Price.
@@ -119,19 +119,19 @@ class ROUTER_futures(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        expiration : Optional[str]
+        expiration : Union[str, None]
             Future expiry date with format YYYY-MM
-        provider : Optional[Literal['yfinance']]
+        provider : Union[Literal['yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'yfinance' if there is
             no default.
-        interval : Optional[Literal['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1wk', '1mo', '3mo']]
+        interval : Optional[Union[Literal['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1wk', '1mo', '3mo']]]
             Data granularity. (provider: yfinance)
-        period : Optional[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]
+        period : Optional[Union[Literal['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max']]]
             Period of the data to return. (provider: yfinance)
         prepost : bool
             Include Pre and Post market data. (provider: yfinance)
@@ -143,9 +143,9 @@ class ROUTER_futures(Container):
         Returns
         -------
         OBBject
-            results : List[FuturesHistorical]
+            results : Union[List[FuturesHistorical]]
                 Serializable results.
-            provider : Optional[Literal['yfinance']]
+            provider : Union[Literal['yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.

--- a/openbb_platform/openbb/package/news.py
+++ b/openbb_platform/openbb/package/news.py
@@ -1,14 +1,14 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
-from typing import List, Literal, Optional
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_news(Container):
@@ -22,10 +22,10 @@ class ROUTER_news(Container):
     @validate_call
     def globalnews(
         self,
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int, OpenBBCustomParameter(description="Number of articles to return.")
         ] = 20,
-        provider: Optional[Literal["benzinga", "fmp", "intrinio"]] = None,
+        provider: Union[Literal["benzinga", "fmp", "intrinio"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Global News.
@@ -34,45 +34,45 @@ class ROUTER_news(Container):
         ----------
         limit : int
             Number of articles to return.
-        provider : Optional[Literal['benzinga', 'fmp', 'intrinio']]
+        provider : Union[Literal['benzinga', 'fmp', 'intrinio'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'benzinga' if there is
             no default.
         display : Literal['headline', 'abstract', 'full']
             Specify headline only (headline), headline + teaser (abstract), or headline + full body (full). (provider: benzinga)
-        date : Optional[str]
+        date : Optional[Union[str]]
             Date of the news to retrieve. (provider: benzinga)
-        start_date : Optional[str]
+        start_date : Optional[Union[str]]
             Start date of the news to retrieve. (provider: benzinga)
-        end_date : Optional[str]
+        end_date : Optional[Union[str]]
             End date of the news to retrieve. (provider: benzinga)
-        updated_since : Optional[int]
+        updated_since : Optional[Union[int]]
             Number of seconds since the news was updated. (provider: benzinga)
-        published_since : Optional[int]
+        published_since : Optional[Union[int]]
             Number of seconds since the news was published. (provider: benzinga)
-        sort : Optional[Literal['id', 'created', 'updated']]
+        sort : Optional[Union[Literal['id', 'created', 'updated']]]
             Key to sort the news by. (provider: benzinga)
-        order : Optional[Literal['asc', 'desc']]
+        order : Optional[Union[Literal['asc', 'desc']]]
             Order to sort the news by. (provider: benzinga)
-        isin : Optional[str]
+        isin : Optional[Union[str]]
             The ISIN of the news to retrieve. (provider: benzinga)
-        cusip : Optional[str]
+        cusip : Optional[Union[str]]
             The CUSIP of the news to retrieve. (provider: benzinga)
-        channels : Optional[str]
+        channels : Optional[Union[str]]
             Channels of the news to retrieve. (provider: benzinga)
-        topics : Optional[str]
+        topics : Optional[Union[str]]
             Topics of the news to retrieve. (provider: benzinga)
-        authors : Optional[str]
+        authors : Optional[Union[str]]
             Authors of the news to retrieve. (provider: benzinga)
-        content_types : Optional[str]
+        content_types : Optional[Union[str]]
             Content types of the news to retrieve. (provider: benzinga)
 
         Returns
         -------
         OBBject
-            results : List[GlobalNews]
+            results : Union[List[GlobalNews]]
                 Serializable results.
-            provider : Optional[Literal['benzinga', 'fmp', 'intrinio']]
+            provider : Union[Literal['benzinga', 'fmp', 'intrinio'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -87,31 +87,31 @@ class ROUTER_news(Container):
             Published date of the news.
         title : str
             Title of the news.
-        image : Optional[str]
+        image : Optional[Union[str]]
             Image URL of the news.
-        text : Optional[str]
+        text : Optional[Union[str]]
             Text/body of the news.
-        url : Optional[str]
+        url : Optional[Union[str]]
             URL of the news.
-        id : Optional[str]
+        id : Optional[Union[str]]
             ID of the news. (provider: benzinga); Article ID. (provider: intrinio)
-        author : Optional[str]
+        author : Optional[Union[str]]
             Author of the news. (provider: benzinga)
-        teaser : Optional[str]
+        teaser : Optional[Union[str]]
             Teaser of the news. (provider: benzinga)
-        images : Optional[List[Dict[str, str]]]
+        images : Optional[Union[List[Dict[str, str]]]]
             Images associated with the news. (provider: benzinga)
-        channels : Optional[str]
+        channels : Optional[Union[str]]
             Channels associated with the news. (provider: benzinga)
-        stocks : Optional[str]
+        stocks : Optional[Union[str]]
             Stocks associated with the news. (provider: benzinga)
-        tags : Optional[str]
+        tags : Optional[Union[str]]
             Tags associated with the news. (provider: benzinga)
-        updated : Optional[datetime]
+        updated : Optional[Union[datetime]]
             None
-        site : Optional[str]
+        site : Optional[Union[str]]
             Site of the news. (provider: fmp)
-        company : Optional[Dict[str, Any]]
+        company : Optional[Union[Dict[str, Any]]]
             Company details related to the news article. (provider: intrinio)"""  # noqa: E501
 
         inputs = filter_inputs(

--- a/openbb_platform/openbb/package/qa.py
+++ b/openbb_platform/openbb/package/qa.py
@@ -3,6 +3,7 @@
 from typing import List, Literal, Union
 
 import pandas
+import typing_extensions
 from annotated_types import Ge, Gt
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
@@ -16,7 +17,6 @@ from openbb_qa.qa_models import (
     UnitRootModel,
 )
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_qa(Container):
@@ -57,7 +57,7 @@ class ROUTER_qa(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         target: str,
-        window: Annotated[int, Gt(gt=0)],
+        window: typing_extensions.Annotated[int, Gt(gt=0)],
     ) -> OBBject[List[Data]]:
         """Get the Kurtosis.
 
@@ -166,8 +166,8 @@ class ROUTER_qa(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         target: str,
-        window: Annotated[int, Gt(gt=0)],
-        quantile_pct: Annotated[float, Ge(ge=0)] = 0.5,
+        window: typing_extensions.Annotated[int, Gt(gt=0)],
+        quantile_pct: typing_extensions.Annotated[float, Ge(ge=0)] = 0.5,
     ) -> OBBject[List[Data]]:
         """Get Quantile.
 
@@ -206,7 +206,7 @@ class ROUTER_qa(Container):
         data: Union[List[Data], pandas.DataFrame],
         target: str,
         rfr: float = 0.0,
-        window: Annotated[int, Gt(gt=0)] = 252,
+        window: typing_extensions.Annotated[int, Gt(gt=0)] = 252,
     ) -> OBBject[List[Data]]:
         """Get Sharpe Ratio.
 
@@ -244,7 +244,7 @@ class ROUTER_qa(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         target: str,
-        window: Annotated[int, Gt(gt=0)],
+        window: typing_extensions.Annotated[int, Gt(gt=0)],
     ) -> OBBject[List[Data]]:
         """Get Skewness.
 
@@ -280,7 +280,7 @@ class ROUTER_qa(Container):
         data: Union[List[Data], pandas.DataFrame],
         target: str,
         target_return: float = 0.0,
-        window: Annotated[int, Gt(gt=0)] = 252,
+        window: typing_extensions.Annotated[int, Gt(gt=0)] = 252,
         adjusted: bool = False,
     ) -> OBBject[List[Data]]:
         """Get Sortino Ratio.
@@ -353,7 +353,7 @@ class ROUTER_qa(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         target: str,
-        fuller_reg: Literal["c", "ct", "ctt", "nc"] = "c",
+        fuller_reg: Literal["c", "ct", "ctt", "nc", "c"] = "c",
         kpss_reg: Literal["c", "ct"] = "c",
     ) -> OBBject[UnitRootModel]:
         """Get Unit Root Test.

--- a/openbb_platform/openbb/package/stocks.py
+++ b/openbb_platform/openbb/package/stocks.py
@@ -815,9 +815,9 @@ class ROUTER_stocks(Container):
         query: typing_extensions.Annotated[
             str, OpenBBCustomParameter(description="Search query.")
         ] = "",
-        symbol: typing_extensions.Annotated[
-            Union[bool, List[str]],
-            OpenBBCustomParameter(description="Whether to search by a symbol."),
+        is_symbol: typing_extensions.Annotated[
+            bool,
+            OpenBBCustomParameter(description="Whether to search by ticker symbol."),
         ] = False,
         provider: Union[Literal["cboe"], None] = None,
         **kwargs
@@ -828,8 +828,8 @@ class ROUTER_stocks(Container):
         ----------
         query : str
             Search query.
-        symbol : bool
-            Whether to search by a symbol.
+        is_symbol : bool
+            Whether to search by ticker symbol.
         provider : Union[Literal['cboe'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
@@ -866,7 +866,7 @@ class ROUTER_stocks(Container):
             },
             standard_params={
                 "query": query,
-                "symbol": ",".join(symbol) if isinstance(symbol, list) else symbol,
+                "is_symbol": is_symbol,
             },
             extra_params=kwargs,
         )

--- a/openbb_platform/openbb/package/stocks_ca.py
+++ b/openbb_platform/openbb/package/stocks_ca.py
@@ -1,14 +1,14 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_stocks_ca(Container):
@@ -22,11 +22,11 @@ class ROUTER_stocks_ca(Container):
     @validate_call
     def peers(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[Data]:
         """Company peers.
@@ -35,7 +35,7 @@ class ROUTER_stocks_ca(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -43,9 +43,9 @@ class ROUTER_stocks_ca(Container):
         Returns
         -------
         OBBject
-            results : StockPeers
+            results : Union[StockPeers]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.

--- a/openbb_platform/openbb/package/stocks_fa.py
+++ b/openbb_platform/openbb/package/stocks_fa.py
@@ -1,15 +1,15 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
 import datetime
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_stocks_fa(Container):
@@ -50,19 +50,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def balance(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
+        period: typing_extensions.Annotated[
             Literal["annual", "quarter"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 12,
-        provider: Optional[Literal["fmp", "intrinio", "polygon", "yfinance"]] = None,
+        provider: Union[Literal["fmp", "intrinio", "polygon", "yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Balance Sheet.
@@ -75,55 +75,55 @@ class ROUTER_stocks_fa(Container):
             Period of the data to return.
         limit : int
             The number of data entries to return.
-        provider : Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]
+        provider : Union[Literal['fmp', 'intrinio', 'polygon', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             Central Index Key (CIK) of the company. (provider: fmp)
         type : Literal['reported', 'standardized']
             Type of the statement to be fetched. (provider: intrinio)
-        year : Optional[int]
+        year : Optional[Union[int]]
             Year of the statement to be fetched. (provider: intrinio)
-        company_name : Optional[str]
+        company_name : Optional[Union[str]]
             Name of the company. (provider: polygon)
-        company_name_search : Optional[str]
+        company_name_search : Optional[Union[str]]
             Name of the company to search. (provider: polygon)
-        sic : Optional[str]
+        sic : Optional[Union[str]]
             The Standard Industrial Classification (SIC) of the company. (provider: polygon)
-        filing_date : Optional[datetime.date]
+        filing_date : Optional[Union[datetime.date]]
             Filing date of the financial statement. (provider: polygon)
-        filing_date_lt : Optional[datetime.date]
+        filing_date_lt : Optional[Union[datetime.date]]
             Filing date less than the given date. (provider: polygon)
-        filing_date_lte : Optional[datetime.date]
+        filing_date_lte : Optional[Union[datetime.date]]
             Filing date less than or equal to the given date. (provider: polygon)
-        filing_date_gt : Optional[datetime.date]
+        filing_date_gt : Optional[Union[datetime.date]]
             Filing date greater than the given date. (provider: polygon)
-        filing_date_gte : Optional[datetime.date]
+        filing_date_gte : Optional[Union[datetime.date]]
             Filing date greater than or equal to the given date. (provider: polygon)
-        period_of_report_date : Optional[datetime.date]
+        period_of_report_date : Optional[Union[datetime.date]]
             Period of report date of the financial statement. (provider: polygon)
-        period_of_report_date_lt : Optional[datetime.date]
+        period_of_report_date_lt : Optional[Union[datetime.date]]
             Period of report date less than the given date. (provider: polygon)
-        period_of_report_date_lte : Optional[datetime.date]
+        period_of_report_date_lte : Optional[Union[datetime.date]]
             Period of report date less than or equal to the given date. (provider: polygon)
-        period_of_report_date_gt : Optional[datetime.date]
+        period_of_report_date_gt : Optional[Union[datetime.date]]
             Period of report date greater than the given date. (provider: polygon)
-        period_of_report_date_gte : Optional[datetime.date]
+        period_of_report_date_gte : Optional[Union[datetime.date]]
             Period of report date greater than or equal to the given date. (provider: polygon)
-        include_sources : Optional[bool]
+        include_sources : Optional[Union[bool]]
             Whether to include the sources of the financial statement. (provider: polygon)
-        order : Optional[Literal['asc', 'desc']]
+        order : Optional[Union[Literal['asc', 'desc']]]
             Order of the financial statement. (provider: polygon)
-        sort : Optional[Literal['filing_date', 'period_of_report_date']]
+        sort : Optional[Union[Literal['filing_date', 'period_of_report_date']]]
             Sort of the financial statement. (provider: polygon)
 
         Returns
         -------
         OBBject
-            results : List[BalanceSheet]
+            results : Union[List[BalanceSheet]]
                 Serializable results.
-            provider : Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]
+            provider : Union[Literal['fmp', 'intrinio', 'polygon', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -134,19 +134,19 @@ class ROUTER_stocks_fa(Container):
 
         BalanceSheet
         ------------
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol to get data for.
         date : date
             Date of the fetched statement.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             Central Index Key (CIK) of the company.
-        currency : Optional[str]
+        currency : Optional[Union[str]]
             Reporting currency.
-        filling_date : Optional[date]
+        filling_date : Optional[Union[date]]
             Filling date.
-        accepted_date : Optional[datetime]
+        accepted_date : Optional[Union[datetime]]
             Accepted date.
-        period : Optional[str]
+        period : Optional[Union[str]]
             Reporting period of the statement.
         cash_and_cash_equivalents : Optional[int]
             Cash and cash equivalents
@@ -244,9 +244,9 @@ class ROUTER_stocks_fa(Container):
             Total Debt (provider: fmp)
         net_debt : Optional[int]
             Net Debt (provider: fmp)
-        link : Optional[str]
+        link : Optional[Union[str]]
             Link to the statement. (provider: fmp)
-        final_link : Optional[str]
+        final_link : Optional[Union[str]]
             Link to the final statement. (provider: fmp)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -269,15 +269,15 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def balance_growth(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 10,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Balance Sheet Statement Growth.
@@ -288,7 +288,7 @@ class ROUTER_stocks_fa(Container):
             Symbol to get data for.
         limit : int
             The number of data entries to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -296,9 +296,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[BalanceSheetGrowth]
+            results : Union[List[BalanceSheetGrowth]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -309,7 +309,7 @@ class ROUTER_stocks_fa(Container):
 
         BalanceSheetGrowth
         ------------------
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol to get data for.
         date : date
             The date of the data.
@@ -413,19 +413,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def cal(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Show Dividend Calendar for a given start and end dates.
@@ -436,7 +436,7 @@ class ROUTER_stocks_fa(Container):
             Start date of the data, in YYYY-MM-DD format.
         end_date : date
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -444,9 +444,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[DividendCalendar]
+            results : Union[List[DividendCalendar]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -463,15 +463,15 @@ class ROUTER_stocks_fa(Container):
             The date of the data.
         label : str
             Date in human readable form in the calendar.
-        adj_dividend : Optional[float]
+        adj_dividend : Optional[Union[float]]
             Adjusted dividend on a date in the calendar.
-        dividend : Optional[float]
+        dividend : Optional[Union[float]]
             Dividend amount in the calendar.
-        record_date : Optional[date]
+        record_date : Optional[Union[date]]
             Record date of the dividend in the calendar.
-        payment_date : Optional[date]
+        payment_date : Optional[Union[date]]
             Payment date of the dividend in the calendar.
-        declaration_date : Optional[date]
+        declaration_date : Optional[Union[date]]
             Declaration date of the dividend in the calendar."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -493,19 +493,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def cash(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
+        period: typing_extensions.Annotated[
             Literal["annual", "quarter"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 12,
-        provider: Optional[Literal["fmp", "intrinio", "polygon", "yfinance"]] = None,
+        provider: Union[Literal["fmp", "intrinio", "polygon", "yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Cash Flow Statement.
@@ -518,55 +518,55 @@ class ROUTER_stocks_fa(Container):
             Period of the data to return.
         limit : int
             The number of data entries to return.
-        provider : Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]
+        provider : Union[Literal['fmp', 'intrinio', 'polygon', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             Central Index Key (CIK) of the company. (provider: fmp)
         type : Literal['reported', 'standardized']
             Type of the statement to be fetched. (provider: intrinio)
-        year : Optional[int]
+        year : Optional[Union[int]]
             Year of the statement to be fetched. (provider: intrinio)
-        company_name : Optional[str]
+        company_name : Optional[Union[str]]
             Name of the company. (provider: polygon)
-        company_name_search : Optional[str]
+        company_name_search : Optional[Union[str]]
             Name of the company to search. (provider: polygon)
-        sic : Optional[str]
+        sic : Optional[Union[str]]
             The Standard Industrial Classification (SIC) of the company. (provider: polygon)
-        filing_date : Optional[datetime.date]
+        filing_date : Optional[Union[datetime.date]]
             Filing date of the financial statement. (provider: polygon)
-        filing_date_lt : Optional[datetime.date]
+        filing_date_lt : Optional[Union[datetime.date]]
             Filing date less than the given date. (provider: polygon)
-        filing_date_lte : Optional[datetime.date]
+        filing_date_lte : Optional[Union[datetime.date]]
             Filing date less than or equal to the given date. (provider: polygon)
-        filing_date_gt : Optional[datetime.date]
+        filing_date_gt : Optional[Union[datetime.date]]
             Filing date greater than the given date. (provider: polygon)
-        filing_date_gte : Optional[datetime.date]
+        filing_date_gte : Optional[Union[datetime.date]]
             Filing date greater than or equal to the given date. (provider: polygon)
-        period_of_report_date : Optional[datetime.date]
+        period_of_report_date : Optional[Union[datetime.date]]
             Period of report date of the financial statement. (provider: polygon)
-        period_of_report_date_lt : Optional[datetime.date]
+        period_of_report_date_lt : Optional[Union[datetime.date]]
             Period of report date less than the given date. (provider: polygon)
-        period_of_report_date_lte : Optional[datetime.date]
+        period_of_report_date_lte : Optional[Union[datetime.date]]
             Period of report date less than or equal to the given date. (provider: polygon)
-        period_of_report_date_gt : Optional[datetime.date]
+        period_of_report_date_gt : Optional[Union[datetime.date]]
             Period of report date greater than the given date. (provider: polygon)
-        period_of_report_date_gte : Optional[datetime.date]
+        period_of_report_date_gte : Optional[Union[datetime.date]]
             Period of report date greater than or equal to the given date. (provider: polygon)
-        include_sources : Optional[bool]
+        include_sources : Optional[Union[bool]]
             Whether to include the sources of the financial statement. (provider: polygon)
-        order : Optional[Literal['asc', 'desc']]
+        order : Optional[Union[Literal['asc', 'desc']]]
             Order of the financial statement. (provider: polygon)
-        sort : Optional[Literal['filing_date', 'period_of_report_date']]
+        sort : Optional[Union[Literal['filing_date', 'period_of_report_date']]]
             Sort of the financial statement. (provider: polygon)
 
         Returns
         -------
         OBBject
-            results : List[CashFlowStatement]
+            results : Union[List[CashFlowStatement]]
                 Serializable results.
-            provider : Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]
+            provider : Union[Literal['fmp', 'intrinio', 'polygon', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -577,13 +577,13 @@ class ROUTER_stocks_fa(Container):
 
         CashFlowStatement
         -----------------
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol to get data for.
         date : date
             Date of the fetched statement.
-        period : Optional[str]
+        period : Optional[Union[str]]
             Reporting period of the statement.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             Central Index Key (CIK) of the company.
         net_income : Optional[int]
             Net income.
@@ -641,11 +641,11 @@ class ROUTER_stocks_fa(Container):
             Net cash flow from financing activities.
         net_change_in_cash : Optional[int]
             Net increase (decrease) in cash, cash equivalents, and restricted cash
-        reported_currency : Optional[str]
+        reported_currency : Optional[Union[str]]
             Reported currency in the statement. (provider: fmp)
-        filling_date : Optional[date]
+        filling_date : Optional[Union[date]]
             Filling date. (provider: fmp)
-        accepted_date : Optional[datetime]
+        accepted_date : Optional[Union[datetime]]
             Accepted date. (provider: fmp)
         calendar_year : Optional[int]
             Calendar year. (provider: fmp)
@@ -667,9 +667,9 @@ class ROUTER_stocks_fa(Container):
             Capital expenditure. (provider: fmp)
         free_cash_flow : Optional[int]
             Free cash flow. (provider: fmp)
-        link : Optional[str]
+        link : Optional[Union[str]]
             Link to the statement. (provider: fmp)
-        final_link : Optional[str]
+        final_link : Optional[Union[str]]
             Link to the final statement. (provider: fmp)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -692,15 +692,15 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def cash_growth(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 10,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Cash Flow Statement Growth.
@@ -711,7 +711,7 @@ class ROUTER_stocks_fa(Container):
             Symbol to get data for.
         limit : int
             The number of data entries to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -719,9 +719,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[CashFlowStatementGrowth]
+            results : Union[List[CashFlowStatementGrowth]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -732,7 +732,7 @@ class ROUTER_stocks_fa(Container):
 
         CashFlowStatementGrowth
         -----------------------
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol to get data for.
         date : date
             The date of the data.
@@ -818,11 +818,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def comp(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Executive Compensation.
@@ -831,7 +831,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -839,9 +839,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[ExecutiveCompensation]
+            results : Union[List[ExecutiveCompensation]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -854,7 +854,7 @@ class ROUTER_stocks_fa(Container):
         ---------------------
         symbol : str
             Symbol to get data for.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             Central Index Key (CIK) of the company.
         filing_date : date
             Date of the filing.
@@ -897,30 +897,30 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def comsplit(
         self,
-        start_date: Annotated[
+        start_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="Start date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        end_date: Annotated[
+        end_date: typing_extensions.Annotated[
             Union[datetime.date, None, str],
             OpenBBCustomParameter(
                 description="End date of the data, in YYYY-MM-DD format."
             ),
         ] = None,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Stock Split Calendar.
 
         Parameters
         ----------
-        start_date : Optional[datetime.date]
+        start_date : Union[datetime.date, None]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Optional[datetime.date]
+        end_date : Union[datetime.date, None]
             End date of the data, in YYYY-MM-DD format.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -928,9 +928,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[StockSplitCalendar]
+            results : Union[List[StockSplitCalendar]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -971,11 +971,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def divs(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Historical Dividends.
@@ -984,7 +984,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -992,9 +992,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[HistoricalDividends]
+            results : Union[List[HistoricalDividends]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1013,11 +1013,11 @@ class ROUTER_stocks_fa(Container):
             Adjusted dividend of the historical dividends.
         dividend : float
             Dividend of the historical dividends.
-        record_date : Optional[date]
+        record_date : Optional[Union[date]]
             Record date of the historical dividends.
-        payment_date : Optional[date]
+        payment_date : Optional[Union[date]]
             Payment date of the historical dividends.
-        declaration_date : Optional[date]
+        declaration_date : Optional[Union[date]]
             Declaration date of the historical dividends."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -1038,15 +1038,15 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def earning(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        limit: Annotated[
-            Optional[int],
+        limit: typing_extensions.Annotated[
+            Union[int, None],
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 50,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Earnings Calendar.
@@ -1055,9 +1055,9 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        limit : Optional[int]
+        limit : Union[int, None]
             The number of data entries to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -1065,9 +1065,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[EarningsCalendar]
+            results : Union[List[EarningsCalendar]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1082,15 +1082,15 @@ class ROUTER_stocks_fa(Container):
             Symbol to get data for.
         date : date
             The date of the data.
-        eps : Optional[float]
+        eps : Optional[Union[float]]
             EPS of the earnings calendar.
-        eps_estimated : Optional[float]
+        eps_estimated : Optional[Union[float]]
             Estimated EPS of the earnings calendar.
         time : str
             Time of the earnings calendar.
-        revenue : Optional[float]
+        revenue : Optional[Union[float]]
             Revenue of the earnings calendar.
-        revenue_estimated : Optional[float]
+        revenue_estimated : Optional[Union[float]]
             Estimated revenue of the earnings calendar.
         updated_from_date : Optional[date]
             Updated from date of the earnings calendar.
@@ -1116,11 +1116,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def emp(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Number of Employees.
@@ -1129,7 +1129,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -1137,9 +1137,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[HistoricalEmployees]
+            results : Union[List[HistoricalEmployees]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1187,19 +1187,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def est(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
-            Literal["annual", "quarter"],
+        period: typing_extensions.Annotated[
+            Literal["quarter", "annual"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 30,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Analyst Estimates.
@@ -1212,7 +1212,7 @@ class ROUTER_stocks_fa(Container):
             Period of the data to return.
         limit : int
             The number of data entries to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -1220,9 +1220,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[AnalystEstimates]
+            results : Union[List[AnalystEstimates]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1298,15 +1298,15 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def filings(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        limit: Annotated[
-            Optional[int],
+        limit: typing_extensions.Annotated[
+            Union[int, None],
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 100,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Company Filings.
@@ -1315,23 +1315,23 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        limit : Optional[int]
+        limit : Union[int, None]
             The number of data entries to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        type : Optional[Literal['1', '1-A', '1-E', '1-K', '1-N', '1-SA', '1-U', '1-Z', '10', '10-D', '10-K', '10-M', '10-Q', '11-K', '12b-25', '13F', '13H', '144', '15', '15F', '17-H', '18', '18-K', '19b-4', '19b-4(e)', '19b-7', '2-E', '20-F', '24F-2', '25', '3', '4', '40-F', '5', '6-K', '7-M', '8-A', '8-K', '8-M', '9-M', 'ABS-15G', 'ABS-EE', 'ABS DD-15E', 'ADV', 'ADV-E', 'ADV-H', 'ADV-NR', 'ADV-W', 'ATS', 'ATS-N', 'ATS-R', 'BD', 'BD-N', 'BDW', 'C', 'CA-1', 'CB', 'CFPORTAL', 'CRS', 'CUSTODY', 'D', 'F-1', 'F-10', 'F-3', 'F-4', 'F-6', 'F-7', 'F-8', 'F-80', 'F-N', 'F-X', 'ID', 'MA', 'MA-I', 'MA-NR', 'MA-W', 'MSD', 'MSDW', 'N-14', 'N-17D-1', 'N-17f-1', 'N-17f-2', 'N-18f-1', 'N-1A', 'N-2', 'N-23c-3', 'N-27D-1', 'N-3', 'N-4', 'N-5', 'N-54A', 'N-54C', 'N-6', 'N-6EI-1', 'N-6F', 'N-8A', 'N-8B-2', 'N-8B-4', 'N-8F', 'N-CEN']]
+        type : Optional[Union[Literal['1', '1-A', '1-E', '1-K', '1-N', '1-SA', '1-U', '1-Z', '10', '10-D', '10-K', '10-M', '10-Q', '11-K', '12b-25', '13F', '13H', '144', '15', '15F', '17-H', '18', '18-K', '19b-4', '19b-4(e)', '19b-7', '2-E', '20-F', '24F-2', '25', '3', '4', '40-F', '5', '6-K', '7-M', '8-A', '8-K', '8-M', '9-M', 'ABS-15G', 'ABS-EE', 'ABS DD-15E', 'ADV', 'ADV-E', 'ADV-H', 'ADV-NR', 'ADV-W', 'ATS', 'ATS-N', 'ATS-R', 'BD', 'BD-N', 'BDW', 'C', 'CA-1', 'CB', 'CFPORTAL', 'CRS', 'CUSTODY', 'D', 'F-1', 'F-10', 'F-3', 'F-4', 'F-6', 'F-7', 'F-8', 'F-80', 'F-N', 'F-X', 'ID', 'MA', 'MA-I', 'MA-NR', 'MA-W', 'MSD', 'MSDW', 'N-14', 'N-17D-1', 'N-17f-1', 'N-17f-2', 'N-18f-1', 'N-1A', 'N-2', 'N-23c-3', 'N-27D-1', 'N-3', 'N-4', 'N-5', 'N-54A', 'N-54C', 'N-6', 'N-6EI-1', 'N-6F', 'N-8A', 'N-8B-2', 'N-8B-4', 'N-8F', 'N-CEN']]]
             Type of the SEC filing form. (provider: fmp)
-        page : Optional[int]
+        page : Optional[Union[int]]
             Page number of the results. (provider: fmp)
 
         Returns
         -------
         OBBject
-            results : List[CompanyFilings]
+            results : Union[List[CompanyFilings]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1348,13 +1348,13 @@ class ROUTER_stocks_fa(Container):
             Type of document.
         link : str
             URL to the document.
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             The ticker symbol of the company. (provider: fmp)
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             CIK of the SEC filing. (provider: fmp)
-        accepted_date : Optional[datetime]
+        accepted_date : Optional[Union[datetime]]
             Accepted date of the SEC filing. (provider: fmp)
-        final_link : Optional[str]
+        final_link : Optional[Union[str]]
             Final link of the SEC filing. (provider: fmp)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -1376,19 +1376,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def income(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
+        period: typing_extensions.Annotated[
             Literal["annual", "quarter"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 12,
-        provider: Optional[Literal["fmp", "intrinio", "polygon", "yfinance"]] = None,
+        provider: Union[Literal["fmp", "intrinio", "polygon", "yfinance"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Income Statement.
@@ -1401,55 +1401,55 @@ class ROUTER_stocks_fa(Container):
             Period of the data to return.
         limit : int
             The number of data entries to return.
-        provider : Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]
+        provider : Union[Literal['fmp', 'intrinio', 'polygon', 'yfinance'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             The CIK of the company if no symbol is provided. (provider: fmp)
         type : Literal['reported', 'standardized']
             Type of the statement to be fetched. (provider: intrinio)
-        year : Optional[int]
+        year : Optional[Union[int]]
             Year of the statement to be fetched. (provider: intrinio)
-        company_name : Optional[str]
+        company_name : Optional[Union[str]]
             Name of the company. (provider: polygon)
-        company_name_search : Optional[str]
+        company_name_search : Optional[Union[str]]
             Name of the company to search. (provider: polygon)
-        sic : Optional[str]
+        sic : Optional[Union[str]]
             The Standard Industrial Classification (SIC) of the company. (provider: polygon)
-        filing_date : Optional[datetime.date]
+        filing_date : Optional[Union[datetime.date]]
             Filing date of the financial statement. (provider: polygon)
-        filing_date_lt : Optional[datetime.date]
+        filing_date_lt : Optional[Union[datetime.date]]
             Filing date less than the given date. (provider: polygon)
-        filing_date_lte : Optional[datetime.date]
+        filing_date_lte : Optional[Union[datetime.date]]
             Filing date less than or equal to the given date. (provider: polygon)
-        filing_date_gt : Optional[datetime.date]
+        filing_date_gt : Optional[Union[datetime.date]]
             Filing date greater than the given date. (provider: polygon)
-        filing_date_gte : Optional[datetime.date]
+        filing_date_gte : Optional[Union[datetime.date]]
             Filing date greater than or equal to the given date. (provider: polygon)
-        period_of_report_date : Optional[datetime.date]
+        period_of_report_date : Optional[Union[datetime.date]]
             Period of report date of the financial statement. (provider: polygon)
-        period_of_report_date_lt : Optional[datetime.date]
+        period_of_report_date_lt : Optional[Union[datetime.date]]
             Period of report date less than the given date. (provider: polygon)
-        period_of_report_date_lte : Optional[datetime.date]
+        period_of_report_date_lte : Optional[Union[datetime.date]]
             Period of report date less than or equal to the given date. (provider: polygon)
-        period_of_report_date_gt : Optional[datetime.date]
+        period_of_report_date_gt : Optional[Union[datetime.date]]
             Period of report date greater than the given date. (provider: polygon)
-        period_of_report_date_gte : Optional[datetime.date]
+        period_of_report_date_gte : Optional[Union[datetime.date]]
             Period of report date greater than or equal to the given date. (provider: polygon)
-        include_sources : Optional[bool]
+        include_sources : Optional[Union[bool]]
             Whether to include the sources of the financial statement. (provider: polygon)
-        order : Optional[Literal['asc', 'desc']]
+        order : Optional[Union[Literal['asc', 'desc']]]
             Order of the financial statement. (provider: polygon)
-        sort : Optional[Literal['filing_date', 'period_of_report_date']]
+        sort : Optional[Union[Literal['filing_date', 'period_of_report_date']]]
             Sort of the financial statement. (provider: polygon)
 
         Returns
         -------
         OBBject
-            results : List[IncomeStatement]
+            results : Union[List[IncomeStatement]]
                 Serializable results.
-            provider : Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]
+            provider : Union[Literal['fmp', 'intrinio', 'polygon', 'yfinance'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1460,13 +1460,13 @@ class ROUTER_stocks_fa(Container):
 
         IncomeStatement
         ---------------
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol to get data for.
         date : date
             Date of the income statement.
-        period : Optional[str]
+        period : Optional[Union[str]]
             Period of the income statement.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             Central Index Key.
         revenue : Optional[int]
             Revenue.
@@ -1476,7 +1476,7 @@ class ROUTER_stocks_fa(Container):
             Gross profit.
         cost_and_expenses : Optional[int]
             Cost and expenses.
-        gross_profit_ratio : Optional[float]
+        gross_profit_ratio : Optional[Union[float]]
             Gross profit ratio.
         research_and_development_expenses : Optional[int]
             Research and development expenses.
@@ -1494,11 +1494,11 @@ class ROUTER_stocks_fa(Container):
             Depreciation and amortization.
         ebitda : Optional[int]
             Earnings before interest, taxes, depreciation and amortization.
-        ebitda_ratio : Optional[float]
+        ebitda_ratio : Optional[Union[float]]
             Earnings before interest, taxes, depreciation and amortization ratio.
         operating_income : Optional[int]
             Operating income.
-        operating_income_ratio : Optional[float]
+        operating_income_ratio : Optional[Union[float]]
             Operating income ratio.
         interest_income : Optional[int]
             Interest income.
@@ -1508,51 +1508,51 @@ class ROUTER_stocks_fa(Container):
             Total other income expenses net.
         income_before_tax : Optional[int]
             Income before tax.
-        income_before_tax_ratio : Optional[float]
+        income_before_tax_ratio : Optional[Union[float]]
             Income before tax ratio.
         income_tax_expense : Optional[int]
             Income tax expense.
         net_income : Optional[int]
             Net income.
-        net_income_ratio : Optional[float]
+        net_income_ratio : Optional[Union[float]]
             Net income ratio.
-        eps : Optional[float]
+        eps : Optional[Union[float]]
             Earnings per share.
-        eps_diluted : Optional[float]
+        eps_diluted : Optional[Union[float]]
             Earnings per share diluted.
         weighted_average_shares_outstanding : Optional[int]
             Weighted average shares outstanding.
         weighted_average_shares_outstanding_dil : Optional[int]
             Weighted average shares outstanding diluted.
-        link : Optional[str]
+        link : Optional[Union[str]]
             Link to the income statement.
-        final_link : Optional[str]
+        final_link : Optional[Union[str]]
             Final link to the income statement.
-        reported_currency : Optional[str]
+        reported_currency : Optional[Union[str]]
             Reporting currency. (provider: fmp)
-        filling_date : Optional[date]
+        filling_date : Optional[Union[date]]
             Filling date. (provider: fmp)
-        accepted_date : Optional[datetime]
+        accepted_date : Optional[Union[datetime]]
             Accepted date. (provider: fmp)
-        calendar_year : Optional[int]
+        calendar_year : Optional[Union[int]]
             Calendar year. (provider: fmp)
-        income_loss_from_continuing_operations_before_tax : Optional[float]
+        income_loss_from_continuing_operations_before_tax : Optional[Union[float]]
             Income/Loss From Continuing Operations After Tax (provider: polygon)
-        income_loss_from_continuing_operations_after_tax : Optional[float]
+        income_loss_from_continuing_operations_after_tax : Optional[Union[float]]
             Income (loss) from continuing operations after tax (provider: polygon)
-        benefits_costs_expenses : Optional[float]
+        benefits_costs_expenses : Optional[Union[float]]
             Benefits, costs and expenses (provider: polygon)
         net_income_loss_attributable_to_noncontrolling_interest : Optional[int]
             Net income (loss) attributable to noncontrolling interest (provider: polygon)
-        net_income_loss_attributable_to_parent : Optional[float]
+        net_income_loss_attributable_to_parent : Optional[Union[float]]
             Net income (loss) attributable to parent (provider: polygon)
-        net_income_loss_available_to_common_stockholders_basic : Optional[float]
+        net_income_loss_available_to_common_stockholders_basic : Optional[Union[float]]
             Net Income/Loss Available To Common Stockholders Basic (provider: polygon)
-        participating_securities_distributed_and_undistributed_earnings_loss_basic : Optional[float]
+        participating_securities_distributed_and_undistributed_earnings_loss_basic : Optional[Union[float]]
             Participating Securities Distributed And Undistributed Earnings Loss Basic (provider: polygon)
-        nonoperating_income_loss : Optional[float]
+        nonoperating_income_loss : Optional[Union[float]]
             Nonoperating Income Loss (provider: polygon)
-        preferred_stock_dividends_and_other_adjustments : Optional[float]
+        preferred_stock_dividends_and_other_adjustments : Optional[Union[float]]
             Preferred stock dividends and other adjustments (provider: polygon)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -1575,19 +1575,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def income_growth(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 10,
-        period: Annotated[
+        period: typing_extensions.Annotated[
             Literal["annual", "quarter"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Income Statement Growth.
@@ -1600,7 +1600,7 @@ class ROUTER_stocks_fa(Container):
             The number of data entries to return.
         period : Literal['annual', 'quarter']
             Period of the data to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -1608,9 +1608,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[IncomeStatementGrowth]
+            results : Union[List[IncomeStatementGrowth]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1621,7 +1621,7 @@ class ROUTER_stocks_fa(Container):
 
         IncomeStatementGrowth
         ---------------------
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol to get data for.
         date : date
             The date of the data.
@@ -1700,11 +1700,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def ins(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        transactionType: Annotated[
+        transactionType: typing_extensions.Annotated[
             Union[
                 List[
                     Literal[
@@ -1733,11 +1733,11 @@ class ROUTER_stocks_fa(Container):
             ],
             OpenBBCustomParameter(description="Type of the transaction."),
         ] = ["P-Purchase"],
-        page: Annotated[
-            Optional[int],
+        page: typing_extensions.Annotated[
+            Union[int, None],
             OpenBBCustomParameter(description="Page number of the data to fetch."),
         ] = 0,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Stock Insider Trading.
@@ -1748,9 +1748,9 @@ class ROUTER_stocks_fa(Container):
             Symbol to get data for.
         transactionType : Union[List[Literal['A-Award', 'C-Conversion', 'D-Return', ...
             Type of the transaction.
-        page : Optional[int]
+        page : Union[int, None]
             Page number of the data to fetch.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -1758,9 +1758,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[StockInsiderTrading]
+            results : Union[List[StockInsiderTrading]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1822,19 +1822,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def ins_own(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        include_current_quarter: Annotated[
-            Optional[bool],
+        include_current_quarter: typing_extensions.Annotated[
+            Union[bool, None],
             OpenBBCustomParameter(description="Include current quarter data."),
         ] = False,
-        date: Annotated[
-            Optional[datetime.date],
+        date: typing_extensions.Annotated[
+            Union[datetime.date, None],
             OpenBBCustomParameter(description="A specific date to get data for."),
         ] = None,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Institutional Ownership.
@@ -1843,11 +1843,11 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        include_current_quarter : Optional[bool]
+        include_current_quarter : Union[bool, None]
             Include current quarter data.
-        date : Optional[datetime.date]
+        date : Union[datetime.date, None]
             A specific date to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -1855,9 +1855,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[InstitutionalOwnership]
+            results : Union[List[InstitutionalOwnership]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -1870,7 +1870,7 @@ class ROUTER_stocks_fa(Container):
         ----------------------
         symbol : str
             Symbol to get data for.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             CIK of the company.
         date : date
             The date of the data.
@@ -1962,19 +1962,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def metrics(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
-            Optional[Literal["annual", "quarter"]],
+        period: typing_extensions.Annotated[
+            Union[Literal["annual", "quarter"], None],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        limit: Annotated[
-            Optional[int],
+        limit: typing_extensions.Annotated[
+            Union[int, None],
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 100,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Key Metrics.
@@ -1983,23 +1983,23 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        period : Optional[Literal['annual', 'quarter']]
+        period : Union[Literal['annual', 'quarter'], None]
             Period of the data to return.
-        limit : Optional[int]
+        limit : Union[int, None]
             The number of data entries to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        with_ttm : Optional[bool]
+        with_ttm : Optional[Union[bool]]
             Include trailing twelve months (TTM) data. (provider: fmp)
 
         Returns
         -------
         OBBject
-            results : List[KeyMetrics]
+            results : Union[List[KeyMetrics]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2010,125 +2010,125 @@ class ROUTER_stocks_fa(Container):
 
         KeyMetrics
         ----------
-        symbol : Optional[str]
+        symbol : Optional[Union[str]]
             Symbol to get data for.
         date : date
             The date of the data.
         period : str
             Period of the data.
-        revenue_per_share : Optional[float]
+        revenue_per_share : Optional[Union[float]]
             Revenue per share
-        net_income_per_share : Optional[float]
+        net_income_per_share : Optional[Union[float]]
             Net income per share
-        operating_cash_flow_per_share : Optional[float]
+        operating_cash_flow_per_share : Optional[Union[float]]
             Operating cash flow per share
-        free_cash_flow_per_share : Optional[float]
+        free_cash_flow_per_share : Optional[Union[float]]
             Free cash flow per share
-        cash_per_share : Optional[float]
+        cash_per_share : Optional[Union[float]]
             Cash per share
-        book_value_per_share : Optional[float]
+        book_value_per_share : Optional[Union[float]]
             Book value per share
-        tangible_book_value_per_share : Optional[float]
+        tangible_book_value_per_share : Optional[Union[float]]
             Tangible book value per share
-        shareholders_equity_per_share : Optional[float]
+        shareholders_equity_per_share : Optional[Union[float]]
             Shareholders equity per share
-        interest_debt_per_share : Optional[float]
+        interest_debt_per_share : Optional[Union[float]]
             Interest debt per share
-        market_cap : Optional[float]
+        market_cap : Optional[Union[float]]
             Market capitalization
-        enterprise_value : Optional[float]
+        enterprise_value : Optional[Union[float]]
             Enterprise value
-        pe_ratio : Optional[float]
+        pe_ratio : Optional[Union[float]]
             Price-to-earnings ratio (P/E ratio)
-        price_to_sales_ratio : Optional[float]
+        price_to_sales_ratio : Optional[Union[float]]
             Price-to-sales ratio
-        pocf_ratio : Optional[float]
+        pocf_ratio : Optional[Union[float]]
             Price-to-operating cash flow ratio
-        pfcf_ratio : Optional[float]
+        pfcf_ratio : Optional[Union[float]]
             Price-to-free cash flow ratio
-        pb_ratio : Optional[float]
+        pb_ratio : Optional[Union[float]]
             Price-to-book ratio
-        ptb_ratio : Optional[float]
+        ptb_ratio : Optional[Union[float]]
             Price-to-tangible book ratio
-        ev_to_sales : Optional[float]
+        ev_to_sales : Optional[Union[float]]
             Enterprise value-to-sales ratio
-        enterprise_value_over_ebitda : Optional[float]
+        enterprise_value_over_ebitda : Optional[Union[float]]
             Enterprise value-to-EBITDA ratio
-        ev_to_operating_cash_flow : Optional[float]
+        ev_to_operating_cash_flow : Optional[Union[float]]
             Enterprise value-to-operating cash flow ratio
-        ev_to_free_cash_flow : Optional[float]
+        ev_to_free_cash_flow : Optional[Union[float]]
             Enterprise value-to-free cash flow ratio
-        earnings_yield : Optional[float]
+        earnings_yield : Optional[Union[float]]
             Earnings yield
-        free_cash_flow_yield : Optional[float]
+        free_cash_flow_yield : Optional[Union[float]]
             Free cash flow yield
-        debt_to_equity : Optional[float]
+        debt_to_equity : Optional[Union[float]]
             Debt-to-equity ratio
-        debt_to_assets : Optional[float]
+        debt_to_assets : Optional[Union[float]]
             Debt-to-assets ratio
-        net_debt_to_ebitda : Optional[float]
+        net_debt_to_ebitda : Optional[Union[float]]
             Net debt-to-EBITDA ratio
-        current_ratio : Optional[float]
+        current_ratio : Optional[Union[float]]
             Current ratio
-        interest_coverage : Optional[float]
+        interest_coverage : Optional[Union[float]]
             Interest coverage
-        income_quality : Optional[float]
+        income_quality : Optional[Union[float]]
             Income quality
-        dividend_yield : Optional[float]
+        dividend_yield : Optional[Union[float]]
             Dividend yield
-        payout_ratio : Optional[float]
+        payout_ratio : Optional[Union[float]]
             Payout ratio
-        sales_general_and_administrative_to_revenue : Optional[float]
+        sales_general_and_administrative_to_revenue : Optional[Union[float]]
             Sales general and administrative expenses-to-revenue ratio
-        research_and_development_to_revenue : Optional[float]
+        research_and_development_to_revenue : Optional[Union[float]]
             Research and development expenses-to-revenue ratio
-        intangibles_to_total_assets : Optional[float]
+        intangibles_to_total_assets : Optional[Union[float]]
             Intangibles-to-total assets ratio
-        capex_to_operating_cash_flow : Optional[float]
+        capex_to_operating_cash_flow : Optional[Union[float]]
             Capital expenditures-to-operating cash flow ratio
-        capex_to_revenue : Optional[float]
+        capex_to_revenue : Optional[Union[float]]
             Capital expenditures-to-revenue ratio
-        capex_to_depreciation : Optional[float]
+        capex_to_depreciation : Optional[Union[float]]
             Capital expenditures-to-depreciation ratio
-        stock_based_compensation_to_revenue : Optional[float]
+        stock_based_compensation_to_revenue : Optional[Union[float]]
             Stock-based compensation-to-revenue ratio
-        graham_number : Optional[float]
+        graham_number : Optional[Union[float]]
             Graham number
-        roic : Optional[float]
+        roic : Optional[Union[float]]
             Return on invested capital
-        return_on_tangible_assets : Optional[float]
+        return_on_tangible_assets : Optional[Union[float]]
             Return on tangible assets
-        graham_net_net : Optional[float]
+        graham_net_net : Optional[Union[float]]
             Graham net-net working capital
-        working_capital : Optional[float]
+        working_capital : Optional[Union[float]]
             Working capital
-        tangible_asset_value : Optional[float]
+        tangible_asset_value : Optional[Union[float]]
             Tangible asset value
-        net_current_asset_value : Optional[float]
+        net_current_asset_value : Optional[Union[float]]
             Net current asset value
-        invested_capital : Optional[float]
+        invested_capital : Optional[Union[float]]
             Invested capital
-        average_receivables : Optional[float]
+        average_receivables : Optional[Union[float]]
             Average receivables
-        average_payables : Optional[float]
+        average_payables : Optional[Union[float]]
             Average payables
-        average_inventory : Optional[float]
+        average_inventory : Optional[Union[float]]
             Average inventory
-        days_sales_outstanding : Optional[float]
+        days_sales_outstanding : Optional[Union[float]]
             Days sales outstanding
-        days_payables_outstanding : Optional[float]
+        days_payables_outstanding : Optional[Union[float]]
             Days payables outstanding
-        days_of_inventory_on_hand : Optional[float]
+        days_of_inventory_on_hand : Optional[Union[float]]
             Days of inventory on hand
-        receivables_turnover : Optional[float]
+        receivables_turnover : Optional[Union[float]]
             Receivables turnover
-        payables_turnover : Optional[float]
+        payables_turnover : Optional[Union[float]]
             Payables turnover
-        inventory_turnover : Optional[float]
+        inventory_turnover : Optional[Union[float]]
             Inventory turnover
-        roe : Optional[float]
+        roe : Optional[Union[float]]
             Return on equity
-        capex_per_share : Optional[float]
+        capex_per_share : Optional[Union[float]]
             Capital expenditures per share
         calendar_year : Optional[int]
             Calendar year. (provider: fmp)"""  # noqa: E501
@@ -2153,11 +2153,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def mgmt(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Key Executives.
@@ -2166,7 +2166,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2174,9 +2174,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[KeyExecutives]
+            results : Union[List[KeyExecutives]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2195,7 +2195,7 @@ class ROUTER_stocks_fa(Container):
             Pay of the key executive.
         currency_pay : str
             Currency of the pay.
-        gender : Optional[str]
+        gender : Optional[Union[str]]
             Gender of the key executive.
         year_born : Optional[int]
             Birth year of the key executive.
@@ -2220,11 +2220,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def overview(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[Data]:
         """Company Overview.
@@ -2233,7 +2233,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2241,9 +2241,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : CompanyOverview
+            results : Union[CompanyOverview]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2256,65 +2256,65 @@ class ROUTER_stocks_fa(Container):
         ---------------
         symbol : str
             Symbol to get data for.
-        price : Optional[float]
+        price : Optional[Union[float]]
             Price of the company.
-        beta : Optional[float]
+        beta : Optional[Union[float]]
             Beta of the company.
         vol_avg : Optional[int]
             Volume average of the company.
         mkt_cap : Optional[int]
             Market capitalization of the company.
-        last_div : Optional[float]
+        last_div : Optional[Union[float]]
             Last dividend of the company.
-        range : Optional[str]
+        range : Optional[Union[str]]
             Range of the company.
-        changes : Optional[float]
+        changes : Optional[Union[float]]
             Changes of the company.
-        company_name : Optional[str]
+        company_name : Optional[Union[str]]
             Company name of the company.
-        currency : Optional[str]
+        currency : Optional[Union[str]]
             Currency of the company.
-        cik : Optional[str]
+        cik : Optional[Union[str]]
             CIK of the company.
-        isin : Optional[str]
+        isin : Optional[Union[str]]
             ISIN of the company.
-        cusip : Optional[str]
+        cusip : Optional[Union[str]]
             CUSIP of the company.
-        exchange : Optional[str]
+        exchange : Optional[Union[str]]
             Exchange of the company.
-        exchange_short_name : Optional[str]
+        exchange_short_name : Optional[Union[str]]
             Exchange short name of the company.
-        industry : Optional[str]
+        industry : Optional[Union[str]]
             Industry of the company.
-        website : Optional[str]
+        website : Optional[Union[str]]
             Website of the company.
-        description : Optional[str]
+        description : Optional[Union[str]]
             Description of the company.
-        ceo : Optional[str]
+        ceo : Optional[Union[str]]
             CEO of the company.
-        sector : Optional[str]
+        sector : Optional[Union[str]]
             Sector of the company.
-        country : Optional[str]
+        country : Optional[Union[str]]
             Country of the company.
-        full_time_employees : Optional[str]
+        full_time_employees : Optional[Union[str]]
             Full time employees of the company.
-        phone : Optional[str]
+        phone : Optional[Union[str]]
             Phone of the company.
-        address : Optional[str]
+        address : Optional[Union[str]]
             Address of the company.
-        city : Optional[str]
+        city : Optional[Union[str]]
             City of the company.
-        state : Optional[str]
+        state : Optional[Union[str]]
             State of the company.
-        zip : Optional[str]
+        zip : Optional[Union[str]]
             Zip of the company.
-        dcf_diff : Optional[float]
+        dcf_diff : Optional[Union[float]]
             Discounted cash flow difference of the company.
-        dcf : Optional[float]
+        dcf : Optional[Union[float]]
             Discounted cash flow of the company.
-        image : Optional[str]
+        image : Optional[Union[str]]
             Image of the company.
-        ipo_date : Optional[date]
+        ipo_date : Optional[Union[date]]
             IPO date of the company.
         default_image : bool
             If the image is the default image.
@@ -2345,19 +2345,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def own(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        date: Annotated[
-            Optional[datetime.date],
+        date: typing_extensions.Annotated[
+            Union[datetime.date, None],
             OpenBBCustomParameter(description="A specific date to get data for."),
         ] = None,
-        page: Annotated[
-            Optional[int],
+        page: typing_extensions.Annotated[
+            Union[int, None],
             OpenBBCustomParameter(description="Page number of the data to fetch."),
         ] = 0,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Stock Ownership.
@@ -2366,11 +2366,11 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        date : Optional[datetime.date]
+        date : Union[datetime.date, None]
             A specific date to get data for.
-        page : Optional[int]
+        page : Union[int, None]
             Page number of the data to fetch.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2378,9 +2378,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[StockOwnership]
+            results : Union[List[StockOwnership]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2490,11 +2490,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def pt(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[Data]:
         """Price Target Consensus.
@@ -2503,7 +2503,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2511,9 +2511,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : PriceTargetConsensus
+            results : Union[PriceTargetConsensus]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2526,13 +2526,13 @@ class ROUTER_stocks_fa(Container):
         --------------------
         symbol : str
             Symbol to get data for.
-        target_high : Optional[float]
+        target_high : Optional[Union[float]]
             High target of the price target consensus.
-        target_low : Optional[float]
+        target_low : Optional[Union[float]]
             Low target of the price target consensus.
-        target_consensus : Optional[float]
+        target_consensus : Optional[Union[float]]
             Consensus target of the price target consensus.
-        target_median : Optional[float]
+        target_median : Optional[Union[float]]
             Median target of the price target consensus."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -2553,11 +2553,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def pta(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Price Target.
@@ -2566,7 +2566,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2576,9 +2576,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[PriceTarget]
+            results : Union[List[PriceTarget]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2593,29 +2593,29 @@ class ROUTER_stocks_fa(Container):
             Symbol to get data for.
         published_date : datetime
             Published date of the price target.
-        news_url : Optional[str]
+        news_url : Optional[Union[str]]
             News URL of the price target.
-        news_title : Optional[str]
+        news_title : Optional[Union[str]]
             News title of the price target.
-        analyst_name : Optional[str]
+        analyst_name : Optional[Union[str]]
             Analyst name.
-        analyst_company : Optional[str]
+        analyst_company : Optional[Union[str]]
             Analyst company.
-        price_target : Optional[float]
+        price_target : Optional[Union[float]]
             Price target.
-        adj_price_target : Optional[float]
+        adj_price_target : Optional[Union[float]]
             Adjusted price target.
-        price_when_posted : Optional[float]
+        price_when_posted : Optional[Union[float]]
             Price when posted.
-        news_publisher : Optional[str]
+        news_publisher : Optional[Union[str]]
             News publisher of the price target.
-        news_base_url : Optional[str]
+        news_base_url : Optional[Union[str]]
             News base URL of the price target.
-        new_grade : Optional[str]
+        new_grade : Optional[Union[str]]
             New grade (provider: fmp)
-        previous_grade : Optional[str]
+        previous_grade : Optional[Union[str]]
             Previous grade (provider: fmp)
-        grading_company : Optional[str]
+        grading_company : Optional[Union[str]]
             Grading company (provider: fmp)"""  # noqa: E501
 
         inputs = filter_inputs(
@@ -2636,19 +2636,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def ratios(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
+        period: typing_extensions.Annotated[
             Literal["annual", "quarter"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        limit: Annotated[
+        limit: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="The number of data entries to return."),
         ] = 12,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Extensive set of ratios over time.
@@ -2661,19 +2661,19 @@ class ROUTER_stocks_fa(Container):
             Period of the data to return.
         limit : int
             The number of data entries to return.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        with_ttm : Optional[bool]
+        with_ttm : Optional[Union[bool]]
             Include trailing twelve months (TTM) data. (provider: fmp)
 
         Returns
         -------
         OBBject
-            results : List[FinancialRatios]
+            results : Union[List[FinancialRatios]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2690,113 +2690,113 @@ class ROUTER_stocks_fa(Container):
             Date of the financial ratios.
         period : str
             Period of the financial ratios.
-        current_ratio : Optional[float]
+        current_ratio : Optional[Union[float]]
             Current ratio.
-        quick_ratio : Optional[float]
+        quick_ratio : Optional[Union[float]]
             Quick ratio.
-        cash_ratio : Optional[float]
+        cash_ratio : Optional[Union[float]]
             Cash ratio.
-        days_of_sales_outstanding : Optional[float]
+        days_of_sales_outstanding : Optional[Union[float]]
             Days of sales outstanding.
-        days_of_inventory_outstanding : Optional[float]
+        days_of_inventory_outstanding : Optional[Union[float]]
             Days of inventory outstanding.
-        operating_cycle : Optional[float]
+        operating_cycle : Optional[Union[float]]
             Operating cycle.
-        days_of_payables_outstanding : Optional[float]
+        days_of_payables_outstanding : Optional[Union[float]]
             Days of payables outstanding.
-        cash_conversion_cycle : Optional[float]
+        cash_conversion_cycle : Optional[Union[float]]
             Cash conversion cycle.
-        gross_profit_margin : Optional[float]
+        gross_profit_margin : Optional[Union[float]]
             Gross profit margin.
-        operating_profit_margin : Optional[float]
+        operating_profit_margin : Optional[Union[float]]
             Operating profit margin.
-        pretax_profit_margin : Optional[float]
+        pretax_profit_margin : Optional[Union[float]]
             Pretax profit margin.
-        net_profit_margin : Optional[float]
+        net_profit_margin : Optional[Union[float]]
             Net profit margin.
-        effective_tax_rate : Optional[float]
+        effective_tax_rate : Optional[Union[float]]
             Effective tax rate.
-        return_on_assets : Optional[float]
+        return_on_assets : Optional[Union[float]]
             Return on assets.
-        return_on_equity : Optional[float]
+        return_on_equity : Optional[Union[float]]
             Return on equity.
-        return_on_capital_employed : Optional[float]
+        return_on_capital_employed : Optional[Union[float]]
             Return on capital employed.
-        net_income_per_ebt : Optional[float]
+        net_income_per_ebt : Optional[Union[float]]
             Net income per EBT.
-        ebt_per_ebit : Optional[float]
+        ebt_per_ebit : Optional[Union[float]]
             EBT per EBIT.
-        ebit_per_revenue : Optional[float]
+        ebit_per_revenue : Optional[Union[float]]
             EBIT per revenue.
-        debt_ratio : Optional[float]
+        debt_ratio : Optional[Union[float]]
             Debt ratio.
-        debt_equity_ratio : Optional[float]
+        debt_equity_ratio : Optional[Union[float]]
             Debt equity ratio.
-        long_term_debt_to_capitalization : Optional[float]
+        long_term_debt_to_capitalization : Optional[Union[float]]
             Long term debt to capitalization.
-        total_debt_to_capitalization : Optional[float]
+        total_debt_to_capitalization : Optional[Union[float]]
             Total debt to capitalization.
-        interest_coverage : Optional[float]
+        interest_coverage : Optional[Union[float]]
             Interest coverage.
-        cash_flow_to_debt_ratio : Optional[float]
+        cash_flow_to_debt_ratio : Optional[Union[float]]
             Cash flow to debt ratio.
-        company_equity_multiplier : Optional[float]
+        company_equity_multiplier : Optional[Union[float]]
             Company equity multiplier.
-        receivables_turnover : Optional[float]
+        receivables_turnover : Optional[Union[float]]
             Receivables turnover.
-        payables_turnover : Optional[float]
+        payables_turnover : Optional[Union[float]]
             Payables turnover.
-        inventory_turnover : Optional[float]
+        inventory_turnover : Optional[Union[float]]
             Inventory turnover.
-        fixed_asset_turnover : Optional[float]
+        fixed_asset_turnover : Optional[Union[float]]
             Fixed asset turnover.
-        asset_turnover : Optional[float]
+        asset_turnover : Optional[Union[float]]
             Asset turnover.
-        operating_cash_flow_per_share : Optional[float]
+        operating_cash_flow_per_share : Optional[Union[float]]
             Operating cash flow per share.
-        free_cash_flow_per_share : Optional[float]
+        free_cash_flow_per_share : Optional[Union[float]]
             Free cash flow per share.
-        cash_per_share : Optional[float]
+        cash_per_share : Optional[Union[float]]
             Cash per share.
-        payout_ratio : Optional[float]
+        payout_ratio : Optional[Union[float]]
             Payout ratio.
-        operating_cash_flow_sales_ratio : Optional[float]
+        operating_cash_flow_sales_ratio : Optional[Union[float]]
             Operating cash flow sales ratio.
-        free_cash_flow_operating_cash_flow_ratio : Optional[float]
+        free_cash_flow_operating_cash_flow_ratio : Optional[Union[float]]
             Free cash flow operating cash flow ratio.
-        cash_flow_coverage_ratios : Optional[float]
+        cash_flow_coverage_ratios : Optional[Union[float]]
             Cash flow coverage ratios.
-        short_term_coverage_ratios : Optional[float]
+        short_term_coverage_ratios : Optional[Union[float]]
             Short term coverage ratios.
-        capital_expenditure_coverage_ratio : Optional[float]
+        capital_expenditure_coverage_ratio : Optional[Union[float]]
             Capital expenditure coverage ratio.
-        dividend_paid_and_capex_coverage_ratio : Optional[float]
+        dividend_paid_and_capex_coverage_ratio : Optional[Union[float]]
             Dividend paid and capex coverage ratio.
-        dividend_payout_ratio : Optional[float]
+        dividend_payout_ratio : Optional[Union[float]]
             Dividend payout ratio.
-        price_book_value_ratio : Optional[float]
+        price_book_value_ratio : Optional[Union[float]]
             Price book value ratio.
-        price_to_book_ratio : Optional[float]
+        price_to_book_ratio : Optional[Union[float]]
             Price to book ratio.
-        price_to_sales_ratio : Optional[float]
+        price_to_sales_ratio : Optional[Union[float]]
             Price to sales ratio.
-        price_earnings_ratio : Optional[float]
+        price_earnings_ratio : Optional[Union[float]]
             Price earnings ratio.
-        price_to_free_cash_flows_ratio : Optional[float]
+        price_to_free_cash_flows_ratio : Optional[Union[float]]
             Price to free cash flows ratio.
-        price_to_operating_cash_flows_ratio : Optional[float]
+        price_to_operating_cash_flows_ratio : Optional[Union[float]]
             Price to operating cash flows ratio.
-        price_cash_flow_ratio : Optional[float]
+        price_cash_flow_ratio : Optional[Union[float]]
             Price cash flow ratio.
-        price_earnings_to_growth_ratio : Optional[float]
+        price_earnings_to_growth_ratio : Optional[Union[float]]
             Price earnings to growth ratio.
-        price_sales_ratio : Optional[float]
+        price_sales_ratio : Optional[Union[float]]
             Price sales ratio.
-        dividend_yield : Optional[float]
+        dividend_yield : Optional[Union[float]]
             Dividend yield.
-        enterprise_value_multiple : Optional[float]
+        enterprise_value_multiple : Optional[Union[float]]
             Enterprise value multiple.
-        price_fair_value : Optional[float]
+        price_fair_value : Optional[Union[float]]
             Price fair value."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -2819,19 +2819,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def revgeo(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
-            Literal["annual", "quarter"],
+        period: typing_extensions.Annotated[
+            Literal["quarter", "annual"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        structure: Annotated[
+        structure: typing_extensions.Annotated[
             Literal["hierarchical", "flat"],
             OpenBBCustomParameter(description="Structure of the returned data."),
         ] = "flat",
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Revenue Geographic.
@@ -2844,7 +2844,7 @@ class ROUTER_stocks_fa(Container):
             Period of the data to return.
         structure : Literal['hierarchical', 'flat']
             Structure of the returned data.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2852,9 +2852,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[RevenueGeographic]
+            results : Union[List[RevenueGeographic]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2900,19 +2900,19 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def revseg(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        period: Annotated[
-            Literal["annual", "quarter"],
+        period: typing_extensions.Annotated[
+            Literal["quarter", "annual"],
             OpenBBCustomParameter(description="Period of the data to return."),
         ] = "annual",
-        structure: Annotated[
+        structure: typing_extensions.Annotated[
             Literal["hierarchical", "flat"],
             OpenBBCustomParameter(description="Structure of the returned data."),
         ] = "flat",
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Revenue Business Line.
@@ -2925,7 +2925,7 @@ class ROUTER_stocks_fa(Container):
             Period of the data to return.
         structure : Literal['hierarchical', 'flat']
             Structure of the returned data.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2933,9 +2933,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[RevenueBusinessLine]
+            results : Union[List[RevenueBusinessLine]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -2971,11 +2971,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def shrs(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Share Statistics.
@@ -2984,7 +2984,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -2992,9 +2992,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[ShareStatistics]
+            results : Union[List[ShareStatistics]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -3007,15 +3007,15 @@ class ROUTER_stocks_fa(Container):
         ---------------
         symbol : str
             Symbol to get data for.
-        date : Optional[date]
+        date : Optional[Union[date]]
             A specific date to get data for.
-        free_float : Optional[float]
+        free_float : Optional[Union[float]]
             Percentage of unrestricted shares of a publicly-traded company.
-        float_shares : Optional[float]
+        float_shares : Optional[Union[float]]
             Number of shares available for trading by the general public.
-        outstanding_shares : Optional[float]
+        outstanding_shares : Optional[Union[float]]
             Total number of shares of a publicly-traded company.
-        source : Optional[str]
+        source : Optional[Union[str]]
             Source of the received data."""  # noqa: E501
 
         inputs = filter_inputs(
@@ -3036,11 +3036,11 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def split(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Historical Stock Splits.
@@ -3049,7 +3049,7 @@ class ROUTER_stocks_fa(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -3057,9 +3057,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[HistoricalStockSplits]
+            results : Union[List[HistoricalStockSplits]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -3097,21 +3097,21 @@ class ROUTER_stocks_fa(Container):
     @validate_call
     def transcript(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        year: Annotated[
+        year: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(description="Year of the earnings call transcript."),
         ],
-        quarter: Annotated[
+        quarter: typing_extensions.Annotated[
             int,
             OpenBBCustomParameter(
                 description="Quarter of the earnings call transcript."
             ),
         ] = 1,
-        provider: Optional[Literal["fmp"]] = None,
+        provider: Union[Literal["fmp"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Earnings Call Transcript.
@@ -3124,7 +3124,7 @@ class ROUTER_stocks_fa(Container):
             Year of the earnings call transcript.
         quarter : int
             Quarter of the earnings call transcript.
-        provider : Optional[Literal['fmp']]
+        provider : Union[Literal['fmp'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -3132,9 +3132,9 @@ class ROUTER_stocks_fa(Container):
         Returns
         -------
         OBBject
-            results : List[EarningsCallTranscript]
+            results : Union[List[EarningsCallTranscript]]
                 Serializable results.
-            provider : Optional[Literal['fmp']]
+            provider : Union[Literal['fmp'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.

--- a/openbb_platform/openbb/package/stocks_options.py
+++ b/openbb_platform/openbb/package/stocks_options.py
@@ -1,14 +1,14 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
+import typing_extensions
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_stocks_options(Container):
@@ -22,11 +22,11 @@ class ROUTER_stocks_options(Container):
     @validate_call
     def chains(
         self,
-        symbol: Annotated[
+        symbol: typing_extensions.Annotated[
             Union[str, List[str]],
             OpenBBCustomParameter(description="Symbol to get data for."),
         ],
-        provider: Optional[Literal["cboe", "intrinio"]] = None,
+        provider: Union[Literal["cboe", "intrinio"], None] = None,
         **kwargs
     ) -> OBBject[List[Data]]:
         """Get the complete options chain for a ticker.
@@ -35,19 +35,19 @@ class ROUTER_stocks_options(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['cboe', 'intrinio']]
+        provider : Union[Literal['cboe', 'intrinio'], None]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'cboe' if there is
             no default.
-        date : Optional[str]
+        date : Optional[Union[str]]
             Date for which the options chains are returned. (provider: intrinio)
 
         Returns
         -------
         OBBject
-            results : List[OptionsChains]
+            results : Union[List[OptionsChains]]
                 Serializable results.
-            provider : Optional[Literal['cboe', 'intrinio']]
+            provider : Union[Literal['cboe', 'intrinio'], None]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
@@ -70,67 +70,67 @@ class ROUTER_stocks_options(Container):
             Call or Put.
         date : date
             Date for which the options chains are returned.
-        close : Optional[float]
+        close : Optional[Union[float]]
             Close price for the option that day.
-        close_bid : Optional[float]
+        close_bid : Optional[Union[float]]
             The closing bid price for the option that day.
-        close_ask : Optional[float]
+        close_ask : Optional[Union[float]]
             The closing ask price for the option that day.
-        volume : Optional[float]
+        volume : Optional[Union[float]]
             Current trading volume on the contract.
-        open : Optional[float]
+        open : Optional[Union[float]]
             Opening price of the option.
-        open_bid : Optional[float]
+        open_bid : Optional[Union[float]]
             The opening bid price for the option that day.
-        open_ask : Optional[float]
+        open_ask : Optional[Union[float]]
             The opening ask price for the option that day.
-        open_interest : Optional[float]
+        open_interest : Optional[Union[float]]
             Open interest on the contract.
-        high : Optional[float]
+        high : Optional[Union[float]]
             High price of the option.
-        low : Optional[float]
+        low : Optional[Union[float]]
             Low price of the option.
-        mark : Optional[float]
+        mark : Optional[Union[float]]
             The mid-price between the latest bid-ask spread.
-        ask_high : Optional[float]
+        ask_high : Optional[Union[float]]
             The highest ask price for the option that day.
-        ask_low : Optional[float]
+        ask_low : Optional[Union[float]]
             The lowest ask price for the option that day.
-        bid_high : Optional[float]
+        bid_high : Optional[Union[float]]
             The highest bid price for the option that day.
-        bid_low : Optional[float]
+        bid_low : Optional[Union[float]]
             The lowest bid price for the option that day.
-        implied_volatility : Optional[float]
+        implied_volatility : Optional[Union[float]]
             Implied volatility of the option.
-        delta : Optional[float]
+        delta : Optional[Union[float]]
             Delta of the option.
-        gamma : Optional[float]
+        gamma : Optional[Union[float]]
             Gamma of the option.
-        theta : Optional[float]
+        theta : Optional[Union[float]]
             Theta of the option.
-        vega : Optional[float]
+        vega : Optional[Union[float]]
             Vega of the option.
-        bid_size : Optional[int]
+        bid_size : Optional[Union[int]]
             Bid size for the option. (provider: cboe)
-        ask_size : Optional[int]
+        ask_size : Optional[Union[int]]
             Ask size for the option. (provider: cboe)
-        theoretical : Optional[float]
+        theoretical : Optional[Union[float]]
             Theoretical value of the option. (provider: cboe)
-        last_trade_price : Optional[float]
+        last_trade_price : Optional[Union[float]]
             Last trade price of the option. (provider: cboe)
-        tick : Optional[str]
+        tick : Optional[Union[str]]
             Whether the last tick was up or down in price. (provider: cboe)
-        prev_close : Optional[float]
+        prev_close : Optional[Union[float]]
             Previous closing price of the option. (provider: cboe)
-        change : Optional[float]
+        change : Optional[Union[float]]
             Change in  price of the option. (provider: cboe)
-        change_percent : Optional[float]
+        change_percent : Optional[Union[float]]
             Change, in percent, of the option. (provider: cboe)
-        rho : Optional[float]
+        rho : Optional[Union[float]]
             Rho of the option. (provider: cboe)
-        last_trade_timestamp : Optional[datetime]
+        last_trade_timestamp : Optional[Union[datetime]]
             Last trade timestamp of the option. (provider: cboe)
-        dte : Optional[int]
+        dte : Optional[Union[int]]
             Days to expiration for the option. (provider: cboe)"""  # noqa: E501
 
         inputs = filter_inputs(

--- a/openbb_platform/openbb/package/ta.py
+++ b/openbb_platform/openbb/package/ta.py
@@ -1,15 +1,15 @@
 ### THIS FILE IS AUTO-GENERATED. DO NOT EDIT. ###
 
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Union
 
 import pandas
+import typing_extensions
 from annotated_types import Ge, Gt
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.filters import filter_inputs
 from openbb_provider.abstract.data import Data
 from pydantic import validate_call
-from typing_extensions import Annotated
 
 
 class ROUTER_ta(Container):
@@ -102,8 +102,8 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        fast: Annotated[int, Gt(gt=0)] = 3,
-        slow: Annotated[int, Gt(gt=0)] = 10,
+        fast: typing_extensions.Annotated[int, Gt(gt=0)] = 3,
+        slow: typing_extensions.Annotated[int, Gt(gt=0)] = 10,
         offset: int = 0,
     ) -> OBBject[List[Data]]:
         """
@@ -267,9 +267,9 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        length: Annotated[int, Gt(gt=0)] = 14,
+        length: typing_extensions.Annotated[int, Gt(gt=0)] = 14,
         mamode: Literal["rma", "ema", "sma", "wma"] = "rma",
-        drift: Annotated[int, Ge(ge=0)] = 1,
+        drift: typing_extensions.Annotated[int, Ge(ge=0)] = 1,
         offset: int = 0,
     ) -> OBBject[List[Data]]:
         """
@@ -324,7 +324,7 @@ class ROUTER_ta(Container):
         target: str = "close",
         index: str = "date",
         length: int = 50,
-        std: Annotated[float, Ge(ge=0)] = 2,
+        std: typing_extensions.Annotated[float, Ge(ge=0)] = 2,
         mamode: Literal["sma", "ema", "wma", "rma"] = "sma",
         offset: int = 0,
     ) -> OBBject[List[Data]]:
@@ -393,8 +393,8 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        length: Annotated[int, Gt(gt=0)] = 14,
-        scalar: Annotated[float, Gt(gt=0)] = 0.015,
+        length: typing_extensions.Annotated[int, Gt(gt=0)] = 14,
+        scalar: typing_extensions.Annotated[float, Gt(gt=0)] = 0.015,
     ) -> OBBject[List[Data]]:
         """
         The CCI is designed to detect beginning and ending market trends.
@@ -437,7 +437,7 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        length: Annotated[int, Gt(gt=0)] = 14,
+        length: typing_extensions.Annotated[int, Gt(gt=0)] = 14,
     ) -> OBBject[List[Data]]:
         """
         The Center of Gravity indicator, in short, is used to anticipate future price movements
@@ -484,7 +484,7 @@ class ROUTER_ta(Container):
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
         target: str = "adj_close",
-        period: Annotated[int, Gt(gt=0)] = 90,
+        period: typing_extensions.Annotated[int, Gt(gt=0)] = 90,
     ) -> OBBject[List[Data]]:
         """
         Clenow Volatility Adjusted Momentum.
@@ -665,8 +665,8 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        lower_length: Annotated[int, Gt(gt=0)] = 20,
-        upper_length: Annotated[int, Gt(gt=0)] = 20,
+        lower_length: typing_extensions.Annotated[int, Gt(gt=0)] = 20,
+        upper_length: typing_extensions.Annotated[int, Gt(gt=0)] = 20,
         offset: int = 0,
     ) -> OBBject[List[Data]]:
         """
@@ -781,9 +781,9 @@ class ROUTER_ta(Container):
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
         close_column: Literal["close", "adj_close"] = "close",
-        period: Annotated[int, Gt(gt=0)] = 120,
-        start_date: Optional[str] = None,
-        end_date: Optional[str] = None,
+        period: typing_extensions.Annotated[int, Gt(gt=0)] = 120,
+        start_date: Union[str, None] = None,
+        end_date: Union[str, None] = None,
     ) -> OBBject[List[Data]]:
         """Create Fibonacci Retracement Levels.
 
@@ -827,8 +827,8 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        length: Annotated[int, Gt(gt=0)] = 14,
-        signal: Annotated[int, Gt(gt=0)] = 1,
+        length: typing_extensions.Annotated[int, Gt(gt=0)] = 14,
+        signal: typing_extensions.Annotated[int, Gt(gt=0)] = 1,
     ) -> OBBject[List[Data]]:
         """
         The Fisher Transform is a technical indicator created by John F. Ehlers
@@ -932,10 +932,10 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        conversion: Annotated[int, Gt(gt=0)] = 9,
-        base: Annotated[int, Gt(gt=0)] = 26,
-        lagging: Annotated[int, Gt(gt=0)] = 52,
-        offset: Annotated[int, Gt(gt=0)] = 26,
+        conversion: typing_extensions.Annotated[int, Gt(gt=0)] = 9,
+        base: typing_extensions.Annotated[int, Gt(gt=0)] = 26,
+        lagging: typing_extensions.Annotated[int, Gt(gt=0)] = 52,
+        offset: typing_extensions.Annotated[int, Gt(gt=0)] = 26,
         lookahead: bool = False,
     ) -> OBBject[List[Data]]:
         """
@@ -982,10 +982,10 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        length: Annotated[int, Gt(gt=0)] = 20,
-        scalar: Annotated[float, Gt(gt=0)] = 20,
+        length: typing_extensions.Annotated[int, Gt(gt=0)] = 20,
+        scalar: typing_extensions.Annotated[float, Gt(gt=0)] = 20,
         mamode: Literal["ema", "sma", "wma", "hma", "zlma"] = "ema",
-        offset: Annotated[int, Ge(ge=0)] = 0,
+        offset: typing_extensions.Annotated[int, Ge(ge=0)] = 0,
     ) -> OBBject[List[Data]]:
         """
         Keltner Channels are volatility-based bands that are placed
@@ -1272,9 +1272,9 @@ class ROUTER_ta(Container):
         self,
         data: Union[List[Data], pandas.DataFrame],
         index: str = "date",
-        fast_k_period: Annotated[int, Ge(ge=0)] = 14,
-        slow_d_period: Annotated[int, Ge(ge=0)] = 3,
-        slow_k_period: Annotated[int, Ge(ge=0)] = 3,
+        fast_k_period: typing_extensions.Annotated[int, Ge(ge=0)] = 14,
+        slow_d_period: typing_extensions.Annotated[int, Ge(ge=0)] = 3,
+        slow_k_period: typing_extensions.Annotated[int, Ge(ge=0)] = 3,
     ) -> OBBject[List[Data]]:
         """
         The Stochastic Oscillator measures where the close is in relation

--- a/openbb_platform/platform/core/tests/api/test_auth/test_user_auth.py
+++ b/openbb_platform/platform/core/tests/api/test_auth/test_user_auth.py
@@ -11,7 +11,6 @@ from openbb_core.api.auth.user import (
     get_user_settings,
 )
 
-
 # ruff: noqa: S105 S106
 
 

--- a/openbb_platform/platform/provider/openbb_provider/standard_models/crypto_historical.py
+++ b/openbb_platform/platform/provider/openbb_provider/standard_models/crypto_historical.py
@@ -8,7 +8,7 @@ from datetime import (
 from typing import List, Optional, Set, Union
 
 from dateutil import parser
-from pydantic import Field, PositiveFloat, validator
+from pydantic import Field, PositiveFloat, field_validator
 
 from openbb_provider.abstract.data import Data
 from openbb_provider.abstract.query_params import QueryParams
@@ -18,7 +18,9 @@ from openbb_provider.utils.descriptions import DATA_DESCRIPTIONS, QUERY_DESCRIPT
 class CryptoHistoricalQueryParams(QueryParams):
     """Crypto end of day Query."""
 
-    symbol: str = Field(description=QUERY_DESCRIPTIONS.get("symbol", ""))
+    symbol: str = Field(
+        description="Symbol Pair to get data for in CURR1-CURR2 or CURR1CURR2 format."
+    )
     start_date: Optional[dateType] = Field(
         default=None,
         description=QUERY_DESCRIPTIONS.get("start_date", ""),
@@ -28,12 +30,12 @@ class CryptoHistoricalQueryParams(QueryParams):
         description=QUERY_DESCRIPTIONS.get("end_date", ""),
     )
 
-    @validator("symbol", pre=True, check_fields=False, always=True)
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+    @field_validator("symbol", mode="before", check_fields=False)
+    def validate_symbol(cls, v: Union[str, List[str], Set[str]]):
+        """Convert symbol to uppercase and remove '-'."""
         if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+            return v.upper().replace("-", "")
+        return ",".join([symbol.upper().replace("-", "") for symbol in list(v)])
 
 
 class CryptoHistoricalData(Data):
@@ -49,7 +51,7 @@ class CryptoHistoricalData(Data):
         default=None, description=DATA_DESCRIPTIONS.get("vwap", "")
     )
 
-    @validator("date", pre=True, check_fields=False)
+    @field_validator("date", mode="before", check_fields=False)
     def date_validate(cls, v):  # pylint: disable=E0213
         """Return formatted datetime."""
         return parser.isoparse(str(v))

--- a/openbb_platform/platform/provider/openbb_provider/standard_models/forex_historical.py
+++ b/openbb_platform/platform/provider/openbb_provider/standard_models/forex_historical.py
@@ -8,7 +8,7 @@ from datetime import (
 from typing import List, Optional, Set, Union
 
 from dateutil import parser
-from pydantic import Field, PositiveFloat, validator
+from pydantic import Field, PositiveFloat, field_validator
 
 from openbb_provider.abstract.data import Data
 from openbb_provider.abstract.query_params import QueryParams
@@ -18,7 +18,9 @@ from openbb_provider.utils.descriptions import DATA_DESCRIPTIONS, QUERY_DESCRIPT
 class ForexHistoricalQueryParams(QueryParams):
     """Forex end of day Query."""
 
-    symbol: str = Field(description=QUERY_DESCRIPTIONS.get("symbol", ""))
+    symbol: str = Field(
+        description="Symbol Pair to get data for in CURR1-CURR2 or CURR1CURR2 format."
+    )
     start_date: Optional[dateType] = Field(
         default=None,
         description=QUERY_DESCRIPTIONS.get("start_date", ""),
@@ -28,12 +30,12 @@ class ForexHistoricalQueryParams(QueryParams):
         description=QUERY_DESCRIPTIONS.get("end_date", ""),
     )
 
-    @validator("symbol", pre=True, check_fields=False, always=True)
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+    @field_validator("symbol", mode="before", check_fields=False)
+    def validate_symbol(cls, v: Union[str, List[str], Set[str]]):
+        """Convert symbol to uppercase and remove '-'."""
         if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+            return v.upper().replace("-", "")
+        return ",".join([symbol.upper().replace("-", "") for symbol in list(v)])
 
 
 class ForexHistoricalData(Data):
@@ -49,7 +51,7 @@ class ForexHistoricalData(Data):
         description=DATA_DESCRIPTIONS.get("vwap", ""), default=None
     )
 
-    @validator("date", pre=True, check_fields=False)
+    @field_validator("date", mode="before", check_fields=False)
     def date_validate(cls, v):  # pylint: disable=E0213
         """Return formatted datetime."""
         return parser.isoparse(str(v))


### PR DESCRIPTION
Standardizes the symbol input for the Crypto and Forex Historical standard models.

Accepted formats - `CURR1CURR2` ; `CURR1-CURR2`