### PR TITLE
Add support for multiple symbols on `obb.equity.price.historical`

### DIFF
--- a/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
+++ b/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
@@ -174,7 +174,7 @@ class AVEquityHistoricalFetcher(
         data = {}
 
         for symbol in query.symbol.split(","):
-            raw_data = await amake_request(f"{url}&symbol={symbol}")
+            raw_data = await amake_request(f"{url}&symbol={symbol}", **kwargs)
             dynamic_key = (set(raw_data.keys()) - {"Meta Data"}).pop()
             data[symbol] = raw_data[dynamic_key]
 
@@ -188,9 +188,13 @@ class AVEquityHistoricalFetcher(
         """Transform the data to the standard format."""
         transformed_data = []
         for symbol, content in data.items():
+            if not isinstance(content, dict):
+                # if the content isn't a dict, it means that the API returned an error
+                # most likely too many requests without premium account
+                raise Exception(content)
             d = [
                 {
-                    "symbol": symbol,
+                    **({"symbol": symbol} if "," in query.symbol else {}),
                     "date": date,
                     **{extract_key_name(k): v for k, v in values.items()},
                 }

--- a/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
+++ b/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
@@ -8,7 +8,6 @@ from dateutil.relativedelta import relativedelta
 from openbb_alpha_vantage.utils.helpers import (
     extract_key_name,
     filter_by_dates,
-    get_data,
     get_interval,
 )
 from openbb_core.provider.abstract.fetcher import Fetcher
@@ -20,7 +19,7 @@ from openbb_core.provider.utils.descriptions import (
     DATA_DESCRIPTIONS,
     QUERY_DESCRIPTIONS,
 )
-from openbb_core.provider.utils.helpers import get_querystring
+from openbb_core.provider.utils.helpers import amake_request, get_querystring
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -156,7 +155,7 @@ class AVEquityHistoricalFetcher(
         return AVEquityHistoricalQueryParams(**transformed_params)
 
     @staticmethod
-    def extract_data(
+    async def aextract_data(
         query: AVEquityHistoricalQueryParams,
         credentials: Optional[Dict[str, str]],
         **kwargs: Any,
@@ -166,15 +165,20 @@ class AVEquityHistoricalFetcher(
 
         interval = get_interval(query.interval)
         query_str = get_querystring(
-            query.model_dump(by_alias=True), ["start_date", "end_date", "interval"]
+            query.model_dump(by_alias=True),
+            ["start_date", "end_date", "interval", "symbol"],
         )
         query_str += f"&function={query._function}&interval={interval}"  # pylint: disable=protected-access
         url = f"https://www.alphavantage.co/query?{query_str}&apikey={api_key}"
 
-        data = get_data(url, **kwargs)
-        dynamic_key = (set(data.keys()) - {"Meta Data"}).pop()
+        data = {}
 
-        return data[dynamic_key]
+        for symbol in query.symbol.split(","):
+            raw_data = await amake_request(f"{url}&symbol={symbol}")
+            dynamic_key = (set(raw_data.keys()) - {"Meta Data"}).pop()
+            data[symbol] = raw_data[dynamic_key]
+
+        return data
 
     # pylint: disable=unused-argument
     @staticmethod
@@ -182,10 +186,17 @@ class AVEquityHistoricalFetcher(
         query: AVEquityHistoricalQueryParams, data: Dict, **kwargs: Any
     ) -> List[AVEquityHistoricalData]:
         """Transform the data to the standard format."""
-        data = [
-            {"date": date, **{extract_key_name(k): v for k, v in values.items()}}
-            for date, values in data.items()
-        ]
-        data = filter_by_dates(data, query.start_date, query.end_date)
+        transformed_data = []
+        for symbol, content in data.items():
+            d = [
+                {
+                    "symbol": symbol,
+                    "date": date,
+                    **{extract_key_name(k): v for k, v in values.items()},
+                }
+                for date, values in content.items()
+            ]
+            filter_by_dates(d, query.start_date, query.end_date)
+            transformed_data += d
 
-        return [AVEquityHistoricalData.model_validate(d) for d in data]
+        return [AVEquityHistoricalData.model_validate(d) for d in transformed_data]

--- a/openbb_platform/providers/tiingo/openbb_tiingo/models/equity_historical.py
+++ b/openbb_platform/providers/tiingo/openbb_tiingo/models/equity_historical.py
@@ -10,8 +10,7 @@ from openbb_core.provider.standard_models.equity_historical import (
     EquityHistoricalQueryParams,
 )
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
-from openbb_core.provider.utils.helpers import get_querystring
-from openbb_tiingo.utils.helpers import get_data_many
+from openbb_core.provider.utils.helpers import amake_request, get_querystring
 from pydantic import Field, PrivateAttr, model_validator
 
 
@@ -115,7 +114,7 @@ class TiingoEquityHistoricalFetcher(
 
     # pylint: disable=protected-access
     @staticmethod
-    def extract_data(
+    async def aextract_data(
         query: TiingoEquityHistoricalQueryParams,
         credentials: Optional[Dict[str, str]],
         **kwargs: Any,
@@ -127,9 +126,18 @@ class TiingoEquityHistoricalFetcher(
         query_str = get_querystring(
             query.model_dump(by_alias=True), ["symbol", "interval"]
         )
-        url = f"{base_url}/{query.symbol}/prices?{query_str}&resampleFreq={query._frequency}&token={api_key}"
+        data: List[Dict] = []
+        for symbol in query.symbol.split(","):
+            url = f"{base_url}/{symbol}/prices?{query_str}&resampleFreq={query._frequency}&token={api_key}"
+            d = await amake_request(url, **kwargs)
 
-        return get_data_many(url)
+            if "," in query.symbol:
+                for item in d:
+                    item["symbol"] = symbol
+
+            data += d
+
+        return data
 
     # pylint: disable=unused-argument
     @staticmethod


### PR DESCRIPTION
^

Test:

```python
from openbb import obb

providers = ["polygon", "fmp", "alpha_vantage", "cboe", "intrinio", "tiingo", "yfinance"]

for provider in providers:
    obb.equity.price.historical("AAPL", provider=provider)
    obb.equity.price.historical(["AAPL"], provider=provider)
    obb.equity.price.historical(["AAPL", "TSLA"], provider=provider)
```