### PR TITLE
hotfix/intrinio-strip-control-characters: regex out any invisible control character from sales_conditions field

### DIFF
--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_quote.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_quote.py
@@ -1,5 +1,6 @@
 """Intrinio Equity Quote Model."""
 # pylint: disable=unused-argument
+import re
 import warnings
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -73,12 +74,11 @@ class IntrinioEquityQuoteData(EquityQuoteData):
     @classmethod
     def validate_sales_conditions(cls, v):
         """Validate sales conditions and remove empty strings."""
-        if v == "\u0017   ":
-            return None
-        if v == "" or v is None:
-            return None
-        v = v.strip()
-        return v
+        if v:
+            control_char_re = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+            v = control_char_re.sub("", v).strip()
+            v = None if v == "" else v
+        return v if v else None
 
     @field_validator("exchange", "market_center", mode="before", check_fields=False)
     @classmethod


### PR DESCRIPTION
^^

This PR updates the validator to regex out any and all UTF-8 control characters being returned by Intrinio to the "sales_condition" field in `obb.equity.quote()`.

Example:
```
In: obb.equity.price.quote("SPY", provider="intrinio").results[0].sales_conditions
Out: '\x17\x1e\x7f'
```

Which ends up creating a huge field of empty spaces from `to_df()`.

![Screenshot 2024-01-19 at 4 46 10 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/10724f18-9026-43ea-b4bc-ea48e5268570)

This is replaced by `None`.
