### PR TITLE
[Feature] - remove unused validators from standard models

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
@@ -24,11 +24,9 @@ class AnalystEstimatesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class AnalystEstimatesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet.py
@@ -1,6 +1,5 @@
 """Balance Sheet Standard Model."""
 
-import warnings
 from datetime import date as dateType
 from typing import Optional
 
@@ -11,8 +10,6 @@ from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import (
     QUERY_DESCRIPTIONS,
 )
-
-_warn = warnings.warn
 
 
 class BalanceSheetQueryParams(QueryParams):
@@ -30,12 +27,7 @@ class BalanceSheetQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def upper_symbol(cls, v: str):
-        """Convert symbol to uppercase."""
-        if "," in v:
-            _warn(
-                f"{QUERY_DESCRIPTIONS.get('symbol_list_warning', '')} {v.split(',')[0].upper()}"
-            )
-        return v.split(",")[0].upper() if "," in v else v.upper()
+        return v.upper()
 
 
 class BalanceSheetData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet_growth.py
@@ -21,11 +21,9 @@ class BalanceSheetGrowthQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class BalanceSheetGrowthData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/cash_flow.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cash_flow.py
@@ -1,6 +1,5 @@
 """Cash Flow Statement Standard Model."""
 
-import warnings
 from datetime import date as dateType
 from typing import Optional
 
@@ -9,8 +8,6 @@ from pydantic import Field, NonNegativeInt, field_validator
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
-
-_warn = warnings.warn
 
 
 class CashFlowStatementQueryParams(QueryParams):
@@ -29,11 +26,7 @@ class CashFlowStatementQueryParams(QueryParams):
     @classmethod
     def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
-        if "," in v:
-            _warn(
-                f"{QUERY_DESCRIPTIONS.get('symbol_list_warning', '')} {v.split(',')[0].upper()}"
-            )
-        return v.split(",")[0].upper() if "," in v else v.upper()
+        return v.upper()
 
 
 class CashFlowStatementData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/cash_flow_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cash_flow_growth.py
@@ -21,11 +21,9 @@ class CashFlowStatementGrowthQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class CashFlowStatementGrowthData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/company_overview.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/company_overview.py
@@ -20,11 +20,9 @@ class CompanyOverviewQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class CompanyOverviewData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/earnings_call_transcript.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/earnings_call_transcript.py
@@ -21,11 +21,9 @@ class EarningsCallTranscriptQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EarningsCallTranscriptData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
@@ -4,7 +4,7 @@ from datetime import (
     date as dateType,
     datetime,
 )
-from typing import List, Optional, Set, Union
+from typing import Optional, Union
 
 from dateutil import parser
 from pydantic import Field, field_validator
@@ -36,11 +36,9 @@ class EquityHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EquityHistoricalData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_info.py
@@ -20,11 +20,9 @@ class EquityInfoQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EquityInfoData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
@@ -1,7 +1,7 @@
 """Equity Ownership Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -15,6 +15,8 @@ from openbb_core.provider.utils.descriptions import (
 
 class EquityOwnershipQueryParams(QueryParams):
     """Equity Ownership Query."""
+
+    __validator_dict__ = {"check_single": ("symbol",)}
 
     symbol: str = Field(description=QUERY_DESCRIPTIONS.get("symbol", ""))
     date: Optional[dateType] = Field(
@@ -33,11 +35,9 @@ class EquityOwnershipQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EquityOwnershipData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_peers.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_peers.py
@@ -1,6 +1,6 @@
 """Equity Peers Standard Model."""
 
-from typing import List, Set, Union
+from typing import List
 
 from pydantic import Field, field_validator
 
@@ -16,11 +16,9 @@ class EquityPeersQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EquityPeersData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_quote.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_quote.py
@@ -1,7 +1,7 @@
 """Equity Quote Standard Model."""
 
 from datetime import datetime
-from typing import List, Optional, Set, Union
+from typing import List, Optional, Union
 
 from pydantic import Field, field_validator
 
@@ -23,11 +23,9 @@ class EquityQuoteQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EquityQuoteData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_valuation_multiples.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_valuation_multiples.py
@@ -1,6 +1,6 @@
 """Equity Valuation Multiples Standard Model."""
 
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -19,11 +19,9 @@ class EquityValuationMultiplesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EquityValuationMultiplesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/esg_risk_rating.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/esg_risk_rating.py
@@ -19,11 +19,9 @@ class ESGRiskRatingQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class ESGRiskRatingData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/esg_score.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/esg_score.py
@@ -23,11 +23,9 @@ class ESGScoreQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class ESGScoreData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_countries.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_countries.py
@@ -1,7 +1,5 @@
 """ETF Countries Standard Model."""
 
-from typing import List, Set, Union
-
 from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
@@ -16,11 +14,9 @@ class EtfCountriesQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EtfCountriesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_historical.py
@@ -1,7 +1,7 @@
 """ETF Historical Price Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from dateutil import parser
 from pydantic import Field, NonNegativeInt, PositiveFloat, field_validator
