### PR TITLE
Feature/user-cache-dir: Add User Preference for the Cache Directory

### DIFF
--- a/openbb_platform/platform/core/openbb_core/app/model/preferences.py
+++ b/openbb_platform/platform/core/openbb_core/app/model/preferences.py
@@ -8,6 +8,7 @@ class Preferences(BaseModel):
     data_directory: str = str(Path.home() / "OpenBBUserData")
     export_directory: str = str(Path.home() / "OpenBBUserData" / "exports")
     user_styles_directory: str = str(Path.home() / "OpenBBUserData" / "styles" / "user")
+    cache_directory: str = str(Path.home() / "OpenBBUserData" / "cache")
     charting_extension: Literal["openbb_charting"] = "openbb_charting"
     chart_style: Literal["dark", "light"] = "dark"
     plot_enable_pywry: bool = True

--- a/openbb_platform/platform/core/openbb_core/app/utils.py
+++ b/openbb_platform/platform/core/openbb_core/app/utils.py
@@ -4,6 +4,8 @@ from typing import Iterable, List, Optional, Union
 
 import pandas as pd
 from openbb_provider.abstract.data import Data
+from openbb_core.app.model.preferences import Preferences
+from openbb_core.app.model.system_settings import SystemSettings
 
 
 def basemodel_to_df(
@@ -69,3 +71,16 @@ def get_target_columns(df: pd.DataFrame, target_columns: List[str]) -> pd.DataFr
     for target in target_columns:
         df_result[target] = get_target_column(df, target).to_frame()
     return df_result
+
+
+def get_user_cache_directory() -> str:
+    file = SystemSettings().model_dump()["user_settings_path"]
+    with open(file) as settings_file:
+        contents = settings_file.read()
+    settings = json.loads(contents)["preferences"]
+    cache_dir = (
+        settings["cache_directory"]
+        if "cache_directory" in settings
+        else Preferences().cache_directory
+    )
+    return cache_dir

--- a/openbb_platform/providers/biztoc/openbb_biztoc/utils/helpers.py
+++ b/openbb_platform/providers/biztoc/openbb_biztoc/utils/helpers.py
@@ -1,15 +1,20 @@
+"""Biztoc Helpers"""
+
 from datetime import timedelta
 from typing import Dict, List, Literal
 
 import requests
 import requests_cache
+from openbb_core.app.utils import get_user_cache_directory
+
+cache_dir = get_user_cache_directory()
 
 
 def get_sources(api_key: str) -> List[Dict]:
     """Valid sources for Biztoc queries."""
 
     biztoc_session_sources = requests_cache.CachedSession(
-        "OpenBB_Biztoc_Pages", expire_after=timedelta(days=3), use_cache_dir=True
+        f"{cache_dir} / http / biztoc_sources", expire_after=timedelta(days=3)
     )
     headers = {
         "X-RapidAPI-Key": f"{api_key}",
@@ -28,7 +33,7 @@ def get_pages(api_key: str) -> List[str]:
     """Valid pages for Biztoc queries."""
 
     biztoc_session_pages = requests_cache.CachedSession(
-        "OpenBB_Biztoc_Pages", expire_after=timedelta(days=3), use_cache_dir=True
+        f"{cache_dir} / http / biztoc_pages", expire_after=timedelta(days=3)
     )
     headers = {
         "X-RapidAPI-Key": f"{api_key}",
@@ -47,7 +52,7 @@ def get_tags_by_page(page_id: str, api_key: str) -> List[str]:
     """Valid tags required for Biztoc queries."""
 
     biztoc_session_tags = requests_cache.CachedSession(
-        "OpenBB_Biztoc_Tags", expire_after=timedelta(days=1), use_cache_dir=True
+        f"{cache_dir} / http / biztoc_tags", expire_after=timedelta(days=1)
     )
     headers = {
         "X-RapidAPI-Key": f"{api_key}",

--- a/openbb_platform/providers/cboe/openbb_cboe/utils/helpers.py
+++ b/openbb_platform/providers/cboe/openbb_cboe/utils/helpers.py
@@ -7,14 +7,15 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import requests
 import requests_cache
+from openbb_core.app.utils import get_user_cache_directory
 from openbb_provider.utils.helpers import to_snake_case
 
-TICKER_EXCEPTIONS = ["NDX", "RUT"]
-# This will cache the import requests for 7 days.  Ideally to speed up subsequent imports.
-# Only used on functions run on import
+cache_dir = get_user_cache_directory()
 cboe_session = requests_cache.CachedSession(
-    "OpenBB_CBOE", expire_after=timedelta(days=7), use_cache_dir=True
+    f"{cache_dir} / http / cboe_directories", expire_after=timedelta(days=7)
 )
+
+TICKER_EXCEPTIONS = ["NDX", "RUT"]
 
 US_INDEX_COLUMNS = {
     "symbol": "symbol",
@@ -62,13 +63,6 @@ EUR_INDEX_CONSTITUENTS_COLUMNS = {
     "tick": "tick",
     "security_type": "type",
 }
-
-
-# This will cache certain requests for 7 days.  Ideally to speed up subsequent queries.
-# Only used on functions with static values like symbol directories.
-cboe_session = requests_cache.CachedSession(
-    "OpenBB_CBOE", expire_after=timedelta(days=7), use_cache_dir=True
-)
 
 
 def get_cboe_directory(**kwargs) -> pd.DataFrame:


### PR DESCRIPTION
This PR adds a user preference for the path to a caching directory.  By default - when no preference is given - the path is `~/OpenBBUserData/cache`.  The purpose is for the user to have the ability to easily manage their cache and move it between systems, or store it with external storage that could be a shared resource.

To avoid circular import errors from the UserSettings class, a utility function has been created to provide this information independent of the Fetcher and Router.  For example, helper functions that request data like symbol directories.

This is testable by querying `obb.stocks.search()` and `obb.news.globalnews(provider="biztoc"), and then adding an entry to `user_settings.json`:

```json
{
  "preferences": {
    "cache_directory": "/Some/Path"
}
}
```

```python
from openbb_core.app.utils import get_user_cache_directory
cache_dir = get_user_cache_directory()
print(cache_dir)
```

```console
'/Users/danglewood/OpenBBUserData/cache'
```

Within this directory, different types of cache can be stored.  The implemented cached HTTP requests go to a sub-folder, `http`.

![Screenshot 2023-10-28 at 1 56 18 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/920bac07-35d5-4056-bae3-dad21866a060)


Example of an implementation:

```python
biztoc_session_sources = requests_cache.CachedSession(
    f"{cache_dir} / http / biztoc_sources", expire_after=timedelta(days=3)
)
```
