### PR TITLE
[Feature] - Ensure Bugfix branches can only do PRs to `develop` branches

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -31,7 +31,7 @@ jobs:
       id: check-develop-branch
       if: ${{ steps.branch-names.outputs.base_ref_branch == 'develop' }}
       run: |
-        if ! [[ "${{ steps.branch-names.outputs.head_ref_branch }}" =~ ^(feature/.*|docs/.*|hotfix/.*|bugfix/.*|release/[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
+        if ! [[ "${{ steps.branch-names.outputs.head_ref_branch }}" =~ ^(feature/.*|docs/.*|bugfix/.*|release/[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
           echo "reason=Invalid branch name for a Pull Request to be merged to `${{ steps.branch-names.outputs.base_ref_branch }}` branch. Branches must follow the GitFlow naming convention." >> $GITHUB_OUTPUT
         fi
 
@@ -60,7 +60,7 @@ jobs:
       if: steps.check-comment.outputs.commentExists == 'false'
       run: |
         reason="${{ steps.check-develop-branch.outputs.reason }}${{ steps.check-main-branch.outputs.reason }}"
-        gh pr comment ${{ github.event.pull_request.number }} --body "$reason Please review our [branch naming guidelines](LINK_TO_GUIDELINES)."
+        gh pr comment ${{ github.event.pull_request.number }} --body "$reason Please review our [branch naming guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/develop/CONTRIBUTING.md#branch-naming-conventions)."
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -14,40 +14,58 @@ concurrency:
 jobs:
   check-branch-name:
     runs-on: ubuntu-latest
-    outputs:
-      source-branch: ${{ steps.branch-name-check.outputs.source-branch }}
-      target-branch: ${{ steps.branch-name-check.outputs.target-branch }}
     steps:
-    - name: Extract branch names
-      id: branch-name-check
-      run: |
-        source_branch=$(jq -r .pull_request.head.ref "$GITHUB_EVENT_PATH")
-        target_branch=$(jq -r .pull_request.base.ref "$GITHUB_EVENT_PATH")
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-        echo "Source-branch=$source_branch" >> $GITHUB_OUTPUT
-        echo "target-branch=$target_branch" >> $GITHUB_OUTPUT
+    - name: Get branch names.
+      id: branch-names
+      uses: tj-actions/branch-names@v8
 
     - name: Show Output result for source-branch and target-branch
       run: |
-        echo "source-branch=${{ steps.branch-name-check.outputs.source-branch }}"
-        echo "target-branch=${{ steps.branch-name-check.outputs.target-branch }}"
+        echo "source-branch=${{ steps.branch-names.outputs.head_ref_branch }}"
+        echo "target-branch=${{ steps.branch-names.outputs.base_ref_branch }}"
 
     - name: Check branch name for develop PRs
-      if: ${{ steps.branch-name-check.outputs.target-branch == 'develop' }}
+      id: check-develop-branch
+      if: ${{ steps.branch-names.outputs.base_ref_branch == 'develop' }}
       run: |
-        if [[ "${{ steps.branch-name-check.outputs.source-branch }}" =~ ^(main|feature/.*|docs/.*|hotfix/.*|bugfix/.*|release/[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
-          echo "Branch name is valid"
-        else
-          echo "Invalid branch name. Branches must follow the GitFlow naming convention to be allowed to merge into the develop branch."
-          exit 1
+        if ! [[ "${{ steps.branch-names.outputs.head_ref_branch }}" =~ ^(feature/.*|docs/.*|hotfix/.*|bugfix/.*|release/[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
+          echo "reason=Invalid branch name for a Pull Request to be merged to `${{ steps.branch-names.outputs.base_ref_branch }}` branch. Branches must follow the GitFlow naming convention." >> $GITHUB_OUTPUT
         fi
 
     - name: Check branch name for main PRs
-      if: ${{ steps.branch-name-check.outputs.target-branch == 'main' }}
+      id: check-main-branch
+      if: ${{ steps.branch-names.outputs.base_ref_branch == 'main' }}
       run: |
-        if [[ "${{ steps.branch-name-check.outputs.source-branch }}" =~ ^(hotfix/.*|release/[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
-          echo "PR is from a hotfix or release branch and targets the main branch"
-        else
-          echo "PR is not from a hotfix or release branch. Pull requests must be from a hotfix or release branch and target the main branch"
-          exit 1
+        if ! [[ "${{ steps.branch-names.outputs.head_ref_branch }}" =~ ^(hotfix/.*|release/[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)$ ]]; then
+          echo "reason=Invalid branch name for a Pull Request to be merged to `${{ steps.branch-names.outputs.base_ref_branch }}` branch. Pull requests must be from a hotfix or release branch." >> $GITHUB_OUTPUT
         fi
+
+    - name: Check for existing comment
+      if: ${{ steps.check-develop-branch.outputs.reason || steps.check-main-branch.outputs.reason }}
+      id: check-comment
+      run: |
+        commentExists=$(gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[].body' | grep -F "Invalid branch name" || echo '')
+        if [[ -n "$commentExists" ]]; then
+          echo "commentExists=true" >> $GITHUB_OUTPUT
+        else
+          echo "commentExists=false" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Comment on PR for invalid branch name
+      if: steps.check-comment.outputs.commentExists == 'false'
+      run: |
+        reason="${{ steps.check-develop-branch.outputs.reason }}${{ steps.check-main-branch.outputs.reason }}"
+        gh pr comment ${{ github.event.pull_request.number }} --body "$reason Please review our [branch naming guidelines](LINK_TO_GUIDELINES)."
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Fail if branch name is invalid
+      if: ${{ steps.check-develop-branch.outputs.reason || steps.check-main-branch.outputs.reason }}
+      run: |
+        echo "Invalid branch name. Please review our branch naming guidelines."
+        exit 1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,11 +10,11 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, edited]
-  push:
-    branches:
-      - "feature/*"
-      - "hotfix/*"
-      - "release/*"
+  # push:
+  #   branches:
+  #     - "feature/*"
+  #     - "hotfix/*"
+  #     - "release/*"
   merge_group:
     types: [checks_requested]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1704,8 +1704,9 @@ The accepted branch naming conventions are:
 - `feature/feature-name`
 - `hotfix/hotfix-name`
 - `release/2.1.0` or `release/2.1.0rc0`.
+- `bugfix/bugfix-name`
 
-All `feature/feature-name` related branches can only have PRs pointing to `develop` branch. `hotfix/hotfix-name` and `release/2.1.0` or `release/2.1.0rc0` branches can only have PRs pointing to `main` branch.
+All `feature/feature-name` related branches can only have PRs pointing to `develop` branch. `hotfix/hotfix-name` and `release/*` branches can only have PRs pointing to `main` branch.
 
 ## Installers
 


### PR DESCRIPTION
…pushes to branches outside PRs

# Pull Request OpenBB

Please go the the `Preview` tab and select the appropriate PR sub-template:

* [OpenBB Platform](?expand=1&template=platform_pull_request_template.md)
* [OpenBB Terminal](?expand=1&template=terminal_pull_request_template.md)
* [OpenBB Developers](?expand=1&template=obb_developer_pull_request_template.md)