@@ -29,11 +29,9 @@ class EtfHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def validate_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase and remove '-'."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EtfHistoricalData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_historical_nav.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_historical_nav.py
@@ -1,7 +1,6 @@
 """ETF Historical NAV model."""
 
 from datetime import date as dateType
-from typing import List, Set, Union
 
 from pydantic import Field, field_validator
 
@@ -20,11 +19,9 @@ class EtfHistoricalNavQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EtfHistoricalNavData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_info.py
@@ -1,6 +1,6 @@
 """ETF Info Standard Model."""
 
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -19,11 +19,9 @@ class EtfInfoQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EtfInfoData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_sectors.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_sectors.py
@@ -1,6 +1,6 @@
 """ETF Sectors Standard Model."""
 
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -16,11 +16,9 @@ class EtfSectorsQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class EtfSectorsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/executive_compensation.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/executive_compensation.py
@@ -31,11 +31,9 @@ class ExecutiveCompensationQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class ExecutiveCompensationData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
@@ -1,6 +1,5 @@
 """Financial Ratios Standard Model."""
 
-import warnings
 from typing import Optional
 
 from pydantic import Field, NonNegativeInt, field_validator
@@ -11,8 +10,6 @@ from openbb_core.provider.utils.descriptions import (
     DATA_DESCRIPTIONS,
     QUERY_DESCRIPTIONS,
 )
-
-_warn = warnings.warn
 
 
 class FinancialRatiosQueryParams(QueryParams):
@@ -30,11 +27,7 @@ class FinancialRatiosQueryParams(QueryParams):
     @classmethod
     def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
-        if "," in v:
-            _warn(
-                f"{QUERY_DESCRIPTIONS.get('symbol_list_warning', '')} {v.split(',')[0].upper()}"
-            )
-        return v.split(",")[0].upper() if "," in v else v.upper()
+        return v.upper()
 
 
 class FinancialRatiosData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/fred_series.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/fred_series.py
@@ -1,7 +1,7 @@
 """FRED Series Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -31,11 +31,9 @@ class SeriesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class SeriesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_curve.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_curve.py
@@ -1,7 +1,7 @@
 """Futures Curve Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -24,11 +24,9 @@ class FuturesCurveQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class FuturesCurveData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
@@ -1,7 +1,7 @@
 """Futures Historical Price Standard Model."""
 
 from datetime import date, datetime
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from dateutil import parser
 from pydantic import Field, field_validator
@@ -33,11 +33,9 @@ class FuturesHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class FuturesHistoricalData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
@@ -47,11 +47,9 @@ class HistoricalAttributesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class HistoricalAttributesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
@@ -1,7 +1,7 @@
 """Historical Dividends Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -24,11 +24,9 @@ class HistoricalDividendsQueryParams(QueryParams):
     )
 
     @field_validator("symbol", mode="before", check_fields=False)
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):  # pylint: disable=E0213
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class HistoricalDividendsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
@@ -24,6 +24,7 @@ class HistoricalDividendsQueryParams(QueryParams):
     )
 
     @field_validator("symbol", mode="before", check_fields=False)
+    @classmethod
     def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_employees.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_employees.py
@@ -20,11 +20,9 @@ class HistoricalEmployeesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class HistoricalEmployeesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_eps.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_eps.py
@@ -1,7 +1,7 @@
 """Historical EPS Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from dateutil import parser
 from pydantic import Field, field_validator
