### PR TITLE
[BugFix] - Fix POST docstring examples

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -493,7 +493,7 @@ class MethodDefinition:
 
     @staticmethod
     def get_extra(field: FieldInfo) -> dict:
-        """Get json schema extra"""
+        """Get json schema extra."""
         field_default = getattr(field, "default", None)
         if field_default:
             return getattr(field_default, "json_schema_extra", {})
@@ -542,7 +542,6 @@ class MethodDefinition:
         path: str, parameter_map: Dict[str, Parameter]
     ) -> OrderedDict[str, Parameter]:
         """Format the params."""
-
         DEFAULT_REPLACEMENT = {
             "provider": None,
         }
@@ -701,13 +700,12 @@ class MethodDefinition:
     ):
         """Build the command method docstring."""
         doc = func.__doc__
-        if model_name:
-            doc = DocstringGenerator.generate(
-                func=func,
-                formatted_params=formatted_params,
-                model_name=model_name,
-                examples=examples,
-            )
+        doc = DocstringGenerator.generate(
+            func=func,
+            formatted_params=formatted_params,
+            model_name=model_name,
+            examples=examples,
+        )
         code = f'        """{doc}        """  # noqa: E501\n\n' if doc else ""
 
         return code
@@ -777,7 +775,7 @@ class MethodDefinition:
 
     @classmethod
     def get_expanded_type(cls, field_name: str, extra: Optional[dict] = None) -> object:
-        """Expand the original field type"""
+        """Expand the original field type."""
         if extra and "multiple_items_allowed" in extra:
             return List[str]
         return cls.TYPE_EXPANSION.get(field_name, ...)
@@ -1008,6 +1006,12 @@ class DocstringGenerator:
                     examples=examples,
                 )
             return doc
+        if examples and examples != [""] and doc:
+            doc += "\n    Examples\n    --------\n"
+            doc += "    >>> from openbb import obb\n"
+            for example in examples:
+                if example != "":
+                    doc += f"    >>> {example}\n"
         return doc
 
     @staticmethod

--- a/openbb_platform/extensions/econometrics/openbb_econometrics/econometrics_router.py
+++ b/openbb_platform/extensions/econometrics/openbb_econometrics/econometrics_router.py
@@ -29,7 +29,13 @@ from openbb_econometrics.utils import get_engle_granger_two_step_cointegration_t
 router = Router(prefix="")
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.econometrics.correlation_matrix(data=stock_data)",
+    ],
+)
 def correlation_matrix(data: List[Data]) -> OBBject[List[Data]]:
     """Get the correlation matrix of an input dataset.
 
@@ -47,12 +53,6 @@ def correlation_matrix(data: List[Data]) -> OBBject[List[Data]]:
     -------
     OBBject[List[Data]]:
         Correlation matrix.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.correlation_matrix(data=stock_data)
     """
     df = basemodel_to_df(data)
     # remove non float columns from the dataframe to perform the correlation
@@ -70,7 +70,14 @@ def correlation_matrix(data: List[Data]) -> OBBject[List[Data]]:
     return OBBject(results=ret)
 
 
