### PR TITLE
hotfix/fmp-replace-zero: Replace Zero with None in FMP Balance, Cash, Income

### DIFF
--- a/openbb_platform/providers/fmp/openbb_fmp/models/balance_sheet.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/balance_sheet.py
@@ -92,6 +92,12 @@ class FMPBalanceSheetData(BalanceSheetData):
         default=None, description="Link to the final statement."
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def replace_zero(cls, values):  # pylint: disable=no-self-argument
+        """Check for zero values and replace with None."""
+        return {k: None if v == 0 else v for k, v in values.items()}
+
 
 class FMPBalanceSheetFetcher(
     Fetcher[

--- a/openbb_platform/providers/fmp/openbb_fmp/models/cash_flow.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/cash_flow.py
@@ -99,6 +99,12 @@ class FMPCashFlowStatementData(CashFlowStatementData):
         default=None, description="Link to the final statement."
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def replace_zero(cls, values):  # pylint: disable=no-self-argument
+        """Check for zero values and replace with None."""
+        return {k: None if v == 0 else v for k, v in values.items()}
+
 
 class FMPCashFlowStatementFetcher(
     Fetcher[

--- a/openbb_platform/providers/fmp/openbb_fmp/models/income_statement.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/income_statement.py
@@ -122,6 +122,13 @@ class FMPIncomeStatementData(IncomeStatementData):
         default=None, description="Final link to the income statement."
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def replace_zero(cls, values):  # pylint: disable=no-self-argument
+        """Check for zero values and replace with None."""
+        return {k: None if v == 0 else v for k, v in values.items()}
+
+
 
 class FMPIncomeStatementFetcher(
     Fetcher[


### PR DESCRIPTION
This PR adds a model validator to Balance, Cash, and Income that replaces 0s with None, allowing them to be dropped cleanly with `model_dump()`.

Before:

![Screenshot 2023-11-28 at 2 02 43 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/863e109a-6ef0-4db3-bf66-0669b1de1fe5)

After:

![Screenshot 2023-11-28 at 2 04 11 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/10d74acc-f329-47e4-890a-8f3e908605f9)