### PR TITLE
[BugFix] - hotfix/polygon-tz-aware - Add tz-aware to timestamp conversion.

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -345,6 +345,7 @@ class ImportDefinition:
         code += "\nfrom openbb_core.app.static.utils.decorators import validate\n"
         code += "\nfrom openbb_core.app.static.utils.filters import filter_inputs\n"
         code += "\nfrom openbb_core.provider.abstract.data import Data"
+        code += "\nfrom openbb_core.app.deprecation import OpenBBDeprecationWarning\n"
         if path.startswith("/quantitative"):
             code += "\nfrom openbb_quantitative.models import "
             code += "(CAPMModel,NormalityModel,OmegaModel,SummaryModel,UnitRootModel)"
@@ -352,15 +353,6 @@ class ImportDefinition:
         module_list = [hint_type.__module__ for hint_type in hint_type_list]
         module_list = list(set(module_list))
         module_list.sort()
-
-        specific_imports = {
-            hint_type.__module__: hint_type.__name__
-            for hint_type in hint_type_list
-            if getattr(hint_type, "__name__", None) is not None
-        }
-        code += "\n"
-        for module, name in specific_imports.items():
-            code += f"from {module} import {name}\n"
 
         code += "\n"
         for module in module_list:

--- a/openbb_platform/openbb/package/index.py
+++ b/openbb_platform/openbb/package/index.py
@@ -4,7 +4,7 @@ import datetime
 from typing import List, Literal, Optional, Union
 from warnings import simplefilter, warn
 
