### PR TITLE
hotfix/ `custom_headers` as args in openapi schema

### DIFF
--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -77,7 +77,9 @@ def build_new_signature(path: str, func: Callable) -> Signature:
                     name.replace("-", "_"),
                     kind=Parameter.POSITIONAL_OR_KEYWORD,
                     default=default,
-                    annotation=Annotated[Optional[str], Header()],
+                    annotation=Annotated[
+                        Optional[str], Header(include_in_schema=False)
+                    ],
                 )
             )
 


### PR DESCRIPTION
Custom headers get added to all endpoints in `/docs` on Platform api docs

## Before 
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/61340027/f67e84cb-dd6b-49e4-824a-6273d44c5ddf)


## After
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/61340027/9e8b1226-1c2c-46de-8712-e376e650e35b)