-@router.command(methods=["POST"], include_in_schema=False)
+@router.command(
+    methods=["POST"],
+    include_in_schema=False,
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.econometrics.ols_regression(data=stock_data, y_column="close", x_columns=["open", "high", "low"])',
+    ],
+)
 def ols_regression(
     data: List[Data],
     y_column: str,
@@ -96,12 +103,6 @@ def ols_regression(
     -------
     OBBject[Dict]:
         OBBject with the results being model and results objects.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.ols_regression(data=stock_data, y_column="close", x_columns=["open", "high", "low"])
     """
     X = sm.add_constant(get_target_columns(basemodel_to_df(data), x_columns))
     y = get_target_column(basemodel_to_df(data), y_column)
@@ -110,7 +111,13 @@ def ols_regression(
     return OBBject(results={"model": model, "results": results})
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.econometrics.ols_regression_summary(data=stock_data, y_column="close", x_columns=["open", "high", "low"])',
+    ],
+)
 def ols_regression_summary(
     data: List[Data],
     y_column: str,
@@ -133,12 +140,6 @@ def ols_regression_summary(
     -------
     OBBject[Data]:
         OBBject with the results being summary object.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.ols_regression_summary(data=stock_data, y_column="close", x_columns=["open", "high", "low"])
     """
     X = sm.add_constant(get_target_columns(basemodel_to_df(data), x_columns))
     y = get_target_column(basemodel_to_df(data), y_column)
@@ -183,7 +184,13 @@ def ols_regression_summary(
     return OBBject(results=clean_results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.econometrics.autocorrelation(data=stock_data, y_column="close", x_columns=["open", "high", "low"])',
+    ],
+)
 def autocorrelation(
     data: List[Data],
     y_column: str,
@@ -212,12 +219,6 @@ def autocorrelation(
     -------
     OBBject[Dict]:
         OBBject with the results being the score from the test.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.autocorrelation(data=stock_data, y_column="close", x_columns=["open", "high", "low"])
     """
     X = sm.add_constant(get_target_columns(basemodel_to_df(data), x_columns))
     y = get_target_column(basemodel_to_df(data), y_column)
@@ -225,7 +226,13 @@ def autocorrelation(
     return OBBject(results=Data(score=durbin_watson(results.resid)))
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.econometrics.residual_autocorrelation(data=stock_data, y_column="close", x_columns=["open", "high", "low"])',
+    ],
+)
 def residual_autocorrelation(
     data: List[Data],
     y_column: str,
@@ -257,12 +264,6 @@ def residual_autocorrelation(
     -------
     OBBject[Data]:
         OBBject with the results being the score from the test.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.residual_autocorrelation(data=stock_data, y_column="close", x_columns=["open", "high", "low"])
     """
     X = sm.add_constant(get_target_columns(basemodel_to_df(data), x_columns))
     y = get_target_column(basemodel_to_df(data), y_column)
@@ -280,7 +281,13 @@ def residual_autocorrelation(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.econometrics.cointegration(data=stock_data, columns=["open", "close"])',
+    ],
+)
 def cointegration(
     data: List[Data],
     columns: List[str],
@@ -309,12 +316,6 @@ def cointegration(
     -------
     OBBject[Data]:
         OBBject with the results being the score from the test.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.cointegration(data=stock_data, columns=["open", "close"])
     """
     pairs = list(combinations(columns, 2))
     dataset = get_target_columns(basemodel_to_df(data), columns)
@@ -339,7 +340,13 @@ def cointegration(
     return OBBject(results=result)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.econometrics.causality(data=stock_data, y_column="close", x_column="open")',
+    ],
+)
 def causality(
     data: List[Data],
     y_column: str,
@@ -371,12 +378,6 @@ def causality(
     -------
     OBBject[Data]:
         OBBject with the results being the score from the test.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.causality(data=stock_data, y_column="close", x_column="open")
     """
     X = get_target_column(basemodel_to_df(data), x_column)
     y = get_target_column(basemodel_to_df(data), y_column)
@@ -396,7 +397,14 @@ def causality(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.econometrics.unit_root(data=stock_data, column="close")',
+        'obb.econometrics.unit_root(data=stock_data, column="close", regression="ct")',
+    ],
+)
 def unit_root(
     data: List[Data],
     column: str,
@@ -427,13 +435,6 @@ def unit_root(
     -------
     OBBject[Data]:
         OBBject with the results being the score from the test.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.econometrics.unit_root(data=stock_data, column="close")
-    >>> obb.econometrics.unit_root(data=stock_data, column="close", regression="ct")
     """
     dataset = get_target_column(basemodel_to_df(data), column)
     adfstat, pvalue, usedlag, nobs, _, icbest = adfuller(dataset, regression=regression)

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/quantitative_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/quantitative_router.py
@@ -30,7 +30,13 @@ from .models import (
 router = Router(prefix="")
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.normality(data=stock_data, target='close')",
+    ],
+)
 def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
     """Get Normality Statistics.
 
@@ -51,12 +57,6 @@ def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
     -------
     OBBject[NormalityModel]
         Normality tests summary. See qa_models.NormalityModel for details.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.normality(data=stock_data, target="close")
     """
     from scipy import stats  # pylint: disable=import-outside-toplevel
 
@@ -80,7 +80,13 @@ def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
     return OBBject(results=norm_summary)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.capm(data=stock_data, target='close')",
+    ],
+)
 def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
     """Get Capital Asset Pricing Model (CAPM).
 
@@ -99,12 +105,6 @@ def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
     -------
     OBBject[CAPMModel]
         CAPM model summary.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").results
-    >>> obb.quantitative.capm(data=stock_data, target="close")
     """
     import statsmodels.api as sm  # pylint: disable=import-outside-toplevel # type: ignore
 
@@ -137,7 +137,13 @@ def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.omega_ratio(data=stock_data, target='close')",
+    ],
+)
 def omega_ratio(
     data: List[Data],
     target: str,
@@ -165,12 +171,6 @@ def omega_ratio(
     -------
     OBBject[List[OmegaModel]]
         Omega ratios.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.omega_ratio(data=stock_data, target="close")
     """
     df = basemodel_to_df(data)
     series_target = get_target_column(df, target)
@@ -195,7 +195,13 @@ def omega_ratio(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.kurtosis(data=stock_data, target='close', window=252)",
+    ],
+)
 def kurtosis(
     data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
 ) -> OBBject[List[Data]]:
@@ -223,12 +229,6 @@ def kurtosis(
     -------
     OBBject[List[Data]]
         Kurtosis.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.kurtosis(data=stock_data, target="close", window=252)
     """
     import pandas_ta as ta  # pylint: disable=import-outside-toplevel # type: ignore
 
@@ -243,7 +243,14 @@ def kurtosis(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.unitroot_test(data=stock_data, target='close')",
+        'obb.quantitative.unitroot_test(data=stock_data, target="close", fuller_reg="ct", kpss_reg="ct")',
+    ],
+)
 def unitroot_test(
     data: List[Data],
     target: str,
@@ -275,13 +282,6 @@ def unitroot_test(
     -------
     OBBject[UnitRootModel]
         Unit root tests summary.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.unitroot_test(data=stock_data, target="close")
-    >>> obb.quantitative.unitroot_test(data=stock_data, target="close", fuller_reg="ct", kpss_reg="ct")
     """
     # pylint: disable=import-outside-toplevel
     from statsmodels.tsa import stattools  # type: ignore
@@ -309,7 +309,14 @@ def unitroot_test(
     return OBBject(results=unitroot_summary)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.sharpe_ratio(data=stock_data, target='close')",
+        "obb.quantitative.sharpe_ratio(data=stock_data, target='close', rfr=0.01, window=126)",
+    ],
+)
 def sharpe_ratio(
     data: List[Data],
     target: str,
@@ -342,13 +349,6 @@ def sharpe_ratio(
     -------
     OBBject[List[Data]]
         Sharpe ratio.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.sharpe_ratio(data=stock_data, target="close")
-    >>> obb.quantitative.sharpe_ratio(data=stock_data, target="close", rfr=0.01, window=126)
     """
     df = basemodel_to_df(data, index=index)
     series_target = get_target_column(df, target)
@@ -363,7 +363,14 @@ def sharpe_ratio(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.sortino_ratio(data=stock_data, target='close')",
+        "obb.quantitative.sortino_ratio(data=stock_data, target='close', target_return=0.01, window=126, adjusted=True)",
+    ],
+)
 def sortino_ratio(
     data: List[Data],
     target: str,
@@ -404,13 +411,6 @@ def sortino_ratio(
     -------
     OBBject[List[Data]]
         Sortino ratio.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.sortino_ratio(data=stock_data, target="close")
-    >>> obb.quantitative.sortino_ratio(data=stock_data, target="close", target_return=0.01, window=126, adjusted=True)
     """
     df = basemodel_to_df(data, index=index)
     series_target = get_target_column(df, target)
@@ -433,7 +433,13 @@ def sortino_ratio(
     return OBBject(results=results_)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.skewness(data=stock_data, target='close', window=252)",
+    ],
+)
 def skewness(
     data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
 ) -> OBBject[List[Data]]:
@@ -459,12 +465,6 @@ def skewness(
     -------
     OBBject[List[Data]]
         Skewness.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.skewness(data=stock_data, target="close", window=252)
     """
     import pandas_ta as ta  # pylint: disable=import-outside-toplevel # type: ignore
 
@@ -479,7 +479,14 @@ def skewness(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        'obb.quantitative.quantile(data=stock_data, target="close", window=252, quantile_pct=0.25)',
+        "obb.quantitative.quantile(data=stock_data, target='close', window=252, quantile_pct=0.75)",
+    ],
+)
 def quantile(
     data: List[Data],
     target: str,
@@ -510,13 +517,6 @@ def quantile(
     -------
     OBBject[List[Data]]
         Quantile.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.quantile(data=stock_data, target="close", window=252, quantile_pct=0.25)
-    >>> obb.quantitative.quantile(data=stock_data, target="close", window=252, quantile_pct=0.75)
     """
     import pandas_ta as ta  # pylint: disable=import-outside-toplevel # type: ignore
 
@@ -534,7 +534,13 @@ def quantile(
     return OBBject(results=results_)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp').to_df()",
+        "obb.quantitative.volatility(data=stock_data, target='close')",
+    ],
+)
 def summary(data: List[Data], target: str) -> OBBject[SummaryModel]:
     """Get Summary Statistics.
 
@@ -556,12 +562,6 @@ def summary(data: List[Data], target: str) -> OBBject[SummaryModel]:
     -------
     OBBject[SummaryModel]
         Summary table.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp").to_df()
-    >>> obb.quantitative.summary(data=stock_data, target="close")
     """
     df = basemodel_to_df(data)
     series_target = get_target_column(df, target)

--- a/openbb_platform/extensions/technical/openbb_technical/technical_router.py
+++ b/openbb_platform/extensions/technical/openbb_technical/technical_router.py
@@ -22,7 +22,13 @@ from . import helpers
 router = Router(prefix="")
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "atr_data = obb.technical.atr(data=stock_data.results)",
+    ],
+)
 def atr(
     data: List[Data],
     index: str = "date",
@@ -60,12 +66,6 @@ def atr(
     -------
     OBBject[List[Data]]
         List of data with the indicator applied.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> atr_data = obb.technical.atr(data=stock_data.results)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close"])
@@ -79,7 +79,13 @@ def atr(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "fib_data = obb.technical.fib(data=stock_data.results, period=120)",
+    ],
+)
 def fib(
     data: List[Data],
     index: str = "date",
@@ -109,12 +115,6 @@ def fib(
     -------
     OBBject[List[Data]]
         List of data with the indicator applied.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> fib_data = obb.technical.fib(data=stock_data.results, period=120)
     """
     df = basemodel_to_df(data, index=index)
 
@@ -144,7 +144,13 @@ def fib(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "obv_data = obb.technical.obv(data=stock_data.results, offset=0)",
+    ],
+)
 def obv(
     data: List[Data],
     index: str = "date",
@@ -174,12 +180,6 @@ def obv(
     -------
     OBBject[List[Data]]
         List of data with the indicator applied.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> obv_data = obb.technical.obv(data=stock_data.results, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["close", "volume"])
@@ -191,7 +191,13 @@ def obv(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "fisher_data = obb.technical.fisher(data=stock_data.results, length=14, signal=1)",
+    ],
+)
 def fisher(
     data: List[Data],
     index: str = "date",
@@ -221,12 +227,6 @@ def fisher(
     -------
     OBBject[List[Data]]
         List of data with the indicator applied.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> fisher_data = obb.technical.fisher(data=stock_data.results, length=14, signal=1)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low"])
@@ -238,7 +238,13 @@ def fisher(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "adosc_data = obb.technical.adosc(data=stock_data.results, fast=3, slow=10, offset=0)",
+    ],
+)
 def adosc(
     data: List[Data],
     index: str = "date",
@@ -271,12 +277,6 @@ def adosc(
     Returns
     -------
     OBBject[List[Data]]
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> adosc_data = obb.technical.adosc(data=stock_data.results, fast=3, slow=10, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close", "volume", "open"])
@@ -288,7 +288,13 @@ def adosc(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "bbands_data = obb.technical.bbands(data=stock_data.results, target='close', length=50, std=2, mamode='sma')",
+    ],
+)
 def bbands(
     data: List[Data],
     target: str = "close",
@@ -334,14 +340,6 @@ def bbands(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> bbands = obb.technical.bbands(
-    >>>     data=stock_data.results, target="close", length=50, std=2, mamode="sma", offset=0
-    >>> )
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -362,7 +360,13 @@ def bbands(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "zlma_data = obb.technical.zlma(data=stock_data.results, target='close', length=50, offset=0)",
+    ],
+)
 def zlma(
     data: List[Data],
     target: str = "close",
@@ -396,12 +400,6 @@ def zlma(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> zlma_data = obb.technical.zlma(data=stock_data.results, target="close", length=50, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -420,7 +418,13 @@ def zlma(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "aaron_data = obb.technical.aroon(data=stock_data.results, length=25, scalar=100)",
+    ],
+)
 def aroon(
     data: List[Data],
     index: str = "date",
@@ -456,12 +460,6 @@ def aroon(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> aroon_data = obb.technical.aroon(data=stock_data.results, length=25, scalar=100)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close"])
@@ -473,7 +471,13 @@ def aroon(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "sma_data = obb.technical.sma(data=stock_data.results, target='close', length=50, offset=0)",
+    ],
+)
 def sma(
     data: List[Data],
     target: str = "close",
@@ -508,12 +512,6 @@ def sma(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> sma_data = obb.technical.sma(data=stock_data.results,target="close", length=50, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -532,7 +530,13 @@ def sma(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "demark_data = obb.technical.demark(data=stock_data.results, offset=0)",
+    ],
+)
 def demark(
     data: List[Data],
     index: str = "date",
@@ -568,12 +572,6 @@ def demark(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> demark_data = obb.technical.demark(data=stock_data.results, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -586,7 +584,13 @@ def demark(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "vwap_data = obb.technical.vwap(data=stock_data.results, anchor='D', offset=0)",
+    ],
+)
 def vwap(
     data: List[Data],
     index: str = "date",
@@ -617,12 +621,6 @@ def vwap(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> vwap_data = obb.technical.vwap(data=stock_data.results, anchor="D", offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close", "volume"])
@@ -634,7 +632,13 @@ def vwap(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "macd_data = obb.technical.macd(data=stock_data.results, target='close', fast=12, slow=26, signal=9)",
+    ],
+)
 def macd(
     data: List[Data],
     target: str = "close",
@@ -673,12 +677,6 @@ def macd(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> macd_data = obb.technical.macd(data=stock_data.results,target="close", fast=12, slow=26, signal=9)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -697,7 +695,13 @@ def macd(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "hma_data = obb.technical.hma(data=stock_data.results, target='close', length=50, offset=0)",
+    ],
+)
 def hma(
     data: List[Data],
     target: str = "close",
@@ -729,12 +733,6 @@ def hma(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> hma_data = obb.technical.hma(data=stock_data.results, target="close", length=50, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -753,7 +751,13 @@ def hma(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "donchian_data = obb.technical.donchian(data=stock_data.results, lower_length=20, upper_length=20, offset=0)",
+    ],
+)
 def donchian(
     data: List[Data],
     index: str = "date",
@@ -786,12 +790,6 @@ def donchian(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> donchian_data = obb.technical.donchian(data=stock_data.results, lower_length=20, upper_length=20, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low"])
@@ -807,7 +805,13 @@ def donchian(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "ichimoku_data = obb.technical.ichimoku(data=stock_data.results, conversion=9, base=26, lookahead=False)",
+    ],
+)
 def ichimoku(
     data: List[Data],
     index: str = "date",
@@ -846,12 +850,6 @@ def ichimoku(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> ichimoku_data = obb.technical.ichimoku(data=stock_data.results, conversion=9, base=26, lookahead=False)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close"])
@@ -871,7 +869,13 @@ def ichimoku(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "clenow_data = obb.technical.clenow(data=stock_data.results, period=90)",
+    ],
+)
 def clenow(
     data: List[Data],
     index: str = "date",
@@ -899,12 +903,6 @@ def clenow(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> clenow_data = obb.technical.clenow(data=stock_data.results, period=90)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target)
@@ -926,7 +924,13 @@ def clenow(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "ad_data = obb.technical.ad(data=stock_data.results, offset=0)",
+    ],
+)
 def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[Data]]:
     """Calculate the Accumulation/Distribution Line.
 
@@ -955,12 +959,6 @@ def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[D
     Returns
     -------
     OBBject[List[Data]]
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> ad_data = obb.technical.ad(data=stock_data.results, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close", "volume"])
@@ -972,7 +970,13 @@ def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[D
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "adx_data = obb.technical.adx(data=stock_data.results, length=50, scalar=100.0, drift=1)",
+    ],
+)
 def adx(
     data: List[Data],
     index: str = "date",
@@ -1003,12 +1007,6 @@ def adx(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> adx_data = obb.technical.adx(data=stock_data.results, length=50, scalar=100.0, drift=1)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["close", "high", "low"])
@@ -1022,7 +1020,13 @@ def adx(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "wma_data = obb.technical.wma(data=stock_data.results, target='close', length=50, offset=0)",
+    ],
+)
 def wma(
     data: List[Data],
     target: str = "close",
@@ -1054,12 +1058,6 @@ def wma(
     -------
     OBBject[List[Data]]
         The WMA data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> wma_data = obb.technical.wma(data=stock_data.results, target="close", length=50, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -1078,7 +1076,13 @@ def wma(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "cci_data = obb.technical.cci(data=stock_data.results, length=14, scalar=0.015)",
+    ],
+)
 def cci(
     data: List[Data],
     index: str = "date",
@@ -1108,12 +1112,6 @@ def cci(
     -------
     OBBject[List[Data]]
         The CCI data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> cci_data = obb.technical.cci(data=stock_data.results, length=14, scalar=0.015)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["close", "high", "low"])
@@ -1125,7 +1123,13 @@ def cci(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "rsi_data = obb.technical.rsi(data=stock_data.results, target='close', length=14, scalar=100.0, drift=1)",
+    ],
+)
 def rsi(
     data: List[Data],
     target: str = "close",
@@ -1161,12 +1165,6 @@ def rsi(
     -------
     OBBject[List[Data]]
         The RSI data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> rsi_data = obb.technical.rsi(data=stock_data.results, target="close", length=14, scalar=100.0, drift=1)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()
@@ -1186,7 +1184,13 @@ def rsi(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "stoch_data = obb.technical.stoch(data=stock_data.results, fast_k_period=14, slow_d_period=3, slow_k_period=3)",
+    ],
+)
 def stoch(
     data: List[Data],
     index: str = "date",
@@ -1220,12 +1224,6 @@ def stoch(
     -------
     OBBject[List[Data]]
         The Stochastic Oscillator data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> stoch_data = obb.technical.stoch(data=stock_data.results, fast_k_period=14, slow_d_period=3, slow_k_period=3)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["close", "high", "low"])
@@ -1243,7 +1241,13 @@ def stoch(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "kc_data = obb.technical.kc(data=stock_data.results, length=20, scalar=20, mamode='ema', offset=0)",
+    ],
+)
 def kc(
     data: List[Data],
     index: str = "date",
@@ -1279,12 +1283,6 @@ def kc(
     -------
     OBBject[List[Data]]
         The Keltner Channels data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> kc_data = obb.technical.kc(data=stock_data.results, length=20, scalar=20, mamode="ema", offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close"])
@@ -1302,7 +1300,13 @@ def kc(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "cg_data = obb.technical.cg(data=stock_data.results, length=14)",
+    ],
+)
 def cg(
     data: List[Data], index: str = "date", length: PositiveInt = 14
 ) -> OBBject[List[Data]]:
@@ -1327,12 +1331,6 @@ def cg(
     -------
     OBBject[List[Data]]
         The COG data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> cg_data = obb.technical.cg(data=stock_data.results, length=14)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_columns(df, ["high", "low", "close"])
@@ -1344,7 +1342,13 @@ def cg(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "cones_data = obb.technical.cones(data=stock_data.results, lower_q=0.25, upper_q=0.75, model='STD')",
+    ],
+)
 def cones(
     data: List[Data],
     index: str = "date",
@@ -1418,12 +1422,6 @@ def cones(
     -------
     OBBject[List[Data]]
         The cones data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> cones_data = obb.technical.cones(data=stock_data.results, lower_q=0.25, upper_q=0.75, model="STD")
     """
     if lower_q > upper_q:
         lower_q, upper_q = upper_q, lower_q
@@ -1443,7 +1441,13 @@ def cones(
     return OBBject(results=results)
 
 
-@router.command(methods=["POST"])
+@router.command(
+    methods=["POST"],
+    examples=[
+        "stock_data = obb.equity.price.historical(symbol='TSLA', start_date='2023-01-01', provider='fmp')",
+        "ema_data = obb.technical.ema(data=stock_data.results, target='close', length=50, offset=0)",
+    ],
+)
 def ema(
     data: List[Data],
     target: str = "close",
@@ -1475,12 +1479,6 @@ def ema(
     -------
     OBBject[List[Data]]
         The calculated data.
-
-    Examples
-    --------
-    >>> from openbb import obb
-    >>> stock_data = obb.equity.price.historical(symbol="TSLA", start_date="2023-01-01", provider="fmp")
-    >>> ema_data = obb.technical.ema(data=stock_data.results, target="close", length=50, offset=0)
     """
     df = basemodel_to_df(data, index=index)
     df_target = get_target_column(df, target).to_frame()


### PR DESCRIPTION
# Pull Request Template for OpenBB Developers

1. **Why**? (1-3 sentences or a bullet point list):

    - The POST commands should follow the same convention as other router commands when adding examples for consistency.

2. **What**? (1-3 sentences or a bullet point list):

    - Moved POST command router examples from docstring to the command decorator.
    - Fixed a bug where the POST examples wouldn't be added to the static assets docstrings.

3. **Impact** (1-2 sentences or a bullet point list):

    - Will change the look of the router files and add `examples` to the `openapi.json`. Shouldn't change anything substantial as these extension aren't yet widely used.

4. **Testing Done**:

    - Ensured that the examples are indeed on the static assets as expected.
