### PR TITLE
docs/extensions-list: Update the Extension Descriptions Pages

### DIFF
--- a/website/content/platform/extensions/data_extensions.md
+++ b/website/content/platform/extensions/data_extensions.md
@@ -63,9 +63,6 @@ These packages are what will be installed when `pip install openbb` is run
 | Extension Name | Description | Installation Command | Minimum Subscription Type Required |
 |----------------|-------------|----------------------|------------------------------------|
 | openbb-benzinga | [Benzinga](https://www.benzinga.com/apis/en-ca/) data connector | pip install openbb-benzinga | Paid |
-| openbb-biztoc | [Biztoc](https://api.biztoc.com/#biztoc-default) News data connector | pip install openbb-biztoc | Free |
-| openbb-ecb | [ECB](https://data.ecb.europa.eu/) data connector | pip install openbb-ecb | None |
-| openbb-finra | [FINRA](https://www.finra.org/finra-data) data connector | pip install openbb-finra | None / Free |
 | openbb-fmp | [FMP](https://site.financialmodelingprep.com/developer/) data connector | pip install openbb-fmp | Free |
 | openbb-fred | [FRED](https://fred.stlouisfed.org/) data connector | pip install openbb-fred | Free |
 | openbb-intrinio | [Intrinio](https://intrinio.com/pricing) data connector | pip install openbb-intrinio | Paid |
@@ -75,7 +72,7 @@ These packages are what will be installed when `pip install openbb` is run
 | openbb-tiingo | [Tiingo](https://www.tiingo.com/about/pricing) data connector | pip install openbb-tiingo | Free |
 | openbb-tradingeconomics | [TradingEconomics](https://tradingeconomics.com/api) data connector | pip install openbb-tradingeconomics | Paid |
 | openbb-ultima | [Ultima Insights](https://ultimainsights.ai/openbb) data connector | pip install openbb-ultima | Paid |
-
+| openbb-yfinance | [Yahoo Finance](https://finance.yahoo.com/) data connector | pip install openbb-yfinance | None |
 
 ### Community Providers
 
@@ -84,14 +81,16 @@ These packages are not installed when `pip install openbb` is run.  They are ava
 | Extension Name | Description | Installation Command | Minimum Subscription Type Required |
 |----------------|-------------|----------------------|------------------------------------|
 | openbb-alpha-vantage | [Alpha Vantage](https://www.alphavantage.co/) data connector | pip install openbb-alpha-vantage | Free |
+| openbb-biztoc | [Biztoc](https://api.biztoc.com/#biztoc-default) News data connector | pip install openbb-biztoc | Free |
 | openbb-cboe | [Cboe](https://www.cboe.com/delayed_quotes/) data connector | pip install openbb-cboe | None |
+| openbb-ecb | [ECB](https://data.ecb.europa.eu/) data connector | pip install openbb-ecb | None |
+| openbb-finra | [FINRA](https://www.finra.org/finra-data) data connector | pip install openbb-finra | None / Free |
+| openbb-finviz | [Finviz](https://finviz.com) data connector | pip install openbb-finviz | None |
 | openbb-government-us | [US Government](https://data.gov) data connector | pip install openbb-us-government | None |
 | openbb-nasdaq | [Nasdaq Data Link](https://data.nasdaq.com/) connector | pip install openbb-nasdaq | None / Free |
 | openbb-seeking-alpha | [Seeking Alpha](https://seekingalpha.com/) data connector | pip install openbb-seeking-alpha | None |
 | openbb-stockgrid | [Stockgrid](https://stockgrid.io) data connector | pip install openbb-stockgrid | None |
 | openbb-wsj | [Wall Street Journal](https://www.wsj.com/) data connector | pip install openbb-wsj | None |
-| openbb-yfinance | [Yahoo Finance](https://finance.yahoo.com/) data connector | pip install openbb-yfinance | None |
-
 
 Have you published a data provider extension and want it featured on this list? Tell us about it! Open a pull request on [GitHub](https://github.com/OpenBB-finance/OpenBBTerminal/) to submit an extension for inclusion. Code contributions, for new and existing, data providers are always welcome.
 

--- a/website/content/platform/extensions/toolkit_extensions.md
+++ b/website/content/platform/extensions/toolkit_extensions.md
@@ -130,6 +130,9 @@ The `openbb-econometrics` extension installs a new router path (`obb.econometric
 - linearmodels
 
 :::note
+
+Statsmodels requires a C compiler be present on the system. Follow the instructions [here](https://cython.readthedocs.io/en/latest/src/quickstart/install.html) for system-specific methods.
+
 This extension is not accessible via REST API because `statsmodels` is not serializable.
 :::
 


### PR DESCRIPTION
This PR updates the extensions pages in the documentation with:

- Move stuff around to reflect current reality of what's shipped at the core level.
- Add note for Econometrics installation indicating that a C compiler needs to be present on the system.