### PR TITLE
Dont run base tests with v4 label

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,7 +15,7 @@ on:
     branches:
       - develop
       - main
-    types: [opened, synchronize, edited, closed]
+    types: [opened, synchronize, edited, closed, labeled, unlabeled]
   push:
     branches:
       - release/*
@@ -61,7 +61,7 @@ jobs:
     name: Base Tests - Ubuntu-latest - Python 3.9
     needs: [check-files-changed]
     runs-on: ubuntu-latest
-    if: needs.check-files-changed.outputs.check-changes == 'true' && github.event.pull_request.base.ref == 'develop'
+    if: needs.check-files-changed.outputs.check-changes == 'true' && github.event.pull_request.base.ref == 'develop' && !contains(github.event.pull_request.labels.*.name, 'v4')
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
# Pull Request Template for OpenBB Developers

0. **Dont run bases tests with v4 label**:

    - Format: [Type] - Brief Description (e.g., [Hotfix] - Improve Calculation Accuracy).

1. **Why**? (1-3 sentences or a bullet point list):

    - PRs blocked by failing v3 tests

2. **What**? (1-3 sentences or a bullet point list):

    - Check if v4 label before running v3 base tests

3. **Impact** (1-2 sentences or a bullet point list):

    - Tests not running

4. **Testing Done**:

    - Add or remove v4 label in the PR