### PR TITLE
hotfix/fmp-price-performance-zeros: Replace returned zero with None and normalize percent values.

### DIFF
--- a/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
@@ -8,7 +8,7 @@ from openbb_core.provider.standard_models.recent_performance import (
     RecentPerformanceQueryParams,
 )
 from openbb_fmp.utils.helpers import create_url, get_data_many
-from pydantic import Field
+from pydantic import Field, model_validator
 
 
 class FMPPricePerformanceQueryParams(RecentPerformanceQueryParams):
@@ -34,6 +34,15 @@ class FMPPricePerformanceData(RecentPerformanceData):
         "five_year": "5Y",
         "ten_year": "10Y",
     }
+
+    @model_validator(mode="before")
+    @classmethod
+    def replace_zero(cls, values):  # pylint: disable=no-self-argument
+        """Replace zero with None and convert percents to normalized values."""
+        for k, v in values.items():
+            if k != "symbol":
+                values[k] = None if v == 0 else float(v) / 100
+        return values
 
 
 class FMPPricePerformanceFetcher(

--- a/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
@@ -1,5 +1,5 @@
 """FMP Price Performance Model."""
-
+# pylint: disable=unused-argument
 from typing import Any, Dict, List, Optional
 
 from openbb_core.provider.abstract.fetcher import Fetcher


### PR DESCRIPTION
This PR fixes:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/4a4865a9-4359-473e-937c-abd7142cb351)

Although now that the market has opened, and data exists for YTD, the bug is not reproducible anymore. A `model_validator` is applied to all fields except 'symbol' that replaces 0 with None.

This also converts percent values to be normalized values - /100.

![Screenshot 2024-01-03 at 11 49 56 AM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/11bcaf7d-a977-453b-9e9b-15fbe4ecfac0)
