### PR TITLE
Feature/v4-earnings-calendar: Adds stocks earnings calendar endpoint and data from Nasdaq

### DIFF
--- a/openbb_platform/extensions/stocks/integration/test_stocks_api.py
+++ b/openbb_platform/extensions/stocks/integration/test_stocks_api.py
@@ -1337,3 +1337,18 @@ def test_stocks_market_snapshots(params, headers):
     result = requests.get(url, headers=headers, timeout=10)
     assert isinstance(result, requests.Response)
     assert result.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "params",
+    [({"start_date": "2023-11-06", "end_date": "2023-11-10", "provider": "nasdaq"})],
+)
+@pytest.mark.integration
+def test_stocks_calendar_earnings(params, headers):
+    params = {p: v for p, v in params.items() if v}
+
+    query_str = get_querystring(params, [])
+    url = f"http://0.0.0.0:8000/api/v1/stocks/calendar_earnings?{query_str}"
+    result = requests.get(url, headers=headers, timeout=10)
+    assert isinstance(result, requests.Response)
+    assert result.status_code == 200

--- a/openbb_platform/extensions/stocks/integration/test_stocks_python.py
+++ b/openbb_platform/extensions/stocks/integration/test_stocks_python.py
@@ -635,21 +635,6 @@ def test_stocks_options_chains(params, obb):
 @pytest.mark.parametrize(
     "params",
     [
-        ({"symbol": None, "source": "delayed", "provider": "intrinio"}),
-        ({"symbol": "PLTR", "source": "delayed", "provider": "intrinio"}),
-    ],
-)
-@pytest.mark.integration
-def test_stocks_options_unusual(params, obb):
-    result = obb.stocks.options.usual(**params)
-    assert result
-    assert isinstance(result, OBBject)
-    assert len(result.results) > 0
-
-
-@pytest.mark.parametrize(
-    "params",
-    [
         (
             {
                 "symbol": "AAPL",
@@ -1242,12 +1227,12 @@ def test_stocks_dps_otc(params, obb):
 @pytest.mark.parametrize(
     "params",
     [
-        ({"symbol": "AAPL"}),
+        ({"symbol": None, "provider": "intrinio"}),
         ({"source": "delayed", "provider": "intrinio", "symbol": "AAPL"}),
     ],
 )
 @pytest.mark.integration
-def test_stocks_options_unusual2(params, obb):
+def test_stocks_options_unusual(params, obb):
     params = {p: v for p, v in params.items() if v}
 
     result = obb.stocks.options.unusual(**params)
@@ -1266,6 +1251,20 @@ def test_stocks_options_unusual2(params, obb):
 @pytest.mark.integration
 def test_stocks_market_snapshots(params, obb):
     result = obb.stocks.market_snapshots(**params)
+    assert result
+    assert isinstance(result, OBBject)
+    assert len(result.results) > 0
+
+
+@pytest.mark.parametrize(
+    "params",
+    [({"start_date": "2023-11-06", "end_date": "2023-11-10", "provider": "nasdaq"})],
+)
+@pytest.mark.integration
+def test_stocks_calendar_earnings(params, obb):
+    params = {p: v for p, v in params.items() if v}
+
+    result = obb.stocks.calendar_earnings(**params)
     assert result
     assert isinstance(result, OBBject)
     assert len(result.results) > 0

--- a/openbb_platform/extensions/stocks/openbb_stocks/stocks_router.py
+++ b/openbb_platform/extensions/stocks/openbb_stocks/stocks_router.py
@@ -143,6 +143,17 @@ def calendar_dividend(
     return OBBject(results=Query(**locals()).execute())
 
 
+@router.command(model="CalendarEarnings")
+def calendar_earnings(
+    cc: CommandContext,
+    provider_choices: ProviderChoices,
+    standard_params: StandardParams,
+    extra_params: ExtraParams,
+) -> OBBject[BaseModel]:
+    """Upcoming and Historical Earnings Calendar."""
+    return OBBject(results=Query(**locals()).execute())
+
+
 @router.command(model="MarketSnapshots")
 def market_snapshots(
     cc: CommandContext,

--- a/openbb_platform/platform/provider/openbb_provider/standard_models/calendar_earnings.py
+++ b/openbb_platform/platform/provider/openbb_provider/standard_models/calendar_earnings.py
@@ -1,0 +1,38 @@
+"""Earnings Calendar data model."""
+
+
+from datetime import date as dateType
+from typing import Optional
+
+from pydantic import Field
+
+from openbb_provider.abstract.data import Data
+from openbb_provider.abstract.query_params import QueryParams
+from openbb_provider.utils.descriptions import DATA_DESCRIPTIONS, QUERY_DESCRIPTIONS
+
+
+class EarningsCalendarQueryParams(QueryParams):
+    """Earnings Calendar Query."""
+
+    start_date: Optional[dateType] = Field(
+        default=None, description=QUERY_DESCRIPTIONS.get("start_date", "")
+    )
+    end_date: Optional[dateType] = Field(
+        default=None, description=QUERY_DESCRIPTIONS.get("end_date", "")
+    )
+
+
+class EarningsCalendarData(Data):
+    """Earnings Calendar Data."""
+
+    report_date: dateType = Field(description="The date of the earnings report.")
+    symbol: str = Field(description=DATA_DESCRIPTIONS.get("symbol", ""))
+    name: Optional[str] = Field(description="Name of the entity.", default=None)
+    eps_previous: Optional[float] = Field(
+        default=None,
+        description="The earnings-per-share from the same previously reported period.",
+    )
+    eps_consensus: Optional[float] = Field(
+        default=None,
+        description="The analyst conesus earnings-per-share estimate.",
+    )

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/__init__.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/__init__.py
@@ -1,5 +1,6 @@
 """Nasdaq provider module."""
 from openbb_nasdaq.models.calendar_dividend import NasdaqDividendCalendarFetcher
+from openbb_nasdaq.models.calendar_earnings import NasdaqEarningsCalendarFetcher
 from openbb_nasdaq.models.calendar_ipo import NasdaqCalendarIpoFetcher
 from openbb_nasdaq.models.cot import NasdaqCotFetcher
 from openbb_nasdaq.models.cot_search import NasdaqCotSearchFetcher
@@ -17,6 +18,7 @@ unmatched technology, insights and markets expertise.""",
     required_credentials=["api_key"],
     fetcher_dict={
         "CalendarDividend": NasdaqDividendCalendarFetcher,
+        "CalendarEarnings": NasdaqEarningsCalendarFetcher,
         "CalendarIpo": NasdaqCalendarIpoFetcher,
         "COT": NasdaqCotFetcher,
         "COTSearch": NasdaqCotSearchFetcher,

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_earnings.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_earnings.py
@@ -1,0 +1,176 @@
+"""Nasdaq Earnings Calendar fetcher."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import (
+    date as dateType,
+    datetime,
+    timedelta,
+)
+from typing import Any, Dict, List, Optional
+
+import requests
+from openbb_nasdaq.utils.helpers import IPO_HEADERS, date_range
+from openbb_provider.abstract.fetcher import Fetcher
+from openbb_provider.standard_models.calendar_earnings import (
+    EarningsCalendarData,
+    EarningsCalendarQueryParams,
+)
+from pydantic import Field, field_validator
+
+
+class NasdaqEarningsCalendarQueryParams(EarningsCalendarQueryParams):
+    """Nasdaq Earnings Calendar Query.
+
+    Source: https://www.nasdaq.com/market-activity/earnings
+    """
+
+
+class NasdaqEarningsCalendarData(EarningsCalendarData):
+    """Nasdaq Earnings Calendar Data."""
+
+    __alias_dict__ = {
+        "report_date": "date",
+        "eps_previous": "lastYearEPS",
+        "eps_consensus": "epsForecast",
+    }
+    actual_eps: Optional[float] = Field(
+        default=None,
+        description="The actual earnings per share (USD) announced.",
+        alias="eps",
+    )
+    surprise_percent: Optional[float] = Field(
+        default=None,
+        description="The earnings surprise as normalized percentage points.",
+        alias="surprise",
+    )
+    num_estimates: Optional[int] = Field(
+        default=None,
+        description="The number of analysts providing estimates for the consensus.",
+        alias="noOfEsts",
+    )
+    period_ending: Optional[str] = Field(
+        default=None,
+        description="The fiscal period end date.",
+        alias="fiscalQuarterEnding",
+    )
+    previous_report_date: Optional[dateType] = Field(
+        default=None,
+        description="The previous report date for the same period last year.",
+        alias="lastYearRptDt",
+    )
+    reporting_time: Optional[str] = Field(
+        default=None,
+        description="The reporting time - e.g. after market close.",
+        alias="time",
+    )
+    market_cap: Optional[int] = Field(
+        default=None,
+        description="The market cap (USD) of the reporting entity.",
+        alias="marketCap",
+    )
+
+    @field_validator(
+        "period_ending",
+        mode="before",
+        check_fields=False,
+    )
+    def validate_period_ending(cls, v: str):
+        v = v.replace("N/A", "")
+        return datetime.strptime(v, "%b/%Y").strftime("%Y-%m") if v else None
+
+    @field_validator("previous_report_date", mode="before", check_fields=False)
+    def validate_previous_report_date(cls, v: str):
+        v = v.replace("N/A", "")
+        return datetime.strptime(v, "%m/%d/%Y").date() if v else None
+
+    @field_validator(
+        "reporting_time",
+        mode="before",
+        check_fields=False,
+    )
+    def validate_reporting_time(cls, v: str):
+        return v.replace("time-", "") if v else None
+
+    @field_validator(
+        "market_cap",
+        "eps_previous",
+        "eps_consensus",
+        "num_estimates",
+        "actual_eps",
+        "surprise_percent",
+        mode="before",
+        check_fields=False,
+    )
+    def validate_numbers(cls, v: str):
+        v = (
+            v.replace("N/A", "")
+            .replace("$", "")
+            .replace(",", "")
+            .replace("(", "-")
+            .replace(")", "")
+        )
+        return float(v) if v else None
+
+
+class NasdaqEarningsCalendarFetcher(
+    Fetcher[
+        NasdaqEarningsCalendarQueryParams,
+        List[NasdaqEarningsCalendarData],
+    ]
+):
+    """Transform the query, extract and transform the data from the Nasdaq endpoints."""
+
+    @staticmethod
+    def transform_query(params: Dict[str, Any]) -> NasdaqEarningsCalendarQueryParams:
+        """Transform the query params."""
+        now = datetime.today().date()
+        transformed_params = params
+
+        if params.get("start_date") is None:
+            transformed_params["start_date"] = now
+
+        if params.get("end_date") is None:
+            transformed_params["end_date"] = now + timedelta(days=3)
+
+        return NasdaqEarningsCalendarQueryParams(**transformed_params)
+
+    @staticmethod
+    def extract_data(
+        query: NasdaqEarningsCalendarQueryParams,
+        credentials: Optional[Dict[str, str]],  # pylint: disable=unused-argument
+        **kwargs: Any,
+    ) -> List[Dict]:
+        """Return the raw data from the Nasdaq endpoint."""
+        data: List[Dict] = []
+        dates = [
+            date.strftime("%Y-%m-%d")
+            for date in date_range(query.start_date, query.end_date)
+        ]
+
+        def get_calendar_data(date: str) -> None:
+            response = []
+            url = f"https://api.nasdaq.com/api/calendar/earnings?date={date}"
+            r = requests.get(url, headers=IPO_HEADERS, timeout=5)
+            r_json = r.json()
+            if "data" in r_json and "rows" in r_json["data"]:
+                response = r_json["data"]["rows"]
+                _as_of_date = datetime.strptime(
+                    r_json["data"]["asOf"], "%a, %b %d, %Y"
+                ).date()
+                if len(response) > 0:
+                    [d.update({"date": _as_of_date}) for d in response]
+                    data.extend(response)
+
+        with ThreadPoolExecutor() as executor:
+            executor.map(get_calendar_data, dates)
+
+        return sorted(data, key=lambda x: x["date"], reverse=True)
+
+    @staticmethod
+    def transform_data(
+        query: NasdaqEarningsCalendarQueryParams,  # pylint: disable=unused-argument
+        data: List[Dict],
+        **kwargs: Any,  # pylint: disable=unused-argument
+    ) -> List[NasdaqEarningsCalendarData]:
+        """Return the transformed data."""
+        return [NasdaqEarningsCalendarData.model_validate(d) for d in data]

--- a/openbb_platform/providers/nasdaq/tests/record/http/test_nasdaq_fetchers/test_nasdaq_calendar_earnings_fetcher.yaml
+++ b/openbb_platform/providers/nasdaq/tests/record/http/test_nasdaq_fetchers/test_nasdaq_calendar_earnings_fetcher.yaml
@@ -1,0 +1,213 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/plain, */*
+      Accept-Encoding:
+      - gzip
+      Accept-Language:
+      - en-CA,en-US;q=0.7,en;q=0.3
+      Connection:
+      - keep-alive
+      Host:
+      - api.nasdaq.com
+      Origin:
+      - https://www.nasdaq.com
+      Referer:
+      - https://www.nasdaq.com/
+    method: GET
+    uri: https://api.nasdaq.com/api/calendar/earnings?date=2023-11-06
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALVda1fjSJL9Kzps75yZPcKjzNRzvgljbA/40ZbLVPWe/SBsATplSx7Jporu0/99
+        IyQop1MPp7PoDzSIpgpFRWbkjYgbN/+4WIW78OJff1yE+eTx4l8XozTRtXH6otm6Rg3KLvSL5yhc
+        RVmOP7SLNxH80Bw/6Rf56+YhXcNzUH6hXyRh8f+76WYbJq/aOCx+LtrCH77oTQP8M/tsm8U5/tR/
+        a8H7g36xCbOv0a4bbvEdiq81fNAvHuN8Ga5/3YfZLsp6ySpOnuBHborvam/f1t6+X/yqmzSLlmG+
+        K94jyaMk3+ca/PL/0X78H3jRdPLYy3f4Xv+lpY9a8fWf+kWWfoPv/e8fb+/8i9Oh5PitSYdQ+M7b
+        vwR+ukzS3WW+327XcbTi/1lmX3z/y+FfZfYaJmGcaYN0jW+ba9v1UrD8F0JsnVKiu6ahG4bRaH8Q
+        bf/55p5jk+GNCTs2kIFhPwxiHds5Noh1PFvSoMVs/vlgzyKCV/quTZ/DbBMuo/0uhhfNtWGyTLNt
+        moW74g8fmec5uk1NndlMdxymYB3rWIJ14A3OPKNDBPMuiVH+GRkDh/NPVwcDh7twr31K4ocQTNKu
+        iv++OU8LfNE2y9UJc3WLUt0mKrbBu3vHttFjz7HKUpQ2bPx5OjwYBk9aEG3iZZqs9stdmuXauLPo
+        iBaZju56nm4zWzc9R8lb1G7zFi3/P2eSbcqvxm6vz4ecJN9F63W4i9ME4kGUPb1q3beFCN8SbQNP
+        UdeED6qbNlGwjXSY0+It0jHosWmyUWPCRYwoXO9eix21iVqtsXQPPiwK3lLyFDk2xeFNsTqmJyw8
+        2jFMSXNu/DHnpus43MCiewiXX9+cpKN5laVHXZ15pm45DoRDT8EgWEdGe6Ao4g/vH+Z0HFmrrsZ8
+        JLyK0/E8Wj5rQa9iiKnbjqFbFnjHsc435O+/YPj6R4t7jI4phDy748outu585vObCN4pC9+3T61j
+        DN2hNp5NuqEUweF1zWNrvGNrPDGA03IryZjTCw7G9F4AtKT7bBm92VM5a73CNZ5rwWcF1+C7CgHb
+        OjbFFfcNHM5E9ii6ueFOogTeKCm2PqCem3X4gjH7b9pNFj5lcC5Fef02IhDlHKZbjOmepxLlYJvY
+        LWuPdixDMBEAhuwm6va4pRetwyTKW6McgZPVdXXPAGtcU8EaOG+M1rXHrEqg82Qjgj/iAkKWpl8f
+        42i90vw8Byw7Auj3FG2iZFdjlAEHrekRnSi6iAnRmwkbSjhjL4nXYbLAwf9tOj7Y5efbKNEw1CXp
+        Om0K3oRAjIDADScSIa7S2SoiIcEkJqw61jEtSYPu5zPuPOqBd5JdDJvq0y5ex7u4aSd5OrXdEi4U
+        mOV8L9E2cAfYzz02yeq4rqRJ/T4HWvtRtgLYGnT8ig0A50ywgVHdpWorjbRBHqNjCEfqpWnIhoJu
+        lwvd8KRhyFuv4ydwjxak6z0GhPyQO9X5CHaRASHCs3TXUcEMYIDVGs89AdJBsLNknRTc+4uDhcFz
+        uvx6H75E2ihaYd5Uv+psAA0AIBgkhMWRfr5FbhuyIx1HWHVux5IGdlxcuAkfsjiJKsENk1lLZwak
+        Ra6KR0h5mDQFAlIBcV6JVaWy88GUQ9qvmzCB1ZVv410IceBVm2bpFhLcxoAAeA4Wmu1B+LZUwAMp
+        l04LeKjEOFnLboJbzjWBdns7w2IKWlYcr3W2WJ7OAC3A5lFDCU6zLQhhqfUPITQ4VDZi9yd3XHhL
+        19pdnDyHueZHWRTmZaAo4kSU14Y9qwx5pqkTxbBntC1Co2MLMI+WuFDGtoF/x+V7g3Cd/v4Kqd78
+        OcrCbVFSaVx+BHaWadi6bascsUZZB+KMstvrKON/+pI2LXzOX4twHcLfAD7bxDUFIbOodBUY1VAI
+        cMcW4CseLzuPiMuOWCW2kDFk2l3w5a7w+/J1F9W7w9Qdl+imC8iUKuTf+K6OJ2R5prDKTOHwsTtM
+        tlTi+xMexcFToxmOC+gAUI6rtqos4QQlx/GaVNIFr6xXSi2s8YTD2It4W1R+i1R1Cm8IX8E6m9bY
+        RAAReLBTDJXSCCSsQgrkHa0y0jHFVUbdjiO7yLqzgDuHurNhMJ0d7X/N71dNsi2mEwvzIQUwiu/s
+        ucJqOyqP4Ho0nMrescugIWXWZDDjzErBIERytcePWaAcBivPMZTMgZe1BXNcIZqZoi1Ox5Y9gObX
+        3YMpc/AM9kzaElUwyHJ1kzmKNfwq0D6KBWbHEGCb0/GkE7oRl/74j4+Q9WCl/i1DhR3Uz9L9tik8
+        mIYBaSpEOaWCCSvxZhtOsCs4wZLNIQaDAXeUpt/CbKUN9k/P0Ym0wdQNBwKESbF++iH4gJ4Ieh1X
+        dunxR6kfZ9odIJ7WGgkYYxKdeQRcpJIxkHJtNSNuu1oiodIFn6s5FxPCh3R3whQI3A6xdcNVq9Cb
+        Lbvo779QyBWE1UbMMqOQMWZ01AwbxWiEBHCDvcMYpHNMZ5aCg/C1PSoEO7GCWokOtmyWOuhzSeog
+        Xu/SBAJCmKy0RbgMyxy83irHBKsMC5adWlXYaytiUafsuirh0fs5hxrunwGGaqN0n+zCuDAG/k6s
+        oL7Hvbvdqs46iisRPhsKca8NpWIxS6jPEULKqqtUcsTtKFh8Wj9NV69RmGnzOIu0v2mz/cMDwKS3
+        jnzVMNsiOnGxMqRWXxAPKiYEdCImftJp381sytl2k0X58zbaNW0qCiGcQAg3VZLx4uQxhE0lpONM
+        QBCsrHZJlX6u+CZLED5koTbA1t4zpOXgpVlvOG+0i4JvKAAKU7E2LLTLhSzPEZstpi1dZphf33Nr
+        L15F30LkYtTbQUwHUiSsoKrVgcy2vIKWtRTODvMtCsrYcTvmOi23SfwIHolfik1TA1bBFGYAWC16
+        x0qmuCKDQdgyDhO3DOlYsm2jPoeB+vBSqxBQd7nYmpaYAakR8k6Yo5i5emJ/UlhkYpNfPnTfTriq
+        8G2ab9L8PeOrj9OGS3XX9nTDVjiF2uL034uKieAYSF4N2d1yO/vC25K95liOu4rTXbRsdg1ENQ8g
+        N1VN84gY1Y7jswVhrZLlwekj228dXfc5gDoKV1n8BFYJlKBG6wz4sAowpGIdYDUxiXWEzJxR0Tpb
+        vlPkfw444OB/z1OpyhzVPdcGKOTBh6LXqNmezboCBmcdW7oSdM+l5f4mysBDiRbsQqye3hcBvAEr
+        gF2QoWOvUrXxX8TLphheDROXTpm2Sx2x8x5XRQl20TYA6PoG6prcZBYlId1WNIcKiZLI/xGqwlYZ
+        +KXypM98ngTwNNLGnwEidNMaM1xACIYHn5VSclLCmOaeniucrMQt22BSdoy54jY8aDdxAlgb260t
+        VQYKQMEAQOphNFfyjCPk40IlVWy1Urdjyda1erN/H0zqbQDKwY6p6zqAFZYN+YKn20QRWrdUFQpo
+        XamVEEO2VjLjSVkzeJdllOyypjYk2AJ7xfE8OIgUysJFga613lhDl0OOmezZ6g/56vb6AbnHx5SZ
+        ljID1W3b0B1mKxfrWlNXo0KRsTtMuml8y6d3YfIEi+0mRMbmqzbZ79bIksbGV9Z4Flmup1sM2XRq
+        jT2xhCJUg6hgG5yv0rg78Mfc+RqEyQaiQ7unLKT/wAlEFGtbIgdDhN62UYXehjRe+PKZX4XwTq/f
+        G93iQNCGCOcy1W6RWPC2xfK92JSQr6NykG4QLdehNooT5Dw3AgMLElSPuBAlFK0xxIqWyPcRAI8n
+        v4XmsyGHDOZZvPVXL3GeZk2uMR2ABaahE6VMFd5VQDliidurFB3lt8xsMbrm4nb08kaMKVkkcdJE
+        VqA6s7CGYOlUJQ4gJi3XU8uCI5W9c8ax6ncXXIkEnjR/v2wuN1I4iLDUaOsmUzyQiIixBZBgCZUR
+        wD2OdMNoEPBLLoqe030eaTdpump0EGHItneVDyHTbTbn0CHjSySWfCo07nFAbhyl/ShJNy0ZEGEQ
+        FCC7IyrchMI74moTqnGmmCswUlbopALclOPHDOKn52kUnqCj64YNkQGHcqhasiCyLY4D3LEx8vWR
+        2XDCAYRZnO606TrcPabZptE3hkV0hsMCpkJ8KyqlIlHBEjCBwMlihny/a9j9xM2pwFM7Pw6swdEH
+        x4RtoxatPQFkCzmp2LqruiZ8hF91CRs8y3lDRvdcPBvto/UaoFuZX0+zFKduisgmGkR0z2PFjJTt
+        qdFMiQBGhbBmiGGNMXky8JQfZ5uGr8hn3h+6qw1s4MIki9jqrEzWbFIRLMQqzzk2zUfXHGybQ7Kd
+        F0uutREONrmQN1A4hyyl2hUmoW27iHVIpcYjPRg19Wcz3k+w5MJl/BgvT3sKrELatmupsH9Yay0B
+        QYQlHkLyoe6qd0Swj8LNMUumwSDH04lnqXX2iwqi017bFpEpLSOKHPOnz22nbhblmIQfZtdqwTaa
+        ZEDaAMjHUgsQrJ2sIFbhIHhL2hPMZ1zmEMD7rDFrGCaPGfzyDELePmugz4FVDE4l24UzVsUqeG2r
+        beXVEUuo9Ajb9TDguir4pI2j3bc0+9o6rQLxDvJul0CMUIN0ok0iQq1wmkq2txwLiINAxYgKDl1z
+        9blTkcK1kQQESSz9GJ6gWKITbLOsjiUb/uZHnNp5uP7RNGoyxmGAu+HMNWzFA6p9WsVV7n/d8266
+        j+JcK2fjG93iwJHEDAc+Pp6nQISC9qXXsWQrwdcDDqfCw8n15Rg2BG4XsgjFvSPAoKMoZ5ac06Pi
+        vDyXts+dQzfRCs6gteY/ZfFyv4YIBw+jNNs9hU/ts2wA8CA6YHffURllY2UVvq2NLDIvzpjtmHX5
+        wuMsXaIeg1RXD+wywS7L0W2imF+4YjHI+bgj9zNHWQDvRN34JV42WmKYOoEPy1Nbg+JJK4QFIozz
+        U+uMhte8f1RiANQKK20XrmC5adeR1g9zLQi1SbbSrqqGWW+dCVeljHrgBjemTUKKId2V6C263N7C
+        AV5AQZsIR3jrPWQxE8f3AQ8p7KHCEJG6INYZBB85hnwXb9HrcufQIoqWKdLNAAlh3tSEWC1q6LaN
+        8xBqByttg3dVbiCRpzHN+3f8mouWSfq0DvMmQ0wPMj5iKCK6tznwlqyPVUaKzuGn+/MeR+r219tn
+        yM1PJ0gmjkfYkCQZiguOtdHMihVZIWSck80OhiPOR4N4g1PiA6R1t3GA0C4HwpypOypQVWYjUbHu
+        QDuyNaF/X3EloX+HyT4XmnutibqJhTtCdMNU7PKf6sJWxiTsjjTHcfSlz3UuR69ZHK60fpREzfQS
+        sMgydWp6cNAqUh1JW+/ofQqWb1iesa9mkwVXe5ilyKNr9w8SA4sQrnbIiiWHtsLqGQ3ywB9znZYg
+        TFb5Ls02Wh8CBHLPqoYgJRAZqJ5itmecKNyJqEe6pDqecx4pdg7EhG7aaXAIs72CzO0oIu/WYYiq
+        7MolYR3ZrHVxNI9HPzetKYaFOUggDCVoDUd8C3+kKAqpl7GuOUjwJoajTR4f82d4Ae06i9dYM2my
+        i9pYF/Z0z1Sw69gkIbt7K6AcoWpTNiO6WnDlkav1PnrKoijhJgbeRbNa8yGKfX0bafZqPCZKW9ed
+        JbLs5YslwYKDCkGUQcoQcfPh2jzb51VdDzCIYBKkG0qKTNUSiWiQsJFMp/wnkDpSe3dcdMOny/ve
+        +N1PjcuPWTqlts6Y2lHKhDlKu90g+U01HfAEIHwa+k02ABSACK27KgXh1i0EyULluDFLCSC5ityM
+        B6SQ9UT5Mm1yBXGpzmDDUKIW4URaj5Bii0NertVxpHfL7T1/cn59LQbxgm2EdcVCzUyYuGmw0Coo
+        GHCkKi42YfeIybcozXTGzM3c5wUW5mH+9VMjWMMpfYJCOCpEnxPzNe9kk6NkwSzlCORyoICfBY0z
+        7UchQXsLc3wXrMY4AwklkK8qhWyj1OpoyYUsMRcisvDt2r/nIsJ1+KpNkgjZ9lu5IlYxEQor0LYU
+        xm4OTLIWzTahwC0f7PxZn8MQfvaU/mA580nRIZOtm5QACy1aaBYQRUIDEfgmYvmRVKQXKJU/oCY8
+        RWOy/ZqeyF+RBuB6AB4s1UJQK6mhOv5lkjNqDdc9nty0iuKwMEOrscNAqglqBaqFCzFbFegMlhDX
+        L5n8ZNFVN+DmpK7COPkhKnMI7mUDqaHL57nY30NJOkVA5LQvuZJjLBzAVFqIYTLihRiw/Zo3iYEB
+        DndsR/dUctba+qnYKGfiDJghzz67nR1NTUVZmkuMrXhYVcCmiwrtsXjltqGV+soWYedomCzm/C56
+        CZNd2MCvRVuIjbUFRZkzcmKhiYSTM6L3kBuw9rfwTlgMBiteorz8EoetD3KBTTwAj5k6g+RCSZj3
+        BI6l4nyEU5bvpJiCQcDB2LE/7U4ASyz3GWpq/RAObJbZQ1FOaiBsUot/7UmgSKq5tJi8/EwAeOlg
+        Wm/5nAa7MGtLal3ERg6esWoBT6QSi+vQEym38utwOL7iainD5Dl+yBp2k2u7hT6YpTJTWUsdPiHZ
+        fQ4WuuWxEDzVD+26tq07FAKco9ZUadM9LNglItiRFj78dT7j/ADvhCAu/t66qkykPVvqszhl56Rl
+        XdHK2KQ08L665ZK/QgZ1Fa4jCAFJnGbaXfxSUoJqVhkzkH+hNlVdO8BfQaRiw+icftFozldRR+EO
+        3gsTpYYtY8Ba8yB5VWni1bIDRV2FijqTY5bcTjmWLS+tUOQNy2gr2eF3PCxConyJItSmIvg5ki+h
+        FaUPYjhlRVbKTz1u/cHD8MYP5tpw3K2YAdkdyuQwlQzvfV6tjX4hjnnQN7VNGSt+G885Kt1vgAPC
+        dZxL+gevjyCG7tpK/qkJ1xUgJ4YH6dGiCc/MmqzTegMIoDcH0DVRRdciEhU3T0WNkpryIkbB8Ior
+        LQTDy6vJuNcg3woJD3FM3VOtIjCxq1oJA+Iqu6TSLa5hl5doGwKeOdxNUrEEMh7PcHRXRaWxtj8s
+        HqGsIqJnyOem05nP5Qbw1FZbtG2qO4DMHNXgzNpqBUX0FrM3Jp27Da85jDnJds/pNFrF4S5DjnMt
+        trEtFDCDrNpQZKJXDk6hxih2Hi/PGey67vLVqut02a/f9DbkM66BeseKXcd2ZWpxJuUM6mJ/NON0
+        6vvr9AEpfuVUSiHdU6/Pim06SGaoIj9W5C+eEEAntvS29ycBLyqHzJci55xsoqfw+FqYJtVWVD42
+        qYdKZorRQKT4iULiosicewYHZjHip9UW8KMNbRQkvBiM6IaKonut6uQJhrZ8YtMf82sOwHPUpntj
+        uQ7gGA9vRzjfkGMLqk0tYecQr6xdS0UzzojbeAMbZ6311tFyl6VJs7Kxa+DlUDqzFVmX4pVDQnA2
+        xeB8RvP+qEd3HT/F8ObLtlwNjcGLbDzzL/CM8uoKBGrLLF49Ra0cecskBSazVRijrXaQSg+Lykay
+        0Z3PXXwwivJQuwsf0BNp1qzbjmOpFl4RoLK83sQ8myOX2Cc46/qx/mTCeaa/DpF0lCCPvGDBxu1C
+        Fqg+jcopVAU346u36NnUYk3pokD3bsJVPbvrghX2poB3qHzmeglwKm0Rs+jXI5tUkVFeUcES2iLi
+        /Va0FEGVq0DNx3xZGl4qj8NEm0Xl3UN5q8cYegv7CIpd/JYeXM1aJI58lnN1P+KynKv0G96PgJes
+        7dc7LOGULce6w8ikOMQOAMFSG6Y5pdFBKl0e6YDhX895oZjr+cwfn6D8mjgWBHDHUJmIPFSdmgOG
+        uPbko/jkjutXYXv7Ln6IMomrK1DE2WCObn50MC969tXaoX0Og3nUH/OyuuEyQ7WBZjldD29CcNQa
+        prWJqYDhxMvV5P0zGPM3DQ0A/OB4xon5TuZ6AK0Zcq0+3jdmtUFK3LKTLwV/eKX6RYzKkoeroOq9
+        g4qf2CxVLVVTMVGooDmxbEBM+Tt5/O6My7b9ZXlVhYSGM97zwCggIsW6jimWd0UxFVPslZod6RrC
+        ZDbkUOoki5eSgowAum0H6X2K6ZAppkOCMIQlDtOUk5FStSqeVT4cL3pBd6KNJrN53+/3tK4/Hc79
+        u7oyb8FmRu0bR22u2BRvkRTqCsqq1BOeezXBuwrxMpvgOd4+v7FlW0pYSP3DRWioXIN3Iq0Qc+8z
+        klZ/ziXefYDhYFC8BtsarAD4U5YSPnxYVdWEXo87fHobnO1ctdNiGfWKeTqqotdxKmBX+opn3MIz
+        4KZmFuH6OW56f6J7FIVYFbKGU+9fc4fIOVjgajjnKUfx7hHCWF4v/Ush0bbADPpRA0xijkBUPXE1
+        45pt8KD9oH00VHQZsXWLwN4w/wKXWJWOwRl6v4svfS4OL9JXvDJE5sBExIlzwcpX4IoHplhpE+uh
+        RP6m1e5vY+687Ma7+Pcowbm5cZrtwLSk8JJoEvUAdFpUmWMkCpqLnAhhuZ1TAL0b8gbdxckyXSda
+        b7VfvpNDf7B729QWsTkKWTdhipem2a0GilPc8vupO7vu8JcWZ+G3xzRbFUNN9QKFeLdqgUT/gv1k
+        ihwc05QvkPYWPW4/4cDzr/u06Y4xZFpT11a7g6JoSYtgWuxbMTE/IGfIbnQHPJgubnza50i5DpZx
+        1HxFMV7cgLwP5YsbTDHBrlxBIRZ8L2354dMFPyiziNYpu26wA9U8kb+iQjGqV8g9NWkqv2Xm1594
+        EcznLFp9apDFNi3dNphaoffwli2pTVVxnjrSBZzRlJNMGg2vg7k/7wXatDefTe56n0Yasnj98Rcd
+        c4Ea43AiywEDFa/wbUkGDu16Pha48rHg05DbPp+SOH9tD88M7HAVx+WKCQWRJSEAHlFknjpnyap1
+        eaXSebjcxUgDe813ESC4UzdIU7wiCTCD7alJZ7cNBdfi0nOIyDc9/ni9iZIkqmTY9VYBrnNwcEul
+        9VCrilmxq6L5QuXHmnqTgOvX9Q5XbfSQIFb8jU0xnJCiec9U0tFaSclKDBdP2bO0Hj71eWXm/dMm
+        WsVN0syAuw2H6h5RbG2TUxUrqh7GgxFf8g32m02800bxKt9lqIf3fgmmXnMLJlL7HYCsSmocpzDQ
+        T22n+ewTt+zm2T7qhg0Fg2IekIIRTPVwamMiF84RERB1SyqGFPd92uUsGUf7LN2GTcMwBGK3S3HS
+        RzF+V1hIFVvUF1qvz7OSe+ETxG45+ScXyYeFlohaVsTaN4+l3rz37+54zbv1OvyaNmjXOABHXYSl
+        isusvRBavfGNufLD9pj9cF3v09kPcZAqTlAWTg30CHmcGJorTYUzhhBu+d7p8GuUhNoEs9VGYECK
+        e7cgnVN2jYh6BNcYlVuWzzho+gNOvqqfhc8QlNs0DxxAOYSqUZBr+UeVlEHE2mdIS/O3u82i1Te8
+        T7DVGEP3XPhQqYPWCrKfxACm02GyrplM+Yg22cIPx79Hs9ZBC2Ibuoszi6oJNzlxpbfYEGGm/GFz
+        e/eZZ1fdfX5Haz9qO8eN7eqwKVhHUEdWkaEo0kVE5Wyhr+1Q+atVgz4vuLHfRhkOj5SUg/TxLdA1
+        trcJZOKU4LUuiiP3LdKRtSD7kpyjpe/f8V0Sf71DQuwTZORxyYGpN8lGQTg1IvnJgUbWcdUHyeaB
+        z99RE62jPGy91peYrBANsFRsaUOiP9W76s7G/J1bURY+pcm7zG99y4GYpBgqc1WEkloNoeAQZUP8
+        GXcIdbGjvQklSvR4ZQNhOLb0UYoHYvyuXK5zxmF094XDPLNwvX59iNPWVYbjZMxUk0oqkGbbDRQ4
+        JuOoi0DNgwW32GgevcDWf9XApAbfUFcnrqEmtlzMZp8sHIi4+pxw7f8acOb4/9lH+S5+kbkrkRSj
+        PngnhWq2fdKwCpGCyrMOpnccZphmKU5hfceStoRlBvJ40G2q3PJ2iYCagRnC5NWGune8lmcXr6dY
+        7uK89iY7NAWFuRTnf403ubQ2DUX1yND9woft110Uy/QjieEWNyKRj+ZPFJGjgg8AQMr3UQCpciZN
+        cMh0n3DK7G1Bz4DMCAWuFKnzoqaLqGOufijdXHG5d/dGuwqTr/lzmEX1GbiHCbijU/bxIl2GgLnJ
+        ORoh4/EV168bjxtEDEwAaw6kDX+FuvKh5XUk7U2kxfqu51xQu1qHy6/auxChhEoIK27dMlT1lk0x
+        I6pcW6d+qvpzXvfE36V5LgN8PKRRoT7sB09oHGp0xxRsQ5ZsMR7yQ0DjOImEFK9h9twrphtNFQJp
+        4aL21ed2XPWCjz+d8azy9T7S/G0GQLudhP12qbeSImkbiKvTBDhDB24cTI+UVfNtnEWj6/r5Rk93
+        qaGmclvbVq3Mm1e4vaZT6lbImTLn6IjjMEmDXYYkxNOSLXbRT4WMW3E4w2qbcX7v5R2NB0kPOF/z
+        7lmFz6kGVoW76CleHgY0GqwihZ6YKrtHFPM9qSB0jjRxd8LZtUw3wTJtuljHcgtJMVsVulW0AD6w
+        wjjo3nNJHTwhssaV1nCbkwVHqovXKivY0h4FKjMLlMkPbd30e1xMu4kfioGFWsVEQJyMMqy6qXnD
+        PqUKUvHGpfxc8MwfcnPBN1kUPz3vlmGm+eUt8Q2zJKgZ7+qWSqO+dhK40i5V7/j0bnjNlujmpted
+        T2YydEWnaM1R1V1D2sQOyvdXMmg8WXBzdOP0JdQWcY73v/rL/+zhq+Iu2HpOqYP5m07oT4/8HG8e
+        s2NWQpkrTxPx5/ztvPCkTZ9f82K0vnRTQx+ImYWApaXWCDbbyVbvQ2hqpaoj4fgZTta/yyS2ZG6M
+        6ZaDF97/dGyrXtukPCb8iYMEnxIUArjsw0ut4jBp4pLrrsEAen68Jt1PTCVMZvxUAur3v5/97fRX
+        naDSEfn4wW2xx3gGAeTe53yCYCY5NH6bqFTFNL2lclvgqfTGFBkGOHwlfy/BNbf1h8kq3OJloqej
+        M8Boiv0QqhidrVPyZ0wsRzFbHkn3746HYLCw1lTWdfGCZEDOiozRSqZ2DAfsmksPCbPk70keBtPJ
+        hZDfhEW7avm2b6rSIFjQZZCqqYlP0Y59qlZYyXPOqd98/jzkpmIoxeCMd9hmr2061wxdpHsqQuSF
+        SuOpGrWlPuXjD3mapR8naVPFE2mHitfptYPnCvlL/u1vZr9x/A/4jb+H2mfSVLLVGSwu96OvvkA0
+        UCmln9HKGX/mmdVpEn+vcEH56y+qtQ3ddiw1hVDs7FQKauLi+gmN0FGPF6Oaz7771z1t0PPv5oMG
+        6TmdGmCPSnpz6qipaDufcWhe3XAd0WCf5M8xLwZfn/9jrx22y0/3qMXtYosVpzM2+2jORS+//AFt
+        lMIRs1+HvHp/vUUOqgKqXhpltctrko6n7qHxgldFHiaL+CU9vt35vT5Yv4eo7hjFLa4f6awaAY0z
+        XLXgq+z+S7hOZZBNQchhRKk8QNplTgAP/FR1vT+bHJHb0o0WpEVDiqOHN5TSDN1U4YO2+kYsC156
+        RF7JYHA0qzQIUV7nOQpX7wX2GjPOf/1fqjeAgkP+70/4e6M8D5/gVyf79RpeaxcC8r341x8XWTdd
+        wbepYegXD/j16PgnV9FLtEZxj6Pv//nn/wPqsH3kx7cAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - https://www.nasdaq.com
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '8584'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 08 Nov 2023 20:23:59 GMT
+      Expires:
+      - Wed, 08 Nov 2023 20:23:59 GMT
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ak_bmsc=5691590120D1E53DB05B3D4A9F7BCFBA~000000000000000000000000000000~YAAQLKMAF5ZokKmLAQAAESabsBUNQpYA/yynvQ1jvroEZizNFZvYh+ls9o4cCx1txczhSpP68m3Tkx0GE0/Q4FRjjpmabCCA9bJqRyvEH0ftyvKYqH/OlArn8mXrgUSRCxG2k1xjaQjZ0q99KXOXWV1jrT7HFx9kwVkTKwjizpO0DbB4+PXz8T/yDBHcEXmhKCf0INAWAjsG2YzaOPhhGbl+DYOcC+FdOq2r8p30OkH538ZA9uxHciElSYBhTTZbBYg1BdIbbu2eVrN6K0QvCZQwIoRUZFO4rBs5iuocO+GpbfzAgwg3vw3YshDussmA/gjqW8XnBX8UoMrUlRh5gyVkONk7I0c/5j+zrJ8YfWCHxgbXHU+IuGVvHTOI0PZcv/ML4kloDLn3ur6OuUML90XDdb/j;
+        Domain=.nasdaq.com; Path=/; Expires=Wed, 08 Nov 2023 22:23:59 GMT; Max-Age=7200;
+        HttpOnly
+      Strict-Transport-Security:
+      - max-age=86400
+      Vary:
+      - Accept-Encoding
+      cache-hit:
+      - '3004'
+      gid:
+      - '202'
+      lang:
+      - en
+      rid:
+      - 06174182-e827-4562-863d-6c5703e824db
+      srctype:
+      - default
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/openbb_platform/providers/nasdaq/tests/test_nasdaq_fetchers.py
+++ b/openbb_platform/providers/nasdaq/tests/test_nasdaq_fetchers.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 from openbb_core.app.service.user_service import UserService
 from openbb_nasdaq.models.calendar_dividend import NasdaqDividendCalendarFetcher
+from openbb_nasdaq.models.calendar_earnings import NasdaqEarningsCalendarFetcher
 from openbb_nasdaq.models.calendar_ipo import NasdaqCalendarIpoFetcher
 from openbb_nasdaq.models.cot import NasdaqCotFetcher
 from openbb_nasdaq.models.cot_search import NasdaqCotSearchFetcher
@@ -91,5 +92,17 @@ def test_nasdaq_cot_search_fetcher(credentials=test_credentials):
     params = {}
 
     fetcher = NasdaqCotSearchFetcher()
+    result = fetcher.test(params, credentials)
+    assert result is None
+
+
+@pytest.mark.record_http
+def test_nasdaq_calendar_earnings_fetcher(credentials=test_credentials):
+    params = {
+        "start_date": datetime.date(2023, 11, 6),
+        "end_date": datetime.date(2023, 11, 10),
+    }
+
+    fetcher = NasdaqEarningsCalendarFetcher()
     result = fetcher.test(params, credentials)
     assert result is None


### PR DESCRIPTION
** Just leaving this here with a Do Not Merge label, and I will update it when the renaming is done **

This PR adds the earnings calendar, `obb.stocks.calendar_earnings()`, with data added from Nasdaq.  Historical data is available through the start/end date parameters.

![Screenshot 2023-11-08 at 12 53 32 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/dd3bcf40-d281-4ba9-b588-345d58449d7f)
