### PR TITLE
Add json_schema_extra to openapi.json

### DIFF
--- a/openbb_platform/core/openbb_core/app/provider_interface.py
+++ b/openbb_platform/core/openbb_core/app/provider_interface.py
@@ -245,6 +245,7 @@ class ProviderInterface(metaclass=SingletonMeta):
                 title=provider_name,
                 description=description,
                 alias=field.alias or None,
+                json_schema_extra=field.json_schema_extra,
             )
         elif provider_name:
             default: FieldInfo = Field(
@@ -257,6 +258,7 @@ class ProviderInterface(metaclass=SingletonMeta):
                 )
                 if alias_dict.get(name, [])
                 else None,
+                json_schema_extra=field.json_schema_extra,
             )
 
         return DataclassField(new_name, type_, default)
@@ -479,6 +481,7 @@ class ProviderInterface(metaclass=SingletonMeta):
             fields.update(extra.model_fields)
 
             fields_dict: Dict[str, Tuple[Any, Any]] = {}
+
             for name, field in fields.items():
                 fields_dict[name] = (
                     field.annotation,
@@ -488,6 +491,7 @@ class ProviderInterface(metaclass=SingletonMeta):
                         description=field.description,
                         alias=field.alias,
                         validation_alias=field.validation_alias,
+                        json_schema_extra=field.json_schema_extra,
                     ),
                 )
 


### PR DESCRIPTION
To add information about unit measurements pass a dictionary to the `json_schema_extra` Pydantic model field.

```
class SomeData(Data):
    value: Optional[float] = Field(
        default=None, description="Some value.",
        json_schema_extra={"unit_measurement": "percent"}
    )
```