### PR TITLE
hotfix/fix-gov-histcont: Fix #5650 - /stocks/gov/histcont

### DIFF
--- a/openbb_terminal/stocks/government/quiverquant_view.py
+++ b/openbb_terminal/stocks/government/quiverquant_view.py
@@ -437,7 +437,6 @@ def display_contracts(
 
     if df_contracts.empty:
         return
-    df_contracts.sort_values("Date", ascending=True)
     if raw:
         print_rich_table(
             df_contracts,

--- a/openbb_terminal/stocks/government/quiverquant_view.py
+++ b/openbb_terminal/stocks/government/quiverquant_view.py
@@ -638,7 +638,6 @@ def display_hist_contracts(
 
     fig = OpenBBFigure(
         xaxis=dict(
-            title="Quarter",
             tickmode="array",
             tickvals=np.arange(0, len(amounts)),
             ticktext=df_contracts["dates"],

--- a/openbb_terminal/stocks/government/quiverquant_view.py
+++ b/openbb_terminal/stocks/government/quiverquant_view.py
@@ -627,7 +627,7 @@ def display_hist_contracts(
         1: "03-31",
         2: "06-30",
         3: "09-30",
-        4: "12-12",
+        4: "12-31",
     }
     df_contracts["dates"] = (
         df_contracts["Year"].astype(str) + "-" + df_contracts["Qtr"].map(date_dict)

--- a/openbb_terminal/stocks/government/quiverquant_view.py
+++ b/openbb_terminal/stocks/government/quiverquant_view.py
@@ -669,12 +669,13 @@ def display_hist_contracts(
     )
 
     if raw:
-        df = df_contracts.drop(columns=["dates"])
+        df = df_contracts.drop(columns=["dates"]).astype(str)
         return print_rich_table(
             df,
             headers=list(df.columns),
             title="Historical Quarterly Government Contracts",
             export=bool(export),
+            columns_keep_types=["Year"],
         )
 
     return fig.show(external=external_axes)

--- a/openbb_terminal/stocks/government/quiverquant_view.py
+++ b/openbb_terminal/stocks/government/quiverquant_view.py
@@ -437,7 +437,7 @@ def display_contracts(
 
     if df_contracts.empty:
         return
-
+    df_contracts.sort_values("Date", ascending=True)
     if raw:
         print_rich_table(
             df_contracts,
@@ -457,8 +457,8 @@ def display_contracts(
 
     fig.add_bar(
         name="Amount",
-        x=df_contracts["Date"].unique(),
-        y=df_contracts_grouped["Amount"].values / 1000,
+        x=sorted(df_contracts["Date"].unique()),
+        y=df_contracts_grouped["Amount"] / 1000,
     )
     fig.update_layout(xaxis=dict(type="category"))
 
@@ -622,21 +622,26 @@ def display_hist_contracts(
     if df_contracts.empty:
         return None
 
-    amounts = df_contracts.sort_values(by=["Year", "Qtr"])["Amount"].values
+    amounts = df_contracts.sort_values(by=["Year", "Qtr"])["Amount"].astype(float)
 
-    qtr = df_contracts.sort_values(by=["Year", "Qtr"])["Qtr"].values
-    year = df_contracts.sort_values(by=["Year", "Qtr"])["Year"].values
-
-    quarter_ticks = [
-        f"{quarter[0]}" if quarter[1] == 1 else "" for quarter in zip(year, qtr)
-    ]
+    date_dict = {
+        1: "03-31",
+        2: "06-30",
+        3: "09-30",
+        4: "12-12",
+    }
+    df_contracts["dates"] = (
+        df_contracts["Year"].astype(str) + "-" + df_contracts["Qtr"].map(date_dict)
+    )
+    df_contracts["dates"] = pd.to_datetime(df_contracts["dates"]).dt.strftime("%Y-%m")
+    df_contracts.sort_values(by="dates", ascending=True, inplace=True)
 
     fig = OpenBBFigure(
         xaxis=dict(
             title="Quarter",
             tickmode="array",
             tickvals=np.arange(0, len(amounts)),
-            ticktext=quarter_ticks,
+            ticktext=df_contracts["dates"],
         ),
         yaxis_title="Amount ($1k)",
     )
@@ -660,15 +665,16 @@ def display_hist_contracts(
         export,
         os.path.dirname(os.path.abspath(__file__)),
         "histcont",
+        df_contracts.drop(columns=["dates"]),
         sheet_name=sheet_name,
         figure=fig,
     )
 
     if raw:
+        df = df_contracts.drop(columns=["dates"])
         return print_rich_table(
-            df_contracts,
-            headers=list(df_contracts.columns),
-            floatfmt=[".0f", ".0f", ".2f"],
+            df,
+            headers=list(df.columns),
             title="Historical Quarterly Government Contracts",
             export=bool(export),
         )


### PR DESCRIPTION
This PR fixes #5650.  For V4 the API queries should get some attention to improve reliability (some requests fail to connect), but this gets us back to working.

Before:

```
/stocks/gov/load AMT/histcont
```

```console
(🦋) /stocks/gov/ $ histcont

Error: unsupported operand type(s) for /: 'str' and 'int'
```

After:

![Screenshot 2023-11-06 at 6 04 05 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/b3c246d0-a778-4edc-9796-f0083e9e844e)
