### PR TITLE
separate pylint between platform + terminal

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -58,10 +58,11 @@ jobs:
       - run: |
           if [ -n "${{ env.files }}" ]; then
             mypy --ignore-missing-imports ${{ env.files }}
+            pylint terminal.py openbb_terminal tests 
           else
             echo "No Python files changed in openbb_terminal"
           fi
-      - run: pylint terminal.py openbb_terminal tests
+      - run: pylint openbb_platform
 
   markdown-link-check:
     name: Markdown Linting

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,10 +37,12 @@ jobs:
           python-version: "3.9"
           architecture: x64
 
-      - name: Get changed files in openbb_terminal for PR
+      - name: Get changed files in openbb_terminal and openbb_platform for PR
         if: github.event_name == 'pull_request'
         run: |
-          echo "files=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.head_ref }} | grep 'openbb_terminal/.*\.py$' | xargs)" >> $GITHUB_ENV
+          # "Checking PR diff"
+          echo "terminal_files=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.head_ref }} | grep 'openbb_terminal/.*\.py$' | xargs)" >> $GITHUB_ENV
+          echo "platform_files=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.head_ref }} | grep 'openbb_platform/.*\.py$' | grep -v 'openbb_platform/openbb/package' | grep -v 'integration' | grep -v 'tests' | xargs)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:
@@ -56,13 +58,21 @@ jobs:
       - run: codespell --ignore-words=.codespell.ignore --skip="$(tr '\n' ',' < .codespell.skip | sed 's/,$//')" --quiet-level=2
       - run: ruff .
       - run: |
-          if [ -n "${{ env.files }}" ]; then
-            mypy --ignore-missing-imports ${{ env.files }}
-            pylint terminal.py openbb_terminal tests 
+          # Run linters for openbb_terminal
+          if [ -n "${{ env.terminal_files }}" ]; then
+            mypy --ignore-missing-imports ${{ env.terminal_files }}
+            pylint terminal.py ${{ env.terminal_files }}
           else
             echo "No Python files changed in openbb_terminal"
           fi
-      - run: pylint openbb_platform
+      - run: |
+          # Run linters for openbb_platform
+          if [ -n "${{ env.platform_files }}" ]; then
+            # Add mypy to this part of the linting workflow once we're ready
+            pylint ${{ env.platform_files }}
+          else
+            echo "No Python files changed in openbb_platform"
+          fi
 
   markdown-link-check:
     name: Markdown Linting


### PR DESCRIPTION
There is a rogue pylint failing on an untouched terminal file.  This should not raise that error.