### PR TITLE
[BugFix] Fixes `to_df()` where the date series contains multiple TZ-offsets.

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/obbject.py
+++ b/openbb_platform/core/openbb_core/app/model/obbject.py
@@ -113,13 +113,13 @@ class OBBject(Tagged, Generic[T]):
         return f"OBBject[{cls.results_type_repr(params)}]"
 
     def to_df(
-        self, index: Optional[str] = "date", sort_by: Optional[str] = None
+        self, index: Optional[Union[None, str]] = "date", sort_by: Optional[str] = None
     ) -> pd.DataFrame:
         """Alias for `to_dataframe`."""
         return self.to_dataframe(index=index, sort_by=sort_by)
 
     def to_dataframe(
-        self, index: Optional[str] = "date", sort_by: Optional[str] = None
+        self, index: Optional[Union[None, str]] = "date", sort_by: Optional[str] = None
     ) -> pd.DataFrame:
         """Convert results field to pandas dataframe.
 
@@ -234,11 +234,11 @@ class OBBject(Tagged, Generic[T]):
                 "Please install polars: `pip install polars pyarrow`  to use this method."
             ) from exc
 
-        return from_pandas(self.to_dataframe().reset_index())
+        return from_pandas(self.to_dataframe(index=None))
 
     def to_numpy(self) -> ndarray:
         """Convert results field to numpy array."""
-        return self.to_dataframe().reset_index().to_numpy()
+        return self.to_dataframe(index=None).to_numpy()
 
     def to_dict(
         self,

--- a/openbb_platform/core/openbb_core/app/model/obbject.py
+++ b/openbb_platform/core/openbb_core/app/model/obbject.py
@@ -113,13 +113,13 @@ class OBBject(Tagged, Generic[T]):
         return f"OBBject[{cls.results_type_repr(params)}]"
 
     def to_df(
-        self, index: Optional[str] = None, sort_by: Optional[str] = None
+        self, index: Optional[str] = "date", sort_by: Optional[str] = None
     ) -> pd.DataFrame:
         """Alias for `to_dataframe`."""
         return self.to_dataframe(index=index, sort_by=sort_by)
 
     def to_dataframe(
-        self, index: Optional[str] = None, sort_by: Optional[str] = None
+        self, index: Optional[str] = "date", sort_by: Optional[str] = None
     ) -> pd.DataFrame:
         """Convert results field to pandas dataframe.
 
@@ -173,7 +173,7 @@ class OBBject(Tagged, Generic[T]):
                 for k, v in r.items():
                     # Dict[str, List[BaseModel]]
                     if is_list_of_basemodel(v):
-                        dict_of_df[k] = basemodel_to_df(v, index or "date")
+                        dict_of_df[k] = basemodel_to_df(v, index)
                         sort_columns = False
                     # Dict[str, Any]
                     else:
@@ -184,14 +184,14 @@ class OBBject(Tagged, Generic[T]):
             # List[BaseModel]
             elif is_list_of_basemodel(res):
                 dt: Union[List[Data], Data] = res  # type: ignore
-                df = basemodel_to_df(dt, index or "date")
+                df = basemodel_to_df(dt, index)
                 sort_columns = False
             # List[List | str | int | float] | Dict[str, Dict | List | BaseModel]
             else:
                 try:
                     df = pd.DataFrame(res)
                     # Set index, if any
-                    if index and index in df.columns:
+                    if index is not None and index in df.columns:
                         df.set_index(index, inplace=True)
 
                 except ValueError:

--- a/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
+++ b/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
@@ -1,12 +1,11 @@
 """Alpha Vantage Equity Historical Price Model."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Literal, Optional
 
 from dateutil.relativedelta import relativedelta
 from openbb_alpha_vantage.utils.helpers import (
     extract_key_name,
-    filter_by_dates,
     get_interval,
 )
 from openbb_core.provider.abstract.fetcher import Fetcher
@@ -19,6 +18,7 @@ from openbb_core.provider.utils.descriptions import (
     QUERY_DESCRIPTIONS,
 )
 from openbb_core.provider.utils.helpers import amake_request, get_querystring
+from pandas import to_datetime
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -201,7 +201,17 @@ class AVEquityHistoricalFetcher(
                 }
                 for date, values in content.items()
             ]
-            filter_by_dates(d, query.start_date, query.end_date)
-            transformed_data += d
+            if query.start_date and query.end_date:
+                transformed_data = list(
+                    filter(
+                        lambda x: to_datetime(query.start_date)
+                        <= to_datetime(x["date"])
+                        <= to_datetime(query.end_date) + timedelta(days=1),
+                        d,
+                    )
+                )
 
-        return [AVEquityHistoricalData.model_validate(d) for d in transformed_data]
+        return [
+            AVEquityHistoricalData.model_validate(d)
+            for d in sorted(transformed_data, key=lambda x: x["date"], reverse=False)
+        ]

--- a/openbb_platform/providers/fmp/openbb_fmp/models/crypto_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/crypto_historical.py
@@ -107,4 +107,7 @@ class FMPCryptoHistoricalFetcher(
         query: FMPCryptoHistoricalQueryParams, data: List[Dict], **kwargs: Any
     ) -> List[FMPCryptoHistoricalData]:
         """Return the transformed data."""
-        return [FMPCryptoHistoricalData.model_validate(d) for d in data]
+        return [
+            FMPCryptoHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["date"], reverse=False)
+        ]

--- a/openbb_platform/providers/fmp/openbb_fmp/models/currency_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/currency_historical.py
@@ -107,4 +107,7 @@ class FMPCurrencyHistoricalFetcher(
             and d.get("change") != 0
             and d.get("changeOverTime") != 0
         ]
-        return [FMPCurrencyHistoricalData.model_validate(d) for d in data]
+        return [
+            FMPCurrencyHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["date"], reverse=False)
+        ]

--- a/openbb_platform/providers/fmp/openbb_fmp/models/equity_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/equity_historical.py
@@ -132,4 +132,7 @@ class FMPEquityHistoricalFetcher(
         query: FMPEquityHistoricalQueryParams, data: List[Dict], **kwargs: Any
     ) -> List[FMPEquityHistoricalData]:
         """Return the transformed data."""
-        return [FMPEquityHistoricalData.model_validate(d) for d in data]
+        return [
+            FMPEquityHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["date"], reverse=False)
+        ]

--- a/openbb_platform/providers/fmp/openbb_fmp/models/index_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/index_historical.py
@@ -109,7 +109,7 @@ class FMPIndexHistoricalFetcher(
         query: FMPIndexHistoricalQueryParams, data: List[Dict], **kwargs: Any
     ) -> List[FMPIndexHistoricalData]:
         """Return the transformed data."""
-        if query.sort == "asc":
-            data = sorted(data, key=lambda x: x["date"], reverse=True)
-
-        return [FMPIndexHistoricalData.model_validate(d) for d in data]
+        return [
+            FMPIndexHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["date"], reverse=False)
+        ]

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
@@ -229,4 +229,7 @@ class IntrinioEquityHistoricalFetcher(
         **kwargs: Any,
     ) -> List[IntrinioEquityHistoricalData]:
         """Return the transformed data."""
-        return [IntrinioEquityHistoricalData.model_validate(d) for d in data]
+        return [
+            IntrinioEquityHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["date"], reverse=False)
+        ]

--- a/openbb_platform/providers/polygon/openbb_polygon/models/crypto_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/crypto_historical.py
@@ -172,4 +172,7 @@ class PolygonCryptoHistoricalFetcher(
         """Transform the data."""
         if not data:
             raise EmptyDataError()
-        return [PolygonCryptoHistoricalData.model_validate(d) for d in data]
+        return [
+            PolygonCryptoHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["t"], reverse=False)
+        ]

--- a/openbb_platform/providers/polygon/openbb_polygon/models/currency_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/currency_historical.py
@@ -169,4 +169,7 @@ class PolygonCurrencyHistoricalFetcher(
         """Return the transformed data."""
         if not data:
             raise EmptyDataError()
-        return [PolygonCurrencyHistoricalData.model_validate(d) for d in data]
+        return [
+            PolygonCurrencyHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["t"], reverse=False)
+        ]

--- a/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
@@ -178,4 +178,7 @@ class PolygonEquityHistoricalFetcher(
         """Transform the data from the Polygon endpoint."""
         if not data:
             raise EmptyDataError()
-        return [PolygonEquityHistoricalData.model_validate(d) for d in data]
+        return [
+            PolygonEquityHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["t"], reverse=False)
+        ]

--- a/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
@@ -158,7 +158,7 @@ class PolygonEquityHistoricalFetcher(
                 if query._timespan not in ["second", "minute", "hour"]:
                     r["t"] = r["t"].date()
                 else:
-                    r["t"] = r["t"].strftime("%Y-%m-%dT%H:%M:%S")
+                    r["t"] = r["t"].strftime("%Y-%m-%dT%H:%M:%S%z")
                 if "," in query.symbol:
                     r["symbol"] = symbol
 

--- a/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
@@ -173,4 +173,7 @@ class PolygonIndexHistoricalFetcher(
         """Transform the data."""
         if not data:
             raise EmptyDataError()
-        return [PolygonIndexHistoricalData.model_validate(d) for d in data]
+        return [
+            PolygonIndexHistoricalData.model_validate(d)
+            for d in sorted(data, key=lambda x: x["t"], reverse=False)
+        ]

--- a/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
@@ -153,7 +153,7 @@ class PolygonIndexHistoricalFetcher(
                 if query._timespan not in ["second", "minute", "hour"]:
                     r["t"] = r["t"].date()
                 else:
-                    r["t"] = r["t"].strftime("%Y-%m-%dT%H:%M:%S")
+                    r["t"] = r["t"].strftime("%Y-%m-%dT%H:%M:%S%z")
                 if "," in query.symbol:
                     r["symbol"] = symbol
 


### PR DESCRIPTION
Fixes `to_df()` where the date series contains multiple TZ-offsets.

1. **Why**? (1-3 sentences or a bullet point list):

    - `to_df()` was raising an error when the time series was TZ-aware and contained multiple UTC offsets.

    - Couldn't get around it by setting "index=None" because it would replace None with "date".

2. **What**? (1-3 sentences or a bullet point list):

    - Changing `pd.to_datetime(df["date"])` to `df["date"].apply(to_datetime)`

    - Restore the TZ-aware datetime returned from Polygon as this was made naive to workaround this issue.

    - Allow `None` to be a valid choice in `to_df(index=None)`.

    - Ensure that all providers return the historical price time series data as ascending dates because that is how most downstream processes expect it.  The outputs from providers were mixed. 
 

3. **Impact** (1-2 sentences or a bullet point list):

    - No real impact other than bug squashing.

4. **Testing Done**:

    - Loading intraday data that is TZ-aware, starting before Nov 3.  

    - Use `to_df()` and then `to_df(index=None)` to check each provider is returning the same direction.
