### PR TITLE
fix: A value is trying to be set on a copy of a slice from a DataFrame

### DIFF
--- a/openbb_terminal/stocks/fundamental_analysis/fmp_model.py
+++ b/openbb_terminal/stocks/fundamental_analysis/fmp_model.py
@@ -647,7 +647,7 @@ def clean_metrics_df(data: pd.DataFrame, num: int, mask: bool = False) -> pd.Dat
     """
     # iloc will fail if number is greater than number of columns
     num = min(num, data.shape[1])
-    data = data.iloc[:, 0:num]
+    data = data.iloc[:, 0:num].copy()
 
     if mask:
         data = data.mask(data.astype(object).eq(num * ["None"])).dropna()


### PR DESCRIPTION
- Fixes warning caused by setting a value on copy of a DataFrame by explicitly creating a copy.
- Link #5582 
