### PR TITLE
[BugFix] Fix ECB Yield Curve

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/eu_yield_curve.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/eu_yield_curve.py
@@ -1,7 +1,7 @@
 """Euro Area Yield Curve Standard Model."""
 
 from datetime import date as dateType
-from typing import Literal, Optional
+from typing import Optional
 
 from pydantic import Field
 
@@ -16,16 +16,14 @@ class EUYieldCurveQueryParams(QueryParams):
     date: Optional[dateType] = Field(
         default=None, description=QUERY_DESCRIPTIONS.get("date", "")
     )
-    yield_curve_type: Literal["spot_rate", "instantaneous_forward", "par_yield"] = (
-        Field(
-            default="spot_rate",
-            description="The yield curve type.",
-        )
-    )
 
 
 class EUYieldCurveData(Data):
     """Euro Area Yield Curve Data."""
 
-    maturity: str = Field(description="Yield curve rate maturity.")
-    rate: Optional[float] = Field(description="Yield curve rate.", default=None)
+    maturity: Optional[float] = Field(description="Maturity, in years.", default=None)
+    rate: Optional[float] = Field(
+        description="Yield curve rate, as a normalized percent.",
+        default=None,
+        json_schema_extra={"unit_measurement": "percent.", "frontend_multiply": 100},
+    )

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
@@ -439,10 +439,9 @@ def test_fixedincome_spreads_treasury_effr(params, headers):
 @parametrize(
     "params",
     [
-        ({"date": "2023-01-01", "yield_curve_type": "spot_rate"}),
         (
             {
-                "rating": "A",
+                "rating": "aaa",
                 "provider": "ecb",
                 "date": "2023-01-01",
                 "yield_curve_type": "spot_rate",

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
@@ -405,10 +405,9 @@ def test_fixedincome_spreads_treasury_effr(params, obb):
 @parametrize(
     "params",
     [
-        ({"date": "2023-01-01", "yield_curve_type": "spot_rate"}),
         (
             {
-                "rating": "A",
+                "rating": "aaa",
                 "provider": "ecb",
                 "date": "2023-01-01",
                 "yield_curve_type": "spot_rate",

--- a/openbb_platform/providers/ecb/openbb_ecb/models/eu_yield_curve.py
+++ b/openbb_platform/providers/ecb/openbb_ecb/models/eu_yield_curve.py
@@ -1,6 +1,10 @@
 """Euro Area Yield Curve Model."""
 
-from datetime import datetime, timedelta
+# pylint: disable=unused-argument
+
+import asyncio
+import warnings
+from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
 from openbb_core.provider.abstract.fetcher import Fetcher
@@ -8,34 +12,38 @@ from openbb_core.provider.standard_models.eu_yield_curve import (
     EUYieldCurveData,
     EUYieldCurveQueryParams,
 )
-from openbb_ecb.utils.ecb_helpers import get_series_data
+from openbb_core.provider.utils.errors import EmptyDataError
+from openbb_core.provider.utils.helpers import amake_request
+from openbb_ecb.utils.yield_curve_series import get_yield_curve_ids
+from pandas import DataFrame, to_datetime
 from pydantic import Field, field_validator
+
+_warn = warnings.warn
 
 
 class ECBEUYieldCurveQueryParams(EUYieldCurveQueryParams):
-    """Euro Area Yield Curve Query."""
+    """ECB Yield Curve Query Params."""
 
-    rating: Literal["A", "C"] = Field(
-        default="A",
-        description="The rating type.",
+    rating: Literal["aaa", "all_ratings"] = Field(
+        default="aaa",
+        description="The rating type, either 'aaa' or 'all_ratings'.",
+    )
+    yield_curve_type: Literal["spot_rate", "instantaneous_forward", "par_yield"] = (
+        Field(
+            default="spot_rate",
+            description="The yield curve type.",
+        )
     )
 
 
 class ECBEUYieldCurveData(EUYieldCurveData):
-    """Euro Area Yield Curve Data."""
+    """ECB Yield Curve Data."""
 
-    __alias_dict__ = {
-        "rate": "OBS",
-    }
-
-    @field_validator("OBS", mode="before", check_fields=False)
+    @field_validator("rate", mode="before", check_fields=False)
     @classmethod
-    def value_validate(cls, v):
-        """Validate rate."""
-        try:
-            return float(v)
-        except ValueError:
-            return None
+    def normalize_percent(cls, v):
+        """Normalize percent."""
+        return float(v) / 100 if v else None
 
 
 class ECBEUYieldCurveFetcher(
@@ -44,62 +52,88 @@ class ECBEUYieldCurveFetcher(
         List[ECBEUYieldCurveData],
     ]
 ):
-    """Transform the query, extract and transform the data from the ECB endpoints."""
-
-    data_type = ECBEUYieldCurveData
+    """ECB Yield Curve Fetcher."""
 
     @staticmethod
     def transform_query(params: Dict[str, Any]) -> ECBEUYieldCurveQueryParams:
         """Transform query."""
+        if params.get("date") is None:
+            params["date"] = datetime.now().date()
         return ECBEUYieldCurveQueryParams(**params)
 
     # pylint: disable=unused-argument
     @staticmethod
-    def extract_data(
+    async def aextract_data(
         query: ECBEUYieldCurveQueryParams,
         credentials: Optional[Dict[str, str]],
         **kwargs: Any,
-    ) -> list:
+    ) -> List[Dict]:
         """Extract data."""
-        # Check that the date is in the past
-        today = datetime.today().date()
-        if query.date and query.date >= today:
-            raise ValueError("Date must be in the past")
 
-        if not query.date:
-            date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
-        else:
-            date = query.date.strftime("%Y-%m-%d")
+        results = []
 
-        yield_suffixes = {
-            "spot_rate": "SR_",
-            "instantaneous_forward": "IF_",
-            "par_yield": "PY",
-        }
-        yield_type = f"YC.B.U2.EUR.4F.G_N_{query.rating}.SV_C_YM." + yield_suffixes.get(
-            query.yield_curve_type, ""
+        IDS = get_yield_curve_ids(
+            rating=query.rating,
+            yield_curve_type=query.yield_curve_type,
         )
-        # Add the maturities
-        series_id = [f"{yield_type}{m}M" for m in [3, 6]]
-        series_id += [f"{yield_type}{y}Y" for y in [1, 2, 3, 5, 7, 10, 20, 30]]
+        YIELD_CURVE = IDS["SERIES_IDS"]
+        MATURITIES = IDS["MATURITIES"]
 
-        data = []
+        maturities = list(MATURITIES.keys())
 
-        for id_ in series_id:
-            d = get_series_data(id_, date)
-            maturity = id_.split("_")[-1]
+        BASE_URL = "https://data.ecb.europa.eu/data-detail-api"
 
-            for item in d:
-                item["maturity"] = maturity
+        async def get_one(maturity):
+            """Each maturity is a separate download."""
+            url = f"{BASE_URL}/{YIELD_CURVE[maturity]}"
+            response = await amake_request(url=url, timeout=10)
+            if isinstance(response, List):
+                for item in response:
+                    d = {
+                        "date": item.get("PERIOD"),
+                        "maturity": MATURITIES[maturity],
+                        "rate": item.get("OBS_VALUE_AS_IS"),
+                    }
 
-            data.extend(d)
+                    results.append(d)
 
-        return data
+        tasks = [get_one(maturity) for maturity in maturities]
+
+        await asyncio.gather(*tasks)
+
+        return results
 
     # pylint: disable=unused-argument
     @staticmethod
     def transform_data(
-        query: ECBEUYieldCurveQueryParams, data: list, **kwargs: Any
+        query: ECBEUYieldCurveQueryParams,
+        data: List[Dict],
+        **kwargs: Any,
     ) -> List[ECBEUYieldCurveData]:
         """Transform data."""
-        return [ECBEUYieldCurveData.model_validate(d) for d in data]
+
+        if not data:
+            raise EmptyDataError()
+
+        # Find the nearest date to the requested one.
+        df = DataFrame(data).set_index("date").query("`rate`.notnull()")
+        df.index = to_datetime(df.index)
+        dates = df.index.unique().tolist()
+        date = to_datetime(query.date)
+        nearest_date = min(dates, key=lambda d: abs(d - date)).strftime("%Y-%m-%d")
+        df.index = df.index.astype(str)
+
+        if nearest_date != date.strftime("%Y-%m-%d"):
+            _warn(f"Using nearest date: {nearest_date}")
+
+        df.index = df.index.astype(str)
+        results = (
+            df.filter(like=nearest_date, axis=0)
+            .sort_values("maturity")
+            .reset_index(drop=True)
+        )
+
+        return [
+            ECBEUYieldCurveData.model_validate(d)
+            for d in results.to_dict(orient="records")
+        ]

--- a/openbb_platform/providers/ecb/openbb_ecb/utils/yield_curve_series.py
+++ b/openbb_platform/providers/ecb/openbb_ecb/utils/yield_curve_series.py
@@ -1,0 +1,92 @@
+"""ECB Yield Curve Series IDs"""
+
+from typing import Dict, Literal
+
+RATING_DICT = {"aaa": "A", "all_ratings": "C"}
+
+YIELD_TYPE_DICT = {
+    "spot_rate": "SR",
+    "instantaneous_forward": "IF",
+    "par_yield": "PY",
+}
+
+
+def get_yield_curve_ids(
+    rating: Literal["aaa", "all_ratings"] = "aaa",
+    yield_curve_type: Literal[
+        "spot_rate", "instantaneous_forward", "par_yield"
+    ] = "spot_rate",
+) -> Dict:
+    """Get Yield Curve Series IDs"""
+
+    YIELD_CURVE = {
+        "month_3": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_3M",
+        "month_6": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_6M",
+        "year_1": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_1Y",
+        "year_2": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_2Y",
+        "year_3": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_3Y",
+        "year_4": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_4Y",
+        "year_5": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_5Y",
+        "year_6": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_6Y",
+        "year_7": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_7Y",
+        "year_8": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_8Y",
+        "year_9": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_9Y",
+        "year_10": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_10Y",
+        "year_11": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_11Y",
+        "year_12": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_12Y",
+        "year_13": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_13Y",
+        "year_14": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_14Y",
+        "year_15": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_15Y",
+        "year_16": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_16Y",
+        "year_17": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_17Y",
+        "year_18": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_18Y",
+        "year_19": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_19Y",
+        "year_20": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_20Y",
+        "year_21": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_21Y",
+        "year_22": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_22Y",
+        "year_23": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_23Y",
+        "year_24": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_24Y",
+        "year_25": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_25Y",
+        "year_26": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_26Y",
+        "year_27": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_27Y",
+        "year_28": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_28Y",
+        "year_29": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_29Y",
+        "year_30": f"YC.B.U2.EUR.4F.G_N_{RATING_DICT[rating]}.SV_C_YM.{YIELD_TYPE_DICT[yield_curve_type]}_30Y",
+    }
+
+    MATURITY_VALUES = {
+        "month_3": 0.25,
+        "month_6": 0.5,
+        "year_1": 1,
+        "year_2": 2,
+        "year_3": 3,
+        "year_4": 4,
+        "year_5": 5,
+        "year_6": 6,
+        "year_7": 7,
+        "year_8": 8,
+        "year_9": 9,
+        "year_10": 10,
+        "year_11": 11,
+        "year_12": 12,
+        "year_13": 13,
+        "year_14": 14,
+        "year_15": 15,
+        "year_16": 16,
+        "year_17": 17,
+        "year_18": 18,
+        "year_19": 19,
+        "year_20": 20,
+        "year_21": 21,
+        "year_22": 22,
+        "year_23": 23,
+        "year_24": 24,
+        "year_25": 25,
+        "year_26": 26,
+        "year_27": 27,
+        "year_28": 28,
+        "year_29": 29,
+        "year_30": 30,
+    }
+
+    return dict(SERIES_IDS=YIELD_CURVE, MATURITIES=MATURITY_VALUES)


### PR DESCRIPTION

1. **Why**? (1-3 sentences or a bullet point list):

    - The `date` parameter was not working.
 
    - The request took a really long time to execute.

    - The returned data was not formatted like the US Yield Curve data.

2. **What**? (1-3 sentences or a bullet point list):

    - `date` parameter now works, it will return the nearest date to the user-provided date, defaulting to today.

    - Downloads are now made asynchronously.

    - The format of returned data is now like the US Yield Curve data.

    - Choices for `rating` parameter now have more clarity - "aaa" or "all_ratings".

    - Adds `json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100}`

3. **Impact** (1-2 sentences or a bullet point list):

    - Community provider, does not impact pro.

4. **Testing Done**:

    - Recaptured unit test cassette, updated integration test params.

    - Verified combinations of parameters.

6. **Any other information** (optional)

Before:

```
obb.fixedincome.government.eu_yield_curve(yield_curve_type="par_yield")

OpenBBError: string indices must be integers, not 'str'
```

![Screenshot 2024-02-21 at 10 22 28 AM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/9ccb0bdc-6874-41b7-ae79-b9f394945e2e)


After:

![Screenshot 2024-02-21 at 10 14 20 AM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/0fcaba0f-8986-4ab1-a880-dd47e0e15735)

