### PR TITLE
New Intrinio Endpoints

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/calendar_dividend.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/calendar_dividend.py
@@ -14,7 +14,7 @@ from openbb_core.provider.utils.descriptions import (
 )
 
 
-class DividendCalendarQueryParams(QueryParams):
+class CalendarDividendQueryParams(QueryParams):
     """Dividend Calendar Query."""
 
     start_date: Optional[dateType] = Field(
@@ -25,14 +25,17 @@ class DividendCalendarQueryParams(QueryParams):
     )
 
 
-class DividendCalendarData(Data):
+class CalendarDividendData(Data):
     """Dividend Calendar Data."""
 
     date: dateType = Field(
         description=DATA_DESCRIPTIONS.get("date", "") + " (Ex-Dividend)"
     )
     symbol: str = Field(description=DATA_DESCRIPTIONS.get("symbol", ""))
-    name: Optional[str] = Field(description="Name of the entity.", default=None)
+    amount: Optional[float] = Field(
+        default=None, description="Dividend amount, per-share."
+    )
+    name: Optional[str] = Field(default=None, description="Name of the entity.")
     record_date: Optional[dateType] = Field(
         default=None,
         description="The record date of ownership for eligibility.",
@@ -44,7 +47,4 @@ class DividendCalendarData(Data):
     declaration_date: Optional[dateType] = Field(
         default=None,
         description="Declaration date of the dividend.",
-    )
-    amount: Optional[float] = Field(
-        default=None, description="Dividend amount, per-share."
     )

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/__init__.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/__init__.py
@@ -1,6 +1,6 @@
 """Nasdaq provider module."""
 from openbb_core.provider.abstract.provider import Provider
-from openbb_nasdaq.models.calendar_dividend import NasdaqDividendCalendarFetcher
+from openbb_nasdaq.models.calendar_dividend import NasdaqCalendarDividendFetcher
 from openbb_nasdaq.models.calendar_earnings import NasdaqCalendarEarningsFetcher
 from openbb_nasdaq.models.calendar_ipo import NasdaqCalendarIpoFetcher
 from openbb_nasdaq.models.cot import NasdaqCotFetcher
@@ -17,7 +17,7 @@ provides premier platforms and services for global capital markets and beyond wi
 unmatched technology, insights and markets expertise.""",
     credentials=["api_key"],
     fetcher_dict={
-        "CalendarDividend": NasdaqDividendCalendarFetcher,
+        "CalendarDividend": NasdaqCalendarDividendFetcher,
         "CalendarEarnings": NasdaqCalendarEarningsFetcher,
         "CalendarIpo": NasdaqCalendarIpoFetcher,
         "COT": NasdaqCotFetcher,

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_dividend.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_dividend.py
@@ -7,21 +7,21 @@ from typing import Any, Dict, List, Optional
 import requests
 from openbb_core.provider.abstract.fetcher import Fetcher
 from openbb_core.provider.standard_models.calendar_dividend import (
-    DividendCalendarData,
-    DividendCalendarQueryParams,
+    CalendarDividendData,
+    CalendarDividendQueryParams,
 )
 from openbb_nasdaq.utils.helpers import IPO_HEADERS, date_range
 from pydantic import Field, field_validator
 
 
-class NasdaqDividendCalendarQueryParams(DividendCalendarQueryParams):
+class NasdaqCalendarDividendQueryParams(CalendarDividendQueryParams):
     """Nasdaq Dividend Calendar Query.
 
     Source: https://www.nasdaq.com/market-activity/dividends
     """
 
 
-class NasdaqDividendCalendarData(DividendCalendarData):
+class NasdaqCalendarDividendData(CalendarDividendData):
     """Nasdaq Dividend Calendar Data."""
 
     __alias_dict__ = {
@@ -52,10 +52,10 @@ class NasdaqDividendCalendarData(DividendCalendarData):
         return datetime.strptime(v, "%m/%d/%Y").date() if v else None
 
 
-class NasdaqDividendCalendarFetcher(
+class NasdaqCalendarDividendFetcher(
     Fetcher[
-        NasdaqDividendCalendarQueryParams,
-        List[NasdaqDividendCalendarData],
+        NasdaqCalendarDividendQueryParams,
+        List[NasdaqCalendarDividendData],
     ]
 ):
     """Transform the query, extract and transform the data from the Nasdaq endpoints."""
@@ -63,7 +63,7 @@ class NasdaqDividendCalendarFetcher(
     require_credentials = False
 
     @staticmethod
-    def transform_query(params: Dict[str, Any]) -> NasdaqDividendCalendarQueryParams:
+    def transform_query(params: Dict[str, Any]) -> NasdaqCalendarDividendQueryParams:
         """Transform the query params."""
         now = datetime.today().date()
         transformed_params = params
@@ -74,11 +74,11 @@ class NasdaqDividendCalendarFetcher(
         if params.get("end_date") is None:
             transformed_params["end_date"] = now + timedelta(days=3)
 
-        return NasdaqDividendCalendarQueryParams(**transformed_params)
+        return NasdaqCalendarDividendQueryParams(**transformed_params)
 
     @staticmethod
     def extract_data(
-        query: NasdaqDividendCalendarQueryParams,
+        query: NasdaqCalendarDividendQueryParams,
         credentials: Optional[Dict[str, str]],  # pylint: disable=unused-argument
         **kwargs: Any,
     ) -> List[Dict]:
@@ -110,9 +110,9 @@ class NasdaqDividendCalendarFetcher(
 
     @staticmethod
     def transform_data(
-        query: NasdaqDividendCalendarQueryParams,  # pylint: disable=unused-argument
+        query: NasdaqCalendarDividendQueryParams,  # pylint: disable=unused-argument
         data: List[Dict],
         **kwargs: Any,  # pylint: disable=unused-argument
-    ) -> List[NasdaqDividendCalendarData]:
+    ) -> List[NasdaqCalendarDividendData]:
         """Return the transformed data."""
-        return [NasdaqDividendCalendarData.model_validate(d) for d in data]
+        return [NasdaqCalendarDividendData.model_validate(d) for d in data]

--- a/openbb_platform/providers/nasdaq/tests/test_nasdaq_fetchers.py
+++ b/openbb_platform/providers/nasdaq/tests/test_nasdaq_fetchers.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 from openbb_core.app.service.user_service import UserService
-from openbb_nasdaq.models.calendar_dividend import NasdaqDividendCalendarFetcher
+from openbb_nasdaq.models.calendar_dividend import NasdaqCalendarDividendFetcher
 from openbb_nasdaq.models.calendar_earnings import NasdaqCalendarEarningsFetcher
 from openbb_nasdaq.models.calendar_ipo import NasdaqCalendarIpoFetcher
 from openbb_nasdaq.models.cot import NasdaqCotFetcher
@@ -43,7 +43,7 @@ def test_nasdaq_calendar_dividend_fetcher(credentials=test_credentials):
         "end_date": datetime.date(2023, 11, 6),
     }
 
-    fetcher = NasdaqDividendCalendarFetcher()
+    fetcher = NasdaqCalendarDividendFetcher()
     result = fetcher.test(params, credentials)
     assert result is None
 


### PR DESCRIPTION
# New endpoints added

* equity.info
* index.market
* equity.discovery.filings
* equity.ownership.institutional
* equity.fundamental.latest_attributes
* equity.fundamental.historical_attributes
* equity.fundamental.metrics
* equity.ownership.insider_trading
* equity.calendar.dividend
*  equity.ownership.share_statistics

# Changelog

## Models
* EquityInfo standard model has been modified to favor Intrinio's data. CBOE may need to define their provider model that can be compatible with the standard model.
* MarketIndices standard model is based on the FMP data. Currently Intrinio is the de-facto provider but its data is defined in the provider model so that FMP doesn't break.
* Filings standard model has been removed because of its redundant requirement.
* CompanyFilings standard model has been added to provider SEC filing for the requested symbol(s). All the provider models are compatible with the data in the standard model.
* DiscoveryFilings standard model has been added to provide the latest SEC filings. Currently only FMP uses it.
* InstitutionalOwnership model has been redefined with the common fields. It needs standardization b/w FMP and Intrinio.
* FinancialAttributes model has been renamed to HistoricalAttributes as per the latest requirements for Excel.
* LatestAttributes model has been added to get the latest value of the intrinio tags.
* KeyMetrics model has been redefined to include only the common fields between FMP and Intrinio.
* InsiderTrading model has been redefined to favor Intrinio's data.

## Other
* `regulators.sec.filings` has been removed as the `openbb-sec` provider already caters to `CompanyFilings` standard model.
* `check_missing_integration_tests` has been modified to correctly replace `test` from the names, which includes functions having `test` in their names.
* `get_test_params` has been modified to include provider in `test_params` even if its empty.