### PR TITLE
Feature/ex-dividend: Renames "date" columns as "ex_dividend_date" for Dividend Calendar and Historical Dividends

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/calendar_dividend.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/calendar_dividend.py
@@ -27,12 +27,12 @@ class CalendarDividendQueryParams(QueryParams):
 class CalendarDividendData(Data):
     """Dividend Calendar Data."""
 
-    date: dateType = Field(
-        description=DATA_DESCRIPTIONS.get("date", "") + " (Ex-Dividend)"
+    ex_dividend_date: dateType = Field(
+        description="The ex-dividend date - the date on which the stock begins trading without rights to the dividend."
     )
     symbol: str = Field(description=DATA_DESCRIPTIONS.get("symbol", ""))
     amount: Optional[float] = Field(
-        default=None, description="Dividend amount, per-share."
+        default=None, description="The dividend amount per share."
     )
     name: Optional[str] = Field(default=None, description="Name of the entity.")
     record_date: Optional[dateType] = Field(

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
@@ -8,7 +8,6 @@ from pydantic import Field, field_validator
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import (
-    DATA_DESCRIPTIONS,
     QUERY_DESCRIPTIONS,
 )
 
@@ -35,5 +34,7 @@ class HistoricalDividendsQueryParams(QueryParams):
 class HistoricalDividendsData(Data):
     """Historical Dividends Data."""
 
-    date: dateType = Field(description=DATA_DESCRIPTIONS.get("date", ""))
-    dividend: float = Field(description="Dividend of the historical dividends.")
+    ex_dividend_date: dateType = Field(
+        description="The ex-dividend date - the date on which the stock begins trading without rights to the dividend."
+    )
+    amount: float = Field(description="The dividend amount per share.")

--- a/openbb_platform/extensions/equity/integration/test_equity_api.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_api.py
@@ -313,6 +313,14 @@ def test_equity_fundamental_historical_splits(params, headers):
                 "provider": "fmp",
             }
         ),
+        (
+            {
+                "symbol": "AAPL",
+                "start_date": "2021-01-01",
+                "end_date": "2023-06-06",
+                "provider": "nasdaq",
+            }
+        ),
     ],
 )
 @pytest.mark.integration

--- a/openbb_platform/extensions/equity/integration/test_equity_python.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_python.py
@@ -290,6 +290,14 @@ def test_equity_fundamental_historical_splits(params, obb):
                 "provider": "fmp",
             }
         ),
+        (
+            {
+                "symbol": "AAPL",
+                "start_date": "2021-01-01",
+                "end_date": "2023-06-06",
+                "provider": "nasdaq",
+            }
+        ),
     ],
 )
 @pytest.mark.integration

