### PR TITLE
hotfix/stock-screener-sort:  Fix for #5671 - sort by `fwdp/e` in Stock Screener

### DIFF
--- a/openbb_terminal/stocks/screener/screener_controller.py
+++ b/openbb_terminal/stocks/screener/screener_controller.py
@@ -96,8 +96,8 @@ class ScreenerController(BaseController):
         See `BaseController.parse_input()` for details.
         """
         # Filtering out sorting parameters with forward slashes like P/E
-        f0 = r"(p\/e|fwd p\/e|p\/s|p\/b|p\/c|p\/fcf)"
-        f1 = r"(P\/E|Fwd P\/E|P\/S|P\/B|P\/C|P\/FCF)"
+        f0 = r"(p\/e|fwdp\/e|p\/s|p\/b|p\/c|p\/fcf)"
+        f1 = r"(P\/E|FwdP\/E|P\/S|P\/B|P\/C|P\/FCF)"
 
         sort_filter = r"((\ -s |\ --sort ).*?" + r"(" + f0 + r"|" + f1 + r")" + r"*)"
 


### PR DESCRIPTION
This PR fixes #5671 by removing a space that didn't belong in the regex column filter.  The `e` on the other side of the `/` made the problem worse by activating `e` for `exit`.

Before:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/449152ad-b783-4044-9ad2-054f6593e85c)


After:

![Screenshot 2023-11-06 at 4 30 12 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/6a94bb12-771c-4f08-9170-43f86279586f)
