### PR TITLE
Minor platform pyproject fix

### DIFF
--- a/openbb_platform/pyproject.toml
+++ b/openbb_platform/pyproject.toml
@@ -65,7 +65,6 @@ seeking_alpha = ["openbb-seeking-alpha"]
 stockgrid = ["openbb-stockgrid"]
 technical = ["openbb-technical"]
 wsj = ["openbb-wsj"]
-yfinance = ["openbb-yfinance"]
 
 
 all = [


### PR DESCRIPTION
Removes `yfinance` from the `extras` group in the platform's toml file.

This was an unintended leftover when making yfinance a part of the official packages.