### PR TITLE
Hotfix/pypi openbb terminal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "openbb"
+name = "openbb-terminal"
 version = "3.2.4"
 description = "Investment Research for Everyone, Anywhere."
 license = "MIT"
@@ -16,7 +16,7 @@ openbb = 'terminal:main'
 
 [tool.poetry.dependencies]
 python = "^3.8.1,<3.11, !=3.9.7"
-scipy = "1.10.1" #Pinning on July 6 for pip issues
+scipy = "1.10.1"                                                      #Pinning on July 6 for pip issues
 iso8601 = "^0.1.14"
 FundamentalAnalysis = "^0.2.6"
 requests = "^2.31.0"
@@ -120,8 +120,8 @@ ffn = "0.3.6"
 jupyter-client = "7.4.1"
 jupyter-server = "1.23.6"
 python-jose = "^3.3.0"
-nixtlats = "^0.1.11" # Pinning for stability
-nltk = "^3.8.1" # Is a dependence for llama index
+nixtlats = "^0.1.11"                                                  # Pinning for stability
+nltk = "^3.8.1"                                                       # Is a dependence for llama index
 openai = "0.28.1"
 
 

--- a/website/content/platform/installation.md
+++ b/website/content/platform/installation.md
@@ -76,27 +76,27 @@ pip install poetry toml
 Install from PyPI with:
 
 ```console
-pip install openbb==4.0.0a4
+pip install openbb --pre
 ```
-
-:::note
-While still under active development, the version number is required to install the core OpenBB Platform.
-:::
 
 To install all of the extensions and providers:
 
 ```console
-pip install openbb[all]==4.0.0a4
+pip install openbb[all] --pre
 ```
+
+:::note
+While still under active development, the `pre` flag is required to install the core OpenBB Platform latest version.
+:::
 
 To install a single extension:
 
 ```console
-pip install openbb[charting]==4.0.0a4
+pip install openbb[charting] --pre
 ```
 
 ```console
-pip install openbb[ta]==4.0.0a4
+pip install openbb[ta] --pre
 ```
 
 Import the package with:

--- a/website/content/terminal/installation/pypi.md
+++ b/website/content/terminal/installation/pypi.md
@@ -208,7 +208,7 @@ Make sure to have completed all previous steps. If followed, there will be a vir
 Install the main package of Openbb SDK with `pip`, a package manager.
 
 ```shell
-pip install openbb --no-cache-dir
+pip install openbb-terminal --no-cache-dir
 ```
 
 This method provides access to the data aggregation and charting functions of the OpenBB SDK. It does not provide access to the advanced features that are provided by the Portfolio Optimization and Machine Learning toolkits.
@@ -216,23 +216,23 @@ This method provides access to the data aggregation and charting functions of th
 The toolkits can be installed individually with:
 
 ```shell
-pip install "openbb[optimization]" --no-cache-dir
+pip install "openbb-terminal[optimization]" --no-cache-dir
 ```
 
 and
 
 ```shell
-pip install "openbb[forecast]" --no-cache-dir
+pip install "openbb-terminal[forecast]" --no-cache-dir
 ```
 
 Install all available toolkits at once with:
 
 ```shell
-pip install "openbb[all]" --no-cache-dir
+pip install "openbb-terminal[all]" --no-cache-dir
 ```
 
 :::info
-`pip install openbb[all]` is not yet compatible with environments such as Google Colab and Kaggle as they come with preinstalled packages that can conflict with the ones used in the OpenBBTerminal and SDK.  It may be possible to install without the extra toolkits, but we currently do not officially support this type of installation.  We are working on a solution to this problem and will update this section once it is resolved.
+`pip install openbb-terminal[all]` is not yet compatible with environments such as Google Colab and Kaggle as they come with preinstalled packages that can conflict with the ones used in the OpenBBTerminal and SDK.  It may be possible to install without the extra toolkits, but we currently do not officially support this type of installation.  We are working on a solution to this problem and will update this section once it is resolved.
 :::
 
 ## Verify Installation
@@ -291,7 +291,7 @@ OpenBB SDK is updated daily with new features and bug fixes, but some features b
 
 ```shell
 conda activate obb
-pip install -U openbb-nightly --no-cache-dir
+pip install -U openbb-terminal-nightly --no-cache-dir
 ```
 
 :::info

--- a/website/pypi.md
+++ b/website/pypi.md
@@ -19,7 +19,7 @@ More information on this product can be found [here](https://openbb.co/products/
 The command below provides access to the core functionalities behind the [OpenBB Terminal](https://openbb.co/products/terminal).
 
 ```python
-pip install openbb
+pip install openbb-terminal
 ```
 
 If you wish to utilize our **Portfolio Optimization** or **Machine Learning / Artificial Intelligence** toolkits, please see instructions [here](https://docs.openbb.co/sdk/installation).


### PR DESCRIPTION
Bring back some changes that the merge with the Platform should've introduced, namely:
- OpenBBTerminal to be `openbb-terminal`
- Documentation changes on patterns like `pip install openbb` so that the above point can be reflected once we get the v4 release out.