### PR TITLE
Add devtools metapackage

### DIFF
--- a/openbb_platform/dev_install.py
+++ b/openbb_platform/dev_install.py
@@ -14,6 +14,7 @@ PYPROJECT = PLATFORM_PATH / "pyproject.toml"
 LOCAL_DEPS = """
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
+openbb-devtools = { path = "./extensions/devtools", develop = true }
 openbb-provider = { path = "./platform/provider", develop = true }
 openbb-core = { path = "./platform/core", develop = true }
 

--- a/openbb_platform/extensions/devtools/README.md
+++ b/openbb_platform/extensions/devtools/README.md
@@ -1,0 +1,22 @@
+# The OpenBB DevTools Extension
+
+This extension aggregates the dependencies that facilitate a nice development experience
+for OpenBB. It does not contain any code itself, but rather pulls in the following dependencies:
+
+- Linters (ruff, pylint, mypy)
+- Code formatters (black)
+- Code quality tools (bandit)
+- Pre-commit hooks (pre-commit)
+- CI/CD configuration (tox, pytest, pytest-cov)
+- Jupyter kernel (ipykernel)
+- ... add your productivity booster here ...
+
+## Installation
+
+The extension is included into the dev_install.py script.
+
+Standalone installation:
+
+```bash
+pip install openbb-devtools
+```

--- a/openbb_platform/extensions/devtools/openbb_devtools/__init__.py
+++ b/openbb_platform/extensions/devtools/openbb_devtools/__init__.py
@@ -1,0 +1,1 @@
+"""Placeholder for openbb_devtools."""

--- a/openbb_platform/extensions/devtools/pyproject.toml
+++ b/openbb_platform/extensions/devtools/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.poetry]
+name = "openbb-devtools"
+version = "0.1.0"
+description = "Tools for OpenBB Platform Developers"
+authors = ["OpenBB Team <hello@openbb.co>"]
+readme = "README.md"
+packages = [{ include = "openbb_devtools" }]
+
+[tool.poetry.dependencies]
+python = ">=3.8,<3.12"               # scipy forces <4.0 explicitly
+ruff = "^0.1.5"
+pylint = "^3.0.2"
+mypy = "^1.6.1"
+pydocstyle = "^6.3.0"
+black = "^23.11.0"
+bandit = "^1.7.5"
+pre-commit = "^3.5.0"
+tox = "^4.11.3"
+pytest = "^7.4.3"
+pytest-cov = "^4.1.0"
+ipykernel = "^6.26.0"
+types-python-dateutil = "^2.8.19.14"
+types-toml = "^0.10.8.7"
+poetry = "^1.7.0"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
What this does is adds a package that has the developer tools we use. It's a package that has no logic in it and that's being installed only as a part of the dev_install script