@@ -21,11 +21,9 @@ class HistoricalEpsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class HistoricalEpsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_splits.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_splits.py
@@ -1,7 +1,6 @@
 """Historical Splits Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Set, Union
 
 from pydantic import Field, field_validator
 
@@ -20,11 +19,9 @@ class HistoricalSplitsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class HistoricalSplitsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
@@ -1,6 +1,5 @@
 """Income Statement Standard Model."""
 
-import warnings
 from datetime import date as dateType
 from typing import Optional
 
@@ -11,8 +10,6 @@ from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import (
     QUERY_DESCRIPTIONS,
 )
-
-_warn = warnings.warn
 
 
 class IncomeStatementQueryParams(QueryParams):
@@ -31,11 +28,7 @@ class IncomeStatementQueryParams(QueryParams):
     @classmethod
     def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
-        if "," in v:
-            _warn(
-                f"{QUERY_DESCRIPTIONS.get('symbol_list_warning', '')} {v.split(',')[0].upper()}"
-            )
-        return v.split(",")[0].upper() if "," in v else v.upper()
+        return v.upper()
 
 
 class IncomeStatementData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
@@ -24,11 +24,9 @@ class IncomeStatementGrowthQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class IncomeStatementGrowthData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
@@ -4,7 +4,7 @@ from datetime import (
     date as dateType,
     datetime,
 )
-from typing import List, Literal, Optional, Set, Union
+from typing import Literal, Optional, Union
 
 from dateutil import parser
 from pydantic import Field, PositiveInt, StrictFloat, field_validator
@@ -42,11 +42,9 @@ class IndexHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class IndexHistoricalData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_info.py
@@ -1,6 +1,6 @@
 """Index Info Standard Model."""
 
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -19,11 +19,9 @@ class IndexInfoQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class IndexInfoData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_sectors.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_sectors.py
@@ -1,7 +1,5 @@
 """Index Sectors Standard Model."""
 
-from typing import List, Set, Union
-
 from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
@@ -16,11 +14,9 @@ class IndexSectorsQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class IndexSectorsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/insider_trading.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/insider_trading.py
@@ -5,7 +5,7 @@ from datetime import (
     datetime,
     time,
 )
-from typing import List, Optional, Set, Union
+from typing import Optional, Union
 
 from dateutil import parser
 from pydantic import Field, StrictInt, field_validator
@@ -29,11 +29,9 @@ class InsiderTradingQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class InsiderTradingData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/institutional_ownership.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/institutional_ownership.py
@@ -20,11 +20,9 @@ class InstitutionalOwnershipQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class InstitutionalOwnershipData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/key_executives.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/key_executives.py
@@ -1,6 +1,6 @@
 """Key Executives Standard Model."""
 
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -16,11 +16,9 @@ class KeyExecutivesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class KeyExecutivesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
@@ -25,11 +25,9 @@ class KeyMetricsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class KeyMetricsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/latest_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/latest_attributes.py
@@ -28,11 +28,9 @@ class LatestAttributesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class LatestAttributesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/market_indices.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/market_indices.py
@@ -4,7 +4,7 @@ from datetime import (
     date as dateType,
     datetime,
 )
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from dateutil import parser
 from pydantic import Field, StrictFloat, field_validator
@@ -30,11 +30,9 @@ class MarketIndicesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class MarketIndicesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/options_chains.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/options_chains.py
@@ -4,7 +4,7 @@ from datetime import (
     date as dateType,
     datetime,
 )
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -23,11 +23,8 @@ class OptionsChainsQueryParams(QueryParams):
 
     @classmethod
     @field_validator("symbol", mode="before", check_fields=False)
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+    def upper_symbol(cls, v: str) -> str:
+        return v.upper()
 
 
 class OptionsChainsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/otc_aggregate.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/otc_aggregate.py
@@ -1,6 +1,7 @@
 """OTC Aggregate Standard Model."""
 
 from datetime import date as dateType
+from typing import Optional
 
 from pydantic import Field
 
@@ -12,7 +13,7 @@ from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
 class OTCAggregateQueryParams(QueryParams):
     """OTC Aggregate Query."""
 
-    symbol: str = Field(
+    symbol: Optional[str] = Field(
         description=QUERY_DESCRIPTIONS.get("symbol", ""),
         default=None,
     )

--- a/openbb_platform/core/openbb_core/provider/standard_models/price_target.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/price_target.py
@@ -23,11 +23,9 @@ class PriceTargetQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class PriceTargetData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/price_target_consensus.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/price_target_consensus.py
@@ -19,11 +19,9 @@ class PriceTargetConsensusQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class PriceTargetConsensusData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/recent_performance.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/recent_performance.py
@@ -1,6 +1,6 @@
 """Recent Performance Standard Model."""
 
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from pydantic import Field, field_validator
 
@@ -16,11 +16,9 @@ class RecentPerformanceQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class RecentPerformanceData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
@@ -1,6 +1,5 @@
 """Reported Financials."""
 
-import warnings
 from datetime import date as dateType
 from typing import Optional
 
@@ -11,8 +10,6 @@ from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import (
     QUERY_DESCRIPTIONS,
 )
-
-_warn = warnings.warn
 
 
 class ReportedFinancialsQueryParams(QueryParams):
@@ -40,11 +37,7 @@ class ReportedFinancialsQueryParams(QueryParams):
     @classmethod
     def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
-        if "," in v:
-            _warn(
-                f"{QUERY_DESCRIPTIONS.get('symbol_list_warning', '')} {v.split(',')[0].upper()}"
-            )
-        return v.split(",")[0].upper() if "," in v else v.upper()
+        return v.upper()
 
 
 class ReportedFinancialsData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
@@ -1,6 +1,5 @@
 """Revenue by Business Line Standard Model."""
 
-import warnings
 from datetime import date as dateType
 from typing import Dict, Literal, Optional
 
@@ -11,8 +10,6 @@ from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import (
     QUERY_DESCRIPTIONS,
 )
-
-_warn = warnings.warn
 
 
 class RevenueBusinessLineQueryParams(QueryParams):
@@ -30,11 +27,7 @@ class RevenueBusinessLineQueryParams(QueryParams):
     @classmethod
     def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
-        if "," in v:
-            _warn(
-                f"{QUERY_DESCRIPTIONS.get('symbol_list_warning', '')} {v.split(',')[0].upper()}"
-            )
-        return v.split(",")[0].upper() if "," in v else v.upper()
+        return v.upper()
 
 
 class RevenueBusinessLineData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
@@ -1,6 +1,5 @@
 """Revenue by Geographic Segments Standard Model."""
 
-import warnings
 from datetime import date as dateType
 from typing import Dict, Literal, Optional
 
@@ -11,8 +10,6 @@ from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import (
     QUERY_DESCRIPTIONS,
 )
-
-_warn = warnings.warn
 
 
 class RevenueGeographicQueryParams(QueryParams):
@@ -30,11 +27,7 @@ class RevenueGeographicQueryParams(QueryParams):
     @classmethod
     def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
-        if "," in v:
-            _warn(
-                f"{QUERY_DESCRIPTIONS.get('symbol_list_warning', '')} {v.split(',')[0].upper()}"
-            )
-        return v.split(",")[0].upper() if "," in v else v.upper()
+        return v.upper()
 
 
 class RevenueGeographicData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/share_statistics.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/share_statistics.py
@@ -20,11 +20,9 @@ class ShareStatisticsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def upper_symbol(cls, v: str) -> str:
         """Convert symbol to uppercase."""
-        if isinstance(v, str):
-            return v.upper()
-        return ",".join([symbol.upper() for symbol in list(v)])
+        return v.upper()
 
 
 class ShareStatisticsData(Data):


### PR DESCRIPTION
1. **Why**?

    - These validators were not used since the `symbol` was always passed as comma-separated string in python
    - The additional features like some warnings being raised will be handled here https://github.com/OpenBB-finance/OpenBBTerminal/pull/6062

2. **What**?:

    - Remove the validators

3. **Impact**:

    - No impact, not used
    
4. **Testing Done**:

    - `List[str]` is not allowed in any case so no test