### PR TITLE
[Bugfix] - Fix economic calendar country

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/cpi.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cpi.py
@@ -106,7 +106,7 @@ class ConsumerPriceIndexQueryParams(QueryParams):
     def validate_country(cls, c: str):  # pylint: disable=E0213
         """Validate country."""
         result = []
-        values = c.split(",")
+        values = c.replace(" ", "_").split(",")
         for v in values:
             check_item(v.lower(), CPI_COUNTRIES)
             result.append(v.lower())

--- a/openbb_platform/openbb/package/economy.py
+++ b/openbb_platform/openbb/package/economy.py
@@ -59,8 +59,8 @@ class ROUTER_economy(Container):
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
-        country : Optional[Union[str, List[str]]]
-            Country of the event (provider: tradingeconomics)
+        country : Optional[str]
+            Country of the event. (provider: tradingeconomics)
         importance : Optional[Literal['Low', 'Medium', 'High']]
             Importance of the event. (provider: tradingeconomics)
         group : Optional[Literal['interest rate', 'inflation', 'bonds', 'consumer', 'gdp', 'government', 'housing', 'labour', 'markets', 'money', 'prices', 'trade', 'business']]
@@ -69,7 +69,7 @@ class ROUTER_economy(Container):
         Returns
         -------
         OBBject
-            results : List[EconomicCalendar]
+            results : EconomicCalendar
                 Serializable results.
             provider : Optional[Literal['fmp', 'tradingeconomics']]
                 Provider name.

--- a/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/utils/countries.py
+++ b/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/utils/countries.py
@@ -224,11 +224,9 @@ country_dict = {
 }
 
 COUNTRIES = list(
-    set(
-        [
-            item.lower().replace(" ", "_")
-            for sublist in country_dict.values()
-            for item in sublist
-        ]
-    )
+    {
+        item.lower().replace(" ", "_")
+        for sublist in country_dict.values()
+        for item in sublist
+    }
 )

--- a/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/utils/countries.py
+++ b/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/utils/countries.py
@@ -223,6 +223,12 @@ country_dict = {
     ],
 }
 
-country_list = list(
-    set([item.lower() for sublist in country_dict.values() for item in sublist])
+COUNTRIES = list(
+    set(
+        [
+            item.lower().replace(" ", "_")
+            for sublist in country_dict.values()
+            for item in sublist
+        ]
+    )
 )

--- a/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/utils/url_generator.py
+++ b/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/utils/url_generator.py
@@ -35,7 +35,7 @@ def generate_url(in_query):
 
     # Handle the formatting for the api
     if "country" in query:
-        country = quote(",".join(query["country"]).replace("_", " "))
+        country = quote(query["country"].replace("_", " "))
     if "group" in query:
         group = quote(query["group"])
 


### PR DESCRIPTION
# Pull Request Template for OpenBB Developers

1. **Why**?

    - Consistency with other country inputs

2. **What**?

    - Change country to `str` instead of `List[str]`

3. **Impact**

    - Terminal Pro calendar

4. **Testing Done**:

```python
from openbb import obb
obb.economy.calendar(country="japan,united_states", provider="tradingeconomics")
```