### PR TITLE
Remove code that wrongfully infers the filing date as end of quarter

### DIFF
--- a/openbb_platform/extensions/etf/integration/test_etf_api.py
+++ b/openbb_platform/extensions/etf/integration/test_etf_api.py
@@ -106,18 +106,36 @@ def test_etf_sectors(params, headers):
 @pytest.mark.parametrize(
     "params",
     [
+        ({"symbol": "IOO"}),
+        ({"symbol": "MISL", "cik": None, "provider": "fmp"}),
+    ],
+)
+@pytest.mark.integration
+def test_etf_holdings_date(params, headers):
+    params = {p: v for p, v in params.items() if v}
+
+    query_str = get_querystring(params, [])
+    url = f"http://0.0.0.0:8000/api/v1/etf/holdings_date?{query_str}"
+    result = requests.get(url, headers=headers, timeout=10)
+    assert isinstance(result, requests.Response)
+    assert result.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
         (
             {
                 "symbol": "IOO",
-                "date": "2023-01-01",
+                "date": "2023-03-31",
                 "cik": None,
                 "provider": "fmp",
             }
         ),
         (
             {
-                "symbol": "SPY",
-                "date": "2023-04-20",
+                "symbol": "SILJ",
+                "date": "2019-12-31",
                 "cik": None,
                 "provider": "fmp",
             }
@@ -125,7 +143,7 @@ def test_etf_sectors(params, headers):
         (
             {
                 "symbol": "MISL",
-                "date": "2023-04-20",
+                "date": "2023-03-31",
                 "cik": "0001329377",
                 "provider": "fmp",
             }
@@ -138,24 +156,6 @@ def test_etf_holdings(params, headers):
 
     query_str = get_querystring(params, [])
     url = f"http://0.0.0.0:8000/api/v1/etf/holdings?{query_str}"
-    result = requests.get(url, headers=headers, timeout=10)
-    assert isinstance(result, requests.Response)
-    assert result.status_code == 200
-
-
-@pytest.mark.parametrize(
-    "params",
-    [
-        ({"symbol": "IOO"}),
-        ({"symbol": "MISL", "cik": None, "provider": "fmp"}),
-    ],
-)
-@pytest.mark.integration
-def test_etf_holdings_date(params, headers):
-    params = {p: v for p, v in params.items() if v}
-
-    query_str = get_querystring(params, [])
-    url = f"http://0.0.0.0:8000/api/v1/etf/holdings_date?{query_str}"
     result = requests.get(url, headers=headers, timeout=10)
     assert isinstance(result, requests.Response)
     assert result.status_code == 200

--- a/openbb_platform/extensions/etf/integration/test_etf_python.py
+++ b/openbb_platform/extensions/etf/integration/test_etf_python.py
@@ -100,18 +100,35 @@ def test_etf_sectors(params, obb):
 @pytest.mark.parametrize(
     "params",
     [
+        ({"symbol": "IOO"}),
+        ({"symbol": "MISL", "cik": None, "provider": "fmp"}),
+    ],
+)
+@pytest.mark.integration
+def test_etf_holdings_date(params, obb):
+    params = {p: v for p, v in params.items() if v}
+
+    result = obb.etf.holdings_date(**params)
+    assert result
+    assert isinstance(result, OBBject)
+    assert len(result.results) > 0
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
         (
             {
                 "symbol": "IOO",
-                "date": "2023-01-01",
+                "date": "2023-03-31",
                 "cik": None,
                 "provider": "fmp",
             }
         ),
         (
             {
-                "symbol": "SPY",
-                "date": "2023-04-20",
+                "symbol": "SILJ",
+                "date": "2019-12-31",
                 "cik": None,
                 "provider": "fmp",
             }
@@ -119,7 +136,7 @@ def test_etf_sectors(params, obb):
         (
             {
                 "symbol": "MISL",
-                "date": "2023-04-20",
+                "date": "2023-03-31",
                 "cik": "0001329377",
                 "provider": "fmp",
             }
@@ -131,23 +148,6 @@ def test_etf_holdings(params, obb):
     params = {p: v for p, v in params.items() if v}
 
     result = obb.etf.holdings(**params)
-    assert result
-    assert isinstance(result, OBBject)
-    assert len(result.results) > 0
-
-
-@pytest.mark.parametrize(
-    "params",
-    [
-        ({"symbol": "IOO"}),
-        ({"symbol": "MISL", "cik": None, "provider": "fmp"}),
-    ],
-)
-@pytest.mark.integration
-def test_etf_holdings_date(params, obb):
-    params = {p: v for p, v in params.items() if v}
-
-    result = obb.etf.holdings_date(**params)
     assert result
     assert isinstance(result, OBBject)
     assert len(result.results) > 0

--- a/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
@@ -1,10 +1,6 @@
 """FMP ETF Holdings fetcher."""
 
-from datetime import (
-    date as dateType,
-    datetime,
-    timedelta,
-)
+from datetime import date as dateType
 from typing import Any, Dict, List, Optional, Union
 
 from openbb_fmp.utils.helpers import create_url, get_data_many
@@ -25,8 +21,8 @@ class FMPEtfHoldingsQueryParams(EtfHoldingsQueryParams):
 
     date: Optional[Union[str, dateType]] = Field(
         description=QUERY_DESCRIPTIONS.get("date", "")
-        + " The input date is adjusted to the nearest previous quarter-end date."
-        + " Holdings are returned as of the adjusted date if available, with no data from the subsequent quarter.",
+        + " This needs to be _exactly_ the date of the filing."
+        + " Use the holdings_date command/endpoint to find available filing dates for the ETF.",
         default=None,
     )
 
@@ -120,21 +116,7 @@ class FMPEtfHoldingsFetcher(
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> FMPEtfHoldingsQueryParams:
-        """Transform the query.
-
-        Adjust input date to the nearest previous quarter-end date.
-        """
-        date_str = params.get("date", datetime.today().strftime("%Y-%m-%d"))
-        date_str = (
-            date_str.strftime("%Y-%m-%d")
-            if isinstance(date_str, dateType)
-            else date_str
-        )
-        date_obj = datetime.strptime(date_str, "%Y-%m-%d")
-        quarter_month = ((date_obj.month - 1) // 3) * 3 + 1
-        quarter_start = date_obj.replace(month=quarter_month, day=1)
-        previous_quarter_end = quarter_start - timedelta(days=1)
-        params["date"] = previous_quarter_end.strftime("%Y-%m-%d")
+        """Transform the query."""
         return FMPEtfHoldingsQueryParams(**params)
 
     @staticmethod


### PR DESCRIPTION
This is a tricky one. The holdings are made public through a regulatory filing that usually comes at the end of each quarter.
There is no consistency between companies filing their filings when end of quarter falls onto a weekend. Some file on Saturdays, some don’t and I’ve not found data for Q1 2019 on FMP which was the last time end of quarter was a Sunday.

The initial code was inferring that the date of filing is the last day of the quarter (which is false for some companies' filings). Then I made code to infer that the date of the filing is the last working day of the quarter (which is false for other companies' filings)
Both of the solutions above lead to a situation when you can't consistently get the holdings even if you know the exact date of the filing.

In this PR i remove the code that adjusts the date and point the user to the holdings_dates endpoint to get the exact dates of the filings