### PR TITLE
[Feature] - Display warnings based on user preference

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/preferences.py
+++ b/openbb_platform/core/openbb_core/app/model/preferences.py
@@ -30,6 +30,7 @@ class Preferences(BaseModel):
     output_type: Literal["OBBject", "dataframe", "polars", "numpy", "dict", "chart"] = (
         Field(default="OBBject", description="Python default output type.")
     )
+    show_warnings: bool = True
 
     model_config = ConfigDict(validate_assignment=True)
 

--- a/website/content/platform/usage/index.md
+++ b/website/content/platform/usage/index.md
@@ -146,7 +146,8 @@ HTTP_PROXY="http://10.10.10.10:8000"
 | request_timeout       | 15                               | Any positive integer.  | Specifies the timeout duration for HTTP requests.  |
 | metadata              | True                             | [True, False]        | Enables or disables the collection of metadata  which provides information about operations  including arguments  duration  route  and timestamp. Disabling this feature may improve performance in cases where contextual information is not needed or when the additional computation time and storage space are a concern.  |
 | field_order           | False                            | [True, False]        | Enables or disables the information on the field order defined with Pydantic models. Useful for frontend as the API returns JSON which is an unordered collection.  |
-| output_type           | OBBject                          | ["OBBject", "dataframe", "numpy", "dict", "chart", "polars"] | Specifies the type of data the application will output when a command or endpoint is accessed. Note that choosing data formats only available in Python  such as `dataframe` | `numpy` or `polars` will render the application's API non-functional. |
+| output_type           | OBBject                          | ["OBBject", "dataframe", "numpy", "dict", "chart", "polars"] | Specifies the type of data the application will output when a command or endpoint is accessed. Note that choosing data formats only available in Python  such as `dataframe`, `numpy` or `polars` will render the application's API non-functional. |
+| show_warnings         | True                             | [True, False]        | Enables or disables the display of warnings.  |
 
 User settings can be set from the Python interface directly.
 


### PR DESCRIPTION
1. **Why**?

    - Warnings were hidden inside `OBBject.warnings`
    - @mnicstruwig pointed the issue

2. **What**?

    - Show warnings given user preference

3. **Impact**:

    - No relevant impact

4. **Testing Done**:
Toggle the preference and check if a warning is raised

```python
 from openbb import obb
 obb.user.preferences.show_warnings = True
 obb.equity.fundamental.income("AAPL,MSFT").to_df()
 ```
