### PR TITLE
Deprecation warning on the reference docs

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -9,9 +9,11 @@ from inspect import Parameter, _empty, isclass, signature
 from json import dumps, load
 from pathlib import Path
 from typing import (
+    Any,
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     OrderedDict,
     Set,
@@ -20,6 +22,7 @@ from typing import (
     TypeVar,
     Union,
     get_args,
+    get_origin,
     get_type_hints,
 )
 
@@ -35,7 +38,7 @@ from openbb_core.app.charting_service import ChartingService
 from openbb_core.app.extension_loader import ExtensionLoader, OpenBBGroups
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.provider_interface import ProviderInterface
-from openbb_core.app.router import RouterLoader
+from openbb_core.app.router import CommandMap, RouterLoader
 from openbb_core.app.static.utils.console import Console
 from openbb_core.app.static.utils.linters import Linters
 from openbb_core.env import Env
@@ -983,6 +986,114 @@ class DocstringGenerator:
                 )
             return doc
         return doc
+
+    @staticmethod
+    def get_model_standard_params(param_fields: Dict[str, FieldInfo]) -> Dict[str, Any]:
+        """Get the test params for the fetcher based on the required standard params."""
+        test_params: Dict[str, Any] = {}
+        for field_name, field in param_fields.items():
+            if field.default and field.default is not PydanticUndefined:
+                test_params[field_name] = field.default
+            elif field.default and field.default is PydanticUndefined:
+                example_dict = {
+                    "symbol": "AAPL",
+                    "symbols": "AAPL,MSFT",
+                    "start_date": "2023-01-01",
+                    "end_date": "2023-06-06",
+                    "country": "Portugal",
+                    "date": "2023-01-01",
+                    "countries": ["portugal", "spain"],
+                }
+                if field_name in example_dict:
+                    test_params[field_name] = example_dict[field_name]
+                elif field.annotation == str:
+                    test_params[field_name] = "TEST_STRING"
+                elif field.annotation == int:
+                    test_params[field_name] = 1
+                elif field.annotation == float:
+                    test_params[field_name] = 1.0
+                elif field.annotation == bool:
+                    test_params[field_name] = True
+                elif get_origin(field.annotation) is Literal:  # type: ignore
+                    option = field.annotation.__args__[0]  # type: ignore
+                    if isinstance(option, str):
+                        test_params[field_name] = f'"{option}"'
+                    else:
+                        test_params[field_name] = option
+
+        return test_params
+
+    @staticmethod
+    def get_full_command_name(route: str) -> str:
+        """Get the full command name."""
+        cmd_parts = route.split("/")
+        del cmd_parts[0]
+
+        menu = cmd_parts[0]
+        command = cmd_parts[-1]
+        sub_menus = cmd_parts[1:-1]
+
+        sub_menu_str_cmd = f".{'.'.join(sub_menus)}" if sub_menus else ""
+
+        full_command = f"{menu}{sub_menu_str_cmd}.{command}"
+
+        return full_command
+
+    @classmethod
+    def generate_example(
+        cls,
+        model_name: str,
+        standard_params: Dict[str, FieldInfo],
+    ) -> str:
+        """Generate the example for the command."""
+        # find the model router here
+        cm = CommandMap()
+        commands_model = cm.commands_model
+        route = [k for k, v in commands_model.items() if v == model_name]
+
+        if not route:
+            return ""
+
+        full_command_name = cls.get_full_command_name(route=route[0])
+        example_params = cls.get_model_standard_params(param_fields=standard_params)
+
+        # Edge cases (might find more)
+        if "crypto" in route[0] and "symbol" in example_params:
+            example_params["symbol"] = "BTCUSD"
+        elif "currency" in route[0] and "symbol" in example_params:
+            example_params["symbol"] = "EURUSD"
+        elif (
+            "index" in route[0]
+            and "european" not in route[0]
+            and "symbol" in example_params
+        ):
+            example_params["symbol"] = "SPX"
+        elif (
+            "index" in route[0]
+            and "european" in route[0]
+            and "symbol" in example_params
+        ):
+            example_params["symbol"] = "BUKBUS"
+        elif (
+            "futures" in route[0] and "curve" in route[0] and "symbol" in example_params
+        ):
+            example_params["symbol"] = "VX"
+        elif "futures" in route[0] and "symbol" in example_params:
+            example_params["symbol"] = "ES"
+
+        example = "\n        Example\n        -------\n"
+        example += "        >>> from openbb import obb\n"
+        example += f"        >>> obb.{full_command_name}("
+        for param_name, param_value in example_params.items():
+            if isinstance(param_value, str):
+                param_value = f'"{param_value}"'  # noqa: PLW2901
+            example += f"{param_name}={param_value}, "
+        if example_params:
+            example = example[:-2] + ")\n"
+        else:
+            example += ")\n"
+
+        return example
 
 
 class PathHandler:

--- a/website/content/platform/development/contributor-guidelines/deprecating_endpoints.md
+++ b/website/content/platform/development/contributor-guidelines/deprecating_endpoints.md
@@ -1,0 +1,57 @@
+---
+title: Deprecating Endpoints
+sidebar_position: 5
+description: This guide provides detailed instructions on how to deprecate an endpoint in the OpenBB Platform.
+keywords:
+- OpenBB community
+- OpenBB Platform
+- Custom commands
+- API
+- Python Interface
+- Deprecation
+- Deprecated
+---
+
+import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
+
+<HeadTitle title="Deprecating Endpoints - Contributor Guidelines - Development | OpenBB Platform Docs" />
+
+Deprecating commands is a necessary part of maintaining the OpenBB Platform. This guide outlines the process for deprecating an endpoint.
+
+## Deprecating an endpoint
+
+1. Add new endpoint: the new endpoint that will replace the deprecated one.
+
+2. Add deprecation warning
+
+    Navigate to the **router** where the endpoint you wish to deprecate lives and add the `deprecated=True` flag and `deprecation=OpenBBDeprecationWarning(…)`, to the `@command` decorator. Refer to the example below:
+
+    ```python
+
+    ...
+    from openbb_core.app.deprecation import OpenBBDeprecationWarning
+    ...
+
+        @router.command(
+            model="MarketIndices",
+            deprecated=True,
+            deprecation=OpenBBDeprecationWarning(
+                message="This endpoint is deprecated; use `/index/price/historical` instead.",
+                since=(4, 1),
+                expected_removal=(4, 5),
+            ),
+        )
+        async def market(
+            cc: CommandContext,
+            provider_choices: ProviderChoices,
+            standard_params: StandardParams,
+            extra_params: ExtraParams,
+        ) -> OBBject[BaseModel]:
+            """Historical Market Indices."""
+        return await OBBject.from_query(Query(**locals()))
+
+    ```
+
+3. Get approval from a OpenBB Platform maintainer: they will help you determine the appropriate version for the deprecation warning, and also know what to do in order to warn other OpenBB teams that might depend on the endpoint you are deprecating.
+
+4. Remove as we say - the endpoint will be removed in the version specified in the deprecation warning.

--- a/website/content/platform/development/contributor-guidelines/write_code_commit.md
+++ b/website/content/platform/development/contributor-guidelines/write_code_commit.md
@@ -1,6 +1,6 @@
 ---
 title: Write Code and Commit
-sidebar_position: 5
+sidebar_position: 6
 description: This guide provides detailed instructions on how to write code and commit changes for the OpenBB Platform. It covers the process of creating a PR, branch naming conventions, and important guidelines to follow when committing changes.
 keywords:
 - OpenBB code writing

--- a/website/generate_platform_v4_markdown.py
+++ b/website/generate_platform_v4_markdown.py
@@ -327,6 +327,8 @@ def get_command_meta(path: str, route_map: Dict[str, Any]) -> Dict[str, Any]:
         "returns": {},
         "schema": {},
         "model": model_name,
+        "deprecated": route.deprecated or False,
+        "deprecation_message": route.summary if route.deprecated else "",
     }
 
     # Extract the full path from the 'path' variable, excluding the method name
@@ -346,7 +348,8 @@ def get_command_meta(path: str, route_map: Dict[str, Any]) -> Dict[str, Any]:
         ]
 
         meta_command["description"] += "\n\n" + DocstringGenerator.generate_example(
-            model_name, obb_query_fields
+            model_name=model_name,
+            standard_params=obb_query_fields,
         )
 
         available_fields = list(obb_query_fields.keys())
@@ -512,6 +515,11 @@ def get_command_meta(path: str, route_map: Dict[str, Any]) -> Dict[str, Any]:
 import HeadTitle from '@site/src/components/General/HeadTitle.tsx';
 
 <HeadTitle title="{'/'.join(title)} - Reference | OpenBB Platform Docs" />\n\n"""
+
+    if meta_command["deprecated"]:
+        meta_command[
+            "header"
+        ] += f":::caution Deprecated\n{meta_command['deprecation_message']}\n:::\n\n"
 
     return meta_command
 

--- a/website/generate_platform_v4_markdown.py
+++ b/website/generate_platform_v4_markdown.py
@@ -435,8 +435,8 @@ def get_command_meta(path: str, route_map: Dict[str, Any]) -> Dict[str, Any]:
     chart : Optional[Chart]
         Chart object.
 
-    metadata: Optional[Metadata]
-        Metadata info about the command execution."""
+    extra: Dict[str, Any]
+        Extra info."""
 
             meta_command["returns"] = {
                 "type": return_type.__name__,


### PR DESCRIPTION
Adds a deprecation warning in the reference docs:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/48914296/c1691a64-1005-455e-b5de-040a847c9efb)

> [!NOTE] 
> I tried to make it strike-through the title (fastapi style), but it's not trivial - if we want do also do it, we'll need to allocate more time to it!

> [!IMPORTANT] 
> I needed to bring back some retired methods on the `PackageBuilder` - this might need some revision - added to backlog.