--- a/openbb_platform/providers/fmp/openbb_fmp/models/calendar_dividend.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/calendar_dividend.py
@@ -30,6 +30,7 @@ class FMPCalendarDividendData(CalendarDividendData):
 
     __alias_dict__ = {
         "amount": "dividend",
+        "ex_dividend_date": "date",
         "record_date": "recordDate",
         "payment_date": "paymentDate",
         "declaration_date": "declarationDate",
@@ -45,7 +46,7 @@ class FMPCalendarDividendData(CalendarDividendData):
     )
 
     @field_validator(
-        "date",
+        "ex_dividend_date",
         "record_date",
         "payment_date",
         "declaration_date",

--- a/openbb_platform/providers/fmp/openbb_fmp/models/historical_dividends.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/historical_dividends.py
@@ -27,6 +27,11 @@ class FMPHistoricalDividendsQueryParams(HistoricalDividendsQueryParams):
 class FMPHistoricalDividendsData(HistoricalDividendsData):
     """FMP Historical Dividends Data."""
 
+    __alias_dict__ = {
+        "ex_dividend_date": "date",
+        "amount": "dividend",
+    }
+
     label: str = Field(description="Label of the historical dividends.")
     adj_dividend: float = Field(
         description="Adjusted dividend of the historical dividends."
@@ -48,6 +53,7 @@ class FMPHistoricalDividendsData(HistoricalDividendsData):
         "declaration_date",
         "record_date",
         "payment_date",
+        "ex_dividend_date",
         mode="before",
         check_fields=False,
     )

--- a/openbb_platform/providers/fmp/openbb_fmp/models/historical_dividends.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/historical_dividends.py
@@ -105,7 +105,7 @@ class FMPHistoricalDividendsFetcher(
         query: FMPHistoricalDividendsQueryParams, data: List[Dict], **kwargs: Any
     ) -> List[FMPHistoricalDividendsData]:
         """Return the transformed data."""
-        result = []
+        result: List[FMPHistoricalDividendsData] = []
         for d in data:
             if "date" in d:
                 dt = parser.parse(str(d["date"])).date()

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/__init__.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/__init__.py
@@ -8,6 +8,7 @@ from openbb_nasdaq.models.cot import NasdaqCotFetcher
 from openbb_nasdaq.models.cot_search import NasdaqCotSearchFetcher
 from openbb_nasdaq.models.economic_calendar import NasdaqEconomicCalendarFetcher
 from openbb_nasdaq.models.equity_search import NasdaqEquitySearchFetcher
+from openbb_nasdaq.models.historical_dividends import NasdaqHistoricalDividendsFetcher
 from openbb_nasdaq.models.sp500_multiples import NasdaqSP500MultiplesFetcher
 from openbb_nasdaq.models.top_retail import NasdaqTopRetailFetcher
 
@@ -26,6 +27,7 @@ unmatched technology, insights and markets expertise.""",
         "COTSearch": NasdaqCotSearchFetcher,
         "EconomicCalendar": NasdaqEconomicCalendarFetcher,
         "EquitySearch": NasdaqEquitySearchFetcher,
+        "HistoricalDividends": NasdaqHistoricalDividendsFetcher,
         "SP500Multiples": NasdaqSP500MultiplesFetcher,
         "TopRetail": NasdaqTopRetailFetcher,
     },

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_dividend.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_dividend.py
@@ -26,7 +26,7 @@ class NasdaqCalendarDividendData(CalendarDividendData):
 
     __alias_dict__ = {
         "name": "companyName",
-        "date": "dividend_Ex_Date",
+        "ex_dividend_date": "dividend_Ex_Date",
         "payment_date": "payment_Date",
         "record_date": "record_Date",
         "declaration_date": "announcement_Date",
@@ -40,7 +40,7 @@ class NasdaqCalendarDividendData(CalendarDividendData):
     )
 
     @field_validator(
-        "date",
+        "ex_dividend_date",
         "record_date",
         "payment_date",
         "declaration_date",
@@ -115,4 +115,7 @@ class NasdaqCalendarDividendFetcher(
         **kwargs: Any,  # pylint: disable=unused-argument
     ) -> List[NasdaqCalendarDividendData]:
         """Return the transformed data."""
-        return [NasdaqCalendarDividendData.model_validate(d) for d in data]
+        return [
+            NasdaqCalendarDividendData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["dividend_Ex_Date"], reverse=True)
+        ]

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/historical_dividends.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/historical_dividends.py
@@ -1,0 +1,155 @@
+"""Nasdaq Historical Dividends Model."""
+# pylint: disable=unused-argument
+import asyncio
+import warnings
+from datetime import (
+    date as dateType,
+    datetime,
+)
+from typing import Any, Dict, List, Optional
+
+from dateutil import parser
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.standard_models.historical_dividends import (
+    HistoricalDividendsData,
+    HistoricalDividendsQueryParams,
+)
+from openbb_core.provider.utils.errors import EmptyDataError
+from openbb_core.provider.utils.helpers import amake_request
+from openbb_nasdaq.utils.helpers import IPO_HEADERS
+from pydantic import Field, field_validator
+
+_warn = warnings.warn
+
+
+class NasdaqHistoricalDividendsQueryParams(HistoricalDividendsQueryParams):
+    """Nasdaq Historical Dividends Query Params."""
+
+
+class NasdaqHistoricalDividendsData(HistoricalDividendsData):
+    """Nasdaq Historical Dividends Data."""
+
+    __alias_dict__ = {
+        "ex_dividend_date": "exOrEffDate",
+        "declaration_date": "declarationDate",
+        "record_date": "recordDate",
+        "payment_date": "paymentDate",
+        "dividend_type": "type",
+    }
+
+    dividend_type: Optional[str] = Field(
+        default=None,
+        description="The type of dividend - i.e., cash, stock.",
+    )
+    currency: Optional[str] = Field(
+        default=None,
+        description="The currency in which the dividend is paid.",
+    )
+    record_date: Optional[dateType] = Field(
+        default=None,
+        description="The record date of ownership for eligibility.",
+    )
+    payment_date: Optional[dateType] = Field(
+        default=None,
+        description="The payment date of the dividend.",
+    )
+    declaration_date: Optional[dateType] = Field(
+        default=None,
+        description="Declaration date of the dividend.",
+    )
+
+    @field_validator(
+        "ex_dividend_date",
+        "declaration_date",
+        "record_date",
+        "payment_date",
+        mode="before",
+        check_fields=False,
+    )
+    @classmethod
+    def validate_date(cls, v: str):
+        """Validate the date if available is a date object."""
+        v = v.replace("N/A", "")
+        if not v:
+            return None
+        return datetime.strptime(v, "%m/%d/%Y").date().strftime("%Y-%m-%d")
+
+    @field_validator("amount", mode="before", check_fields=False)
+    @classmethod
+    def validate_amount(cls, v: str):
+        """Validate the amount if available is a float."""
+        v = v.replace("$", "").replace("N/A", "")
+        if not v:
+            return None
+        return float(v)
+
+
+class NasdaqHistoricalDividendsFetcher(
+    Fetcher[NasdaqHistoricalDividendsQueryParams, List[NasdaqHistoricalDividendsData]]
+):
+    """Nasdaq Historical Dividends Fetcher."""
+
+    @staticmethod
+    def transform_query(params: Dict[str, Any]) -> NasdaqHistoricalDividendsQueryParams:
+        """Transform the params to the provider-specific query."""
+        return NasdaqHistoricalDividendsQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: NasdaqHistoricalDividendsQueryParams,
+        credentials: Optional[Dict[str, str]],
+        **kwargs: Any,
+    ) -> List[Dict]:
+        """Extract the raw data."""
+        results = []
+        symbols = query.symbol.split(",")
+
+        async def get_one(symbol):
+            """Response Callback."""
+            data = []
+            asset_class = "stocks"
+            url = f"https://api.nasdaq.com/api/quote/{symbol}/dividends?assetclass={asset_class}"
+
+            response = await amake_request(
+                url,
+                headers=IPO_HEADERS,
+            )
+            if response.get("status").get("rCode") == 400:
+                response = await amake_request(
+                    url.replace("stocks", "etf"),
+                    headers=IPO_HEADERS,
+                )
+            if response.get("status").get("rCode") == 200:
+                data = response.get("data").get("dividends").get("rows")
+
+            if data:
+                if len(symbols) > 1:
+                    for d in data:
+                        d["symbol"] = symbol
+                results.extend(data)
+            if not data:
+                _warn(f"No data found for {symbol}")
+
+        tasks = [get_one(symbol) for symbol in symbols]
+
+        await asyncio.gather(*tasks)
+        if results:
+            return results
+        raise EmptyDataError()
+
+    @staticmethod
+    def transform_data(
+        query: NasdaqHistoricalDividendsQueryParams,
+        data: List[Dict],
+        **kwargs: Any,
+    ) -> List[NasdaqHistoricalDividendsData]:
+        """Return the transformed data."""
+        results: List[NasdaqHistoricalDividendsData] = []
+        for d in data:
+            dt = parser.parse(str(d["exOrEffDate"])).date()
+            if query.start_date and query.start_date > dt:
+                continue
+            if query.end_date and query.end_date < dt:
+                continue
+            results.append(NasdaqHistoricalDividendsData(**d))
+        return results

--- a/openbb_platform/providers/nasdaq/tests/record/http/test_nasdaq_fetchers/test_nasdaq_historical_dividends_fetcher.yaml
+++ b/openbb_platform/providers/nasdaq/tests/record/http/test_nasdaq_fetchers/test_nasdaq_historical_dividends_fetcher.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/plain, */*
+      Accept-Encoding:
+      - gzip
+      Accept-Language:
+      - en-CA,en-US;q=0.7,en;q=0.3
+      Connection:
+      - keep-alive
+      Host:
+      - api.nasdaq.com
+      Origin:
+      - https://www.nasdaq.com
+      Referer:
+      - https://www.nasdaq.com/
+    method: GET
+    uri: https://api.nasdaq.com/api/quote/AAPL/dividends?assetclass=stocks
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAK2aTW/jNhCG/0ogtDfXJilRlnILNln00u5iuy1QFHvQxko3gGMH/kiTLvzfq6E5
+        tFQNlfFEp8Qa8tWTmdekRsz3ZFHtquTye7K4f7pf1KvFz3W1qDd/VMt9vU0u//qeLKuv9TK5TG6e
+        f7r2Yy6uq12dTJInGNWEtJ5pNTPKpMlhcpoRhv95Xy8XrfFqmpU/doZerVb7anmBM1pjf1DTMu+M
+        /Ti7ufhU7e7XrVGpnmZZcvgySepnFHGQHbhJ+Cs/Vi8P9WrXGpLjkBcHi5CTpHJo9//Wi0AHwQZq
+        kjxWL+v97giDEKebbCGv1fbDXXK52i+Xk+Sby627XD9/2Nzc3XmAm+fZzfv3mNbdyyNc/Aw/mvs/
+        rPerXfP5XbX9dnF1/NTcpL5dVhu488qLXJ+uoNKmvl1vMBGf3AcMPXYy4PNxDB6aiet/jtXvcnZy
+        6TEBq43ZFMxkJGAzWxmc3UED3RQjj/Ha3O43m3p1+9Jc//23a+eKLqAqZs0EKWAzW6UkIOhmNCCE
+        5nxAO9NGDmhnKqMBG10bAWxCBR/Q8Eqc0oAmVmLQjZQYQvwSg4tcDowEEP62Oc7+vwdViPQ9qDDE
+        8aCyYkBgKEhA0C1owGB7HmDjolwOmEUBG90yAoi25wEaXokNDahjJQbdSImD7VmA4BVXYi0BhBsV
+        OLvnwRDpe1BjiOXBXAwISZqTgKBb0oDgQcMHtL4UMsAslkEwmooAWr8C8QANr8TKDpuwT2iiNQYT
+        8msMZnE1ViJCSFOJ03suDJG+Cw2GWC6cv05YRF2YKhIQrKZoQAilfEDrayEDzKKA1heSALT+SYIH
+        aFgZnM+jJixoQBPPoDkng7hr6lIC2DC4DLrZvSdCjZG+BzMMsTxYigHRg31AXO4IQAhZPqBfsYSA
+        WRTQL3cUoD0+cDEB/YL1GmDkcUEflxkC0ERLDCF+iXHX1IUEEGZrnN3zoMFI34MWQ6yuRIkBwYM0
+        IC52BCCEcj6gX6+EgDaWQVzsKEB7bJuYgMZ/i4cB83hXEgE00RJDiF9ibBH0XAKInbGbTXbGLkJ3
+        xi7E96AIEFZRTQJiZ0wAYmfMBEQPygBtLIPYGVOAvjNmAqIHhwFtdC9OIxk00RJjZ8wDBBc5oVwC
+        CO6wOJvsjHVOelBhiLUXZ2JAYMhJQOyMCUDsjJmA9vjQLwTMooC+M6YAfWfMBDS8DMY74wigiWfQ
+        nJNB7Iy1lQDi2xk3m+xJXITuSVyI3RnLAMGDmgQM62sfMGzTPEDfGQsBs1gGw/pKAOI2zQM0rBJn
+        8Z4kAmiiJQ7bNAsQG2OdSQBdFXF2by8Okb4HUwyx+2IZIEw1JGBY7PqAYZvmAfq+eBAwnZoy6sGU
+        BsTFjgDEbZoHaBglTqevvJwhAE20xGGbZgEGDw69Ro8C4htCTZ6UaIxE+mLuSYkqxIDgwZQEDH0x
+        fVJi+YD+1ccgoJnm8RJHAE00g6Ht5B5ENHuBLsvhdVDTC/WvsyuitifBLtlxNOshPx8TqSMoQ7Lw
+        zDEmUltQhuS+yWMitQVFSPDdLUBheEc4y0snQbGX7JhIHUGxl+ajIrUFpV5S4yK1BcVeKkFh+AT3
+        PC8FwbetS2MhdQTFXipGRWoLitclMypSW1DqpVSBwvBJ7FleOgmKvTQfE6kjKEPK4e3YmEhtQbGX
+        slGR2oJv2+OGT1QFe1z/JPUML5VjInUExeuSGhWpLSj2kh0VqS0o9pJb/4fPRc/zUhCUeumY51eQ
+        9BleOgmKvaRHRWoLir3EKRwfyby1cFB6WP+L4fNNPlJHUOwlzUBS53hJvw3JwlunMZHagmIvcQrH
+        RzJvLRy28MXwOSUfqSPIQfpyOEySh3q7rf6u8f+Ot7tqt3f/drx5t140l41Sk+Qr/P5Ld+SifqqX
+        68d607l+OPwHWZhG6SguAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - https://www.nasdaq.com
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1442'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 28 Jan 2024 01:33:24 GMT
+      Expires:
+      - Sun, 28 Jan 2024 01:33:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - ak_bmsc=D814B8E13C27CB46A5C31FDFF508A2DD~000000000000000000000000000000~YAAQD6MAF7gsfjqNAQAAxSqzTRYZaYQlf5VY/MEzu8m19srQM7M9z1C2q6lrQDVzNdGuUnQhAXdlZrf9cpvIHkanLPt8/S1r1fV1+jMw1z21kB2SXFtsBaUB9zq1a2Gi2OcyyB0u/2EucnGGJfAYzP47lQBxwelZzIo/rhrp1sx/uaimm0ih8TaPsfUrRSRqgLI9GVbAgA1sLlDBvsbDPNRuKDNGz3eAI5NtmG85P3Du5dS2izz5X3RxSm3Ld07nD1zOVpBoUJkFfIuSQrQFQkOxBwAd8mpAyEHbfjnNNkqLGWw58zBG1S8taYPNX0bzy0qubakjMBD/pSn8tLinbEbtm+N9nQ5aiwCFmSMFuTgg8H37QFgnf5026avJvNLbNd8PU6RrgH9/dN5LKUT8WdrFtC2N6Q==;
+        Domain=.nasdaq.com; Path=/; Expires=Sun, 28 Jan 2024 03:33:24 GMT; Max-Age=7200;
+        HttpOnly
+      Strict-Transport-Security:
+      - max-age=86400
+      Vary:
+      - Accept-Encoding
+      X-EdgeConnect-MidMile-RTT:
+      - '0'
+      - '43'
+      - '0'
+      - '3'
+      X-EdgeConnect-Origin-MEX-Latency:
+      - '49'
+      - '49'
+      - '49'
+      - '49'
+      gid:
+      - '203'
+      lang:
+      - en
+      rid:
+      - e93e6a09-7709-403a-aaa8-208566eb1d7a
+      srctype:
+      - default
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/openbb_platform/providers/nasdaq/tests/test_nasdaq_fetchers.py
+++ b/openbb_platform/providers/nasdaq/tests/test_nasdaq_fetchers.py
@@ -9,6 +9,7 @@ from openbb_nasdaq.models.cot import NasdaqCotFetcher
 from openbb_nasdaq.models.cot_search import NasdaqCotSearchFetcher
 from openbb_nasdaq.models.economic_calendar import NasdaqEconomicCalendarFetcher
 from openbb_nasdaq.models.equity_search import NasdaqEquitySearchFetcher
+from openbb_nasdaq.models.historical_dividends import NasdaqHistoricalDividendsFetcher
 from openbb_nasdaq.models.sp500_multiples import NasdaqSP500MultiplesFetcher
 from openbb_nasdaq.models.top_retail import NasdaqTopRetailFetcher
 
@@ -121,5 +122,14 @@ def test_nasdaq_calendar_earnings_fetcher(credentials=test_credentials):
     }
 
     fetcher = NasdaqCalendarEarningsFetcher()
+    result = fetcher.test(params, credentials)
+    assert result is None
+
+
+@pytest.mark.record_http
+def test_nasdaq_historical_dividends_fetcher(credentials=test_credentials):
+    params = {"symbol": "AAPL"}
+
+    fetcher = NasdaqHistoricalDividendsFetcher()
     result = fetcher.test(params, credentials)
     assert result is None


### PR DESCRIPTION

Why?

To provide more clarity in what the field actually is.  It's not just a date, it's the date the stock begins trading ex-dividend.

What?

The field named "date" in the response data has been changed to, "ex_dividend_date".

- CalendarDividends (`obb.equity.calendar.dividend()`)
- HistoricalDividends(`obb.equity.fundamental.dividends()`)

Impact:

- This changes one field name in two functions.
- Has no impact on Query.
- Adds one new provider (Nasdaq) to the existing endpoint, `obb.historical.dividends()`

Impact score: 5

Testing Done:

New unit test for Nasdaq HistoricalDividends, with updated integration test params to include the new provider at this endpoint.