-from openbb_core.app.deprecation import OpenBBDeprecatedSince41
+from openbb_core.app.deprecation import OpenBBDeprecationWarning
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
@@ -158,8 +158,8 @@ class ROUTER_index(Container):
 
     @validate
     @deprecated(
-        "This endpoint is deprecated; use `/index/price/historical` instead. Deprecated in OpenBB Platform V4.1 to be removed in V4.5.",
-        category=OpenBBDeprecatedSince41,
+        "This endpoint is deprecated; use `/index/price/historical` instead. Deprecated in OpenBB Platform V4.1 to be removed in V4.3.",
+        category=OpenBBDeprecationWarning,
     )
     def market(
         self,
@@ -274,7 +274,7 @@ class ROUTER_index(Container):
 
         simplefilter("always", DeprecationWarning)
         warn(
-            "This endpoint is deprecated since v4.1 and will be removed in v4.3; Use `/index/price/historical` instead.",
+            "This endpoint is deprecated; use `/index/price/historical` instead. Deprecated in OpenBB Platform V4.1 to be removed in V4.3.",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/openbb_platform/providers/polygon/openbb_polygon/models/crypto_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/crypto_historical.py
@@ -1,5 +1,7 @@
 """Polygon Crypto Historical Price Model."""
 
+# pylint: disable=unused-argument
+
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
@@ -12,6 +14,7 @@ from openbb_core.provider.standard_models.crypto_historical import (
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
 from openbb_polygon.utils.helpers import get_data_many
 from pydantic import Field, PositiveInt
+from pytz import timezone
 
 
 class PolygonCryptoHistoricalQueryParams(CryptoHistoricalQueryParams):
@@ -97,7 +100,7 @@ class PolygonCryptoHistoricalFetcher(
         data = await get_data_many(request_url, "results", **kwargs)
 
         for d in data:
-            d["t"] = datetime.fromtimestamp(d["t"] / 1000)
+            d["t"] = datetime.fromtimestamp(d["t"] / 1000, tz=timezone("UTC"))
             if query.timespan not in ["minute", "hour"]:
                 d["t"] = d["t"].date()
 

--- a/openbb_platform/providers/polygon/openbb_polygon/models/currency_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/currency_historical.py
@@ -1,5 +1,7 @@
 """Polygon Currency Historical Price Model."""
 
+# pylint: disable=unused-argument
+
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
@@ -12,6 +14,7 @@ from openbb_core.provider.standard_models.currency_historical import (
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
 from openbb_polygon.utils.helpers import get_data_many
 from pydantic import Field, PositiveInt
+from pytz import timezone
 
 
 class PolygonCurrencyHistoricalQueryParams(CurrencyHistoricalQueryParams):
@@ -94,7 +97,7 @@ class PolygonCurrencyHistoricalFetcher(
         data = await get_data_many(request_url, "results", **kwargs)
 
         for d in data:
-            d["t"] = datetime.fromtimestamp(d["t"] / 1000)
+            d["t"] = datetime.fromtimestamp(d["t"] / 1000, tz=timezone("UTC"))
             if query.timespan not in ["minute", "hour"]:
                 d["t"] = d["t"].date()
 

--- a/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
@@ -1,5 +1,7 @@
 """Polygon Equity Historical Price Model."""
 
+# pylint: disable=unused-argument
+
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
@@ -21,6 +23,7 @@ from pydantic import (
     PrivateAttr,
     model_validator,
 )
+from pytz import timezone
 
 
 class PolygonEquityHistoricalQueryParams(EquityHistoricalQueryParams):
@@ -143,7 +146,9 @@ class PolygonEquityHistoricalFetcher(
                 next_url = data.get("next_url", None)
 
             for r in results:
-                r["t"] = datetime.fromtimestamp(r["t"] / 1000)
+                r["t"] = datetime.fromtimestamp(
+                    r["t"] / 1000, tz=timezone("America/New_York")
+                )
                 if query._timespan not in ["second", "minute", "hour"]:
                     r["t"] = r["t"].date()
                 if "," in query.symbol:

--- a/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
@@ -1,5 +1,7 @@
 """Polygon Index Historical Model."""
 
+# pylint: disable=unused-argument
+
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
@@ -12,6 +14,7 @@ from openbb_core.provider.standard_models.index_historical import (
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
 from openbb_polygon.utils.helpers import get_data_many
 from pydantic import Field, PositiveInt
+from pytz import timezone
 
 
 class PolygonIndexHistoricalQueryParams(IndexHistoricalQueryParams):
@@ -94,7 +97,9 @@ class PolygonIndexHistoricalFetcher(
         data = await get_data_many(request_url, "results", **kwargs)
 
         for d in data:
-            d["t"] = datetime.fromtimestamp(d["t"] / 1000)
+            d["t"] = datetime.fromtimestamp(
+                d["t"] / 1000, tz=timezone("America/New_York")
+            )
             if query.timespan not in ["minute", "hour"]:
                 d["t"] = d["t"].date()
 

--- a/openbb_platform/providers/polygon/openbb_polygon/models/market_snapshots.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/market_snapshots.py
@@ -3,13 +3,13 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-import pandas as pd
 from openbb_core.provider.abstract.fetcher import Fetcher
 from openbb_core.provider.standard_models.market_snapshots import (
     MarketSnapshotsData,
     MarketSnapshotsQueryParams,
 )
 from openbb_polygon.utils.helpers import get_data_many
+from pandas import to_datetime
 from pydantic import Field, field_validator
 
 
@@ -23,23 +23,23 @@ class PolygonMarketSnapshotsQueryParams(MarketSnapshotsQueryParams):
 class PolygonMarketSnapshotsData(MarketSnapshotsData):
     """Polygon Market Snapshots Data."""
 
-    vwap: float = Field(
+    vwap: Optional[float] = Field(
         description="The volume weighted average price of the stock on the current trading day.",
         default=None,
     )
-    prev_open: float = Field(
+    prev_open: Optional[float] = Field(
         description="The previous trading session opening price.", default=None
     )
-    prev_high: float = Field(
+    prev_high: Optional[float] = Field(
         description="The previous trading session high price.", default=None
     )
-    prev_low: float = Field(
+    prev_low: Optional[float] = Field(
         description="The previous trading session low price.", default=None
     )
-    prev_volume: float = Field(
+    prev_volume: Optional[float] = Field(
         description="The previous trading session volume.", default=None
     )
-    prev_vwap: float = Field(
+    prev_vwap: Optional[float] = Field(
         description="The previous trading session VWAP.", default=None
     )
     last_updated: Optional[datetime] = Field(
@@ -79,9 +79,7 @@ class PolygonMarketSnapshotsData(MarketSnapshotsData):
     def date_validate(cls, v):
         """Return formatted datetime."""
         return (
-            pd.to_datetime(v, unit="ns", origin="unix", utc=True).tz_convert(
-                "US/Eastern"
-            )
+            to_datetime(v, unit="ns", origin="unix", utc=True).tz_convert("US/Eastern")
             if v
             else None
         )
@@ -120,7 +118,7 @@ class PolygonMarketSnapshotsFetcher(
         **kwargs: Any,
     ) -> List[PolygonMarketSnapshotsData]:
         """Return the transformed data."""
-        processed_data = []
+        processed_data: List[PolygonMarketSnapshotsData] = []
 
         # Process and flatten the response from a nested dictionary
         for item in data:
@@ -129,7 +127,7 @@ class PolygonMarketSnapshotsFetcher(
             day_data = item.get("day", {})
             prev_day = item.get("prevDay", {})
 
-            market_data: Dict[str, List[Any]] = {
+            market_data: Dict = {
                 "symbol": item["ticker"],
                 "bid": last_quote.get("p"),
                 "ask": last_quote.get("P"),
@@ -158,6 +156,8 @@ class PolygonMarketSnapshotsFetcher(
                 "last_trade_timestamp": last_trade.get("t"),
             }
 
-            processed_data.append(market_data)
+            processed_data.append(
+                PolygonMarketSnapshotsData.model_validate(market_data)
+            )
 
-        return [PolygonMarketSnapshotsData.model_validate(d) for d in processed_data]
+        return processed_data


### PR DESCRIPTION

-    Fix polygon timestamps:
       - Format: [BugFix] - Adds a timezone to the Unix timestamp conversion to correct localization errors.

-    Why? (1-3 sentences or a bullet point list):
       - Bug with the conversion of Unix timestamp that made the start of day wrong depending on what timezone you are in. 

-    What? (1-3 sentences or a bullet point list):
      -  Stocks and Indices are stamped as "America/New_York" - Polygon only services American Markets.
      -  Crpyto and currencies are stamped as "UTC".

-    Impact (1-2 sentences or a bullet point list):
      -  None

-    Testing Done:
       - obb.index.price.historical("NDX")
       - obb.equity.price.historical("AAPL")
       - obb.currency.price.historical("USDJPY")
       - obb.crypto.price.historical("BTCUSD")
       - Intraday and daily

Before:

![Screenshot 2024-02-01 at 1 22 05 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/6f222558-1606-4022-a9cb-5b5da69e7902)

Dates are all shifted back one day.

After:

![Screenshot 2024-02-01 at 1 24 31 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/cb514000-e036-4a06-88e5-bbb6054302d7)
