### PR TITLE
[Feature] FMP Current Holdings

### DIFF
--- a/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
@@ -1,8 +1,13 @@
 """FMP ETF Holdings Model."""
 
-from datetime import date as dateType
+import warnings
+from datetime import (
+    date as dateType,
+    datetime,
+)
 from typing import Any, Dict, List, Optional, Union
 
+from openbb_core.provider.abstract.data import ForceInt
 from openbb_core.provider.abstract.fetcher import Fetcher
 from openbb_core.provider.standard_models.etf_holdings import (
     EtfHoldingsData,
@@ -10,7 +15,9 @@ from openbb_core.provider.standard_models.etf_holdings import (
 )
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
 from openbb_fmp.utils.helpers import create_url, get_data_many
-from pydantic import Field
+from pydantic import Field, field_validator
+
+_warn = warnings.warn
 
 
 class FMPEtfHoldingsQueryParams(EtfHoldingsQueryParams):
@@ -21,6 +28,7 @@ class FMPEtfHoldingsQueryParams(EtfHoldingsQueryParams):
 
     date: Optional[Union[str, dateType]] = Field(
         description=QUERY_DESCRIPTIONS.get("date", "")
+        + " Entering a date will attempt to return the NPORT-P filing for the entered date."
         + " This needs to be _exactly_ the date of the filing."
         + " Use the holdings_date command/endpoint to find available filing dates for the ETF.",
         default=None,
@@ -36,26 +44,36 @@ class FMPEtfHoldingsQueryParams(EtfHoldingsQueryParams):
 class FMPEtfHoldingsData(EtfHoldingsData):
     """FMP ETF Holdings Data."""
 
+    __alias_dict__ = {
+        "weight": "weightPercentage",
+        "value": "marketValue",
+        "symbol": "asset",
+        "balance": "sharesNumber",
+    }
+
     lei: Optional[str] = Field(description="The LEI of the holding.", default=None)
     title: Optional[str] = Field(description="The title of the holding.", default=None)
     cusip: Optional[str] = Field(description="The CUSIP of the holding.", default=None)
     isin: Optional[str] = Field(description="The ISIN of the holding.", default=None)
-    balance: Optional[float] = Field(
-        description="The balance of the holding.", default=None
+    balance: Optional[ForceInt] = Field(
+        description="The balance of the holding, in shares or units.", default=None
     )
     units: Optional[Union[float, str]] = Field(
-        description="The units of the holding.", default=None
+        description="The type of units.", default=None
     )
     currency: Optional[str] = Field(
         description="The currency of the holding.", alias="cur_cd", default=None
     )
     value: Optional[float] = Field(
-        description="The value of the holding in USD.", alias="valUsd", default=None
+        description="The value of the holding, in dollars.",
+        alias="valUsd",
+        default=None,
     )
     weight: Optional[float] = Field(
-        description="The weight of the holding in ETF in %.",
+        description="The weight of the holding, as a normalized percent.",
         alias="pctVal",
         default=None,
+        json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
     )
     payoff_profile: Optional[str] = Field(
         description="The payoff profile of the holding.",
@@ -104,6 +122,24 @@ class FMPEtfHoldingsData(EtfHoldingsData):
         alias="acceptanceTime",
         default=None,
     )
+    updated: Optional[Union[dateType, datetime]] = Field(
+        description="The date the data was updated.", default=None
+    )
+
+    @field_validator("weight", mode="before", check_fields=False)
+    @classmethod
+    def normalize_percent(cls, v):
+        """Normalize percent values."""
+        return float(v) / 100 if v else None
+
+    @field_validator("cusip", "isin", "balance", "name", "symbol", "value")
+    @classmethod
+    def replace_empty(cls, v):
+        """Replace empty strings and 0s with None."""
+        if isinstance(v, str):
+            return v if v not in ("", "0") else None
+        if isinstance(v, (float, int)):
+            return v if v and v not in (0.0, 0) else None
 
 
 class FMPEtfHoldingsFetcher(
@@ -127,12 +163,22 @@ class FMPEtfHoldingsFetcher(
     ) -> List[Dict]:
         """Return the raw data from the FMP endpoint."""
         api_key = credentials.get("fmp_api_key") if credentials else ""
+        data = []
+        if query.date is not None:
+            url = create_url(
+                version=4, endpoint="etf-holdings", api_key=api_key, query=query
+            )
+            try:
+                data = await get_data_many(url, **kwargs)
+            except Exception:
+                _warn(
+                    "No data found for this symbol and date, attempting to retrieve the most recent data available."
+                )
 
-        url = create_url(
-            version=4, endpoint="etf-holdings", api_key=api_key, query=query
-        )
-
-        return await get_data_many(url, **kwargs)
+        if query.date is None or not data:
+            url = f"https://financialmodelingprep.com/api/v3/etf-holder/{query.symbol}?apikey={api_key}"
+            data = await get_data_many(url, **kwargs)
+        return data
 
     @staticmethod
     def transform_data(


### PR DESCRIPTION
# Pull Request Template for OpenBB Developers

1. **Why**? (1-3 sentences or a bullet point list):

    - Requested addition.

    - This returns the current holdings of an ETF when no date is supplied, or when a supplied date is not valid.

    - The function will no longer fail because of an invalid, or not supplied, date. 

2. **What**? (1-3 sentences or a bullet point list):

    - Modifies the existing FMPETFHoldings model to accommodate.

    - Add Warning for when a supplied date is not valid or no data is returned with the symbol/date combination.

3. **Impact** (1-2 sentences or a bullet point list):

    - There are fewer returned fields for current holdings.
    - "Weight" is now a normalized percent value.

Impact Score: 2


4. **Testing Done**:

    - No additional or modifications to tests required to implement change.

    - Checked with a variety of symbols from different jurisdictions and verified the Warnings are being raised correctly.


5. **Reviewer Notes** (optional):


6. **Any other information** (optional)

![Screenshot 2024-02-06 at 10 48 18 AM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/6e0a9043-2290-4ccb-b284-3129ee041689)

