### PR TITLE
Hotfix for when user type /intro it takes to wrong docs path

### DIFF
--- a/openbb_terminal/terminal_controller.py
+++ b/openbb_terminal/terminal_controller.py
@@ -607,7 +607,7 @@ class TerminalController(BaseController):
 
     def call_intro(self, _):
         """Process intro command."""
-        webbrowser.open("https://docs.openbb.co/terminal/usage/basics")
+        webbrowser.open("https://docs.openbb.co/terminal/usage/overview/structure-and-navigation")
 
     def call_exe(self, other_args: List[str]):
         """Process exe command."""
@@ -830,7 +830,7 @@ def terminal(jobs_cmds: Optional[List[str]] = None, test_mode=False):
 
         if first_time_user():
             with contextlib.suppress(EOFError):
-                webbrowser.open("https://docs.openbb.co/terminal/usage/basics")
+                webbrowser.open("https://docs.openbb.co/terminal/usage/overview/structure-and-navigation")
 
         t_controller.print_help()
         check_for_updates()


### PR DESCRIPTION
# Description

- [X] Change the URL for docs redirect from terminal to https://docs.openbb.co/terminal/usage/overview/structure-and-navigation
- [X] #5656 
- [ ] None
- [X] Documentation is needed especially when user first starts the terminal
- [ ] None


# How has this been tested?

* I ran the /intro command again in the terminal and validated if the redirect is working
* You may use the develop branch and try the /intro command then try with this fix to see the difference and result
* Please also list any relevant details for your test configuration.
- [X] Make sure affected commands still run in terminal
- [X] Ensure the SDK still works
- [X] Check any related reports


# Checklist:

- [X] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [X] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
