### PR TITLE
[BugFix] Fix OECD Long Term Interest Rate

### DIFF
--- a/openbb_platform/extensions/economy/openbb_economy/economy_router.py
+++ b/openbb_platform/extensions/economy/openbb_economy/economy_router.py
@@ -208,7 +208,7 @@ async def short_term_interest_rate(
 
 
 @router.command(
-    model="STIR",
+    model="LTIR",
     exclude_auto_examples=True,
     examples=[
         'obb.economy.long_term_interest_rate(country="all", frequency="quarterly").to_df()',

--- a/openbb_platform/providers/oecd/openbb_oecd/models/long_term_interest_rate.py
+++ b/openbb_platform/providers/oecd/openbb_oecd/models/long_term_interest_rate.py
@@ -152,7 +152,7 @@ class OECDLTIRFetcher(Fetcher[OECDLTIRQueryParams, List[OECDLTIRData]]):
             )
         )
         data["country"] = data["country"].map(ltir_mapping)
-
+        data = data.fillna("N/A").replace("N/A", None)
         return data.to_dict(orient="records")
 
     @staticmethod

--- a/openbb_platform/providers/oecd/openbb_oecd/models/long_term_interest_rate.py
+++ b/openbb_platform/providers/oecd/openbb_oecd/models/long_term_interest_rate.py
@@ -1,5 +1,7 @@
 """OECD Long Term Interest Rate Rate Data."""
 
+# pylint: disable=unused-argument
+
 import re
 from datetime import date, timedelta
 from typing import Any, Dict, List, Literal, Optional, Union

--- a/openbb_platform/providers/oecd/openbb_oecd/models/short_term_interest_rate.py
+++ b/openbb_platform/providers/oecd/openbb_oecd/models/short_term_interest_rate.py
@@ -1,5 +1,7 @@
 """OECD Short Term Interest Rate Rate Data."""
 
+# pylint: disable=unused-argument
+
 import re
 from datetime import date, timedelta
 from typing import Any, Dict, List, Literal, Optional, Union

--- a/openbb_platform/providers/oecd/openbb_oecd/models/short_term_interest_rate.py
+++ b/openbb_platform/providers/oecd/openbb_oecd/models/short_term_interest_rate.py
@@ -152,7 +152,7 @@ class OECDSTIRFetcher(Fetcher[OECDSTIRQueryParams, List[OECDSTIRData]]):
             )
         )
         data["country"] = data["country"].map(stir_mapping)
-
+        data = data.fillna("N/A").replace("N/A", None)
         return data.to_dict(orient="records")
 
     @staticmethod


### PR DESCRIPTION

1. **Why**? (1-3 sentences or a bullet point list):

The router for the function, `obb.economy.long_term_interest_rate`, was defined incorrectly and was a duplicate of `short_term_interest_rate`.

2. **What**? (1-3 sentences or a bullet point list):

- Mapped the correct model in the router.
- Replaced `nan` values with None which were creating validation errors.

3. **Impact** (1-2 sentences or a bullet point list):

`obb.economy.long_term_interest_rate` now works.

4. **Testing Done**:

The data returned is from the correct series, and no validation errors occur.

5. **Reviewer Notes** (optional):


6. **Any other information** (optional)
