### PR TITLE
[BugFix] Remove charting extension env var

### DIFF
--- a/openbb_platform/core/openbb_core/env.py
+++ b/openbb_platform/core/openbb_core/env.py
@@ -43,11 +43,6 @@ class Env(metaclass=SingletonMeta):
         return self.str2bool(self._environ.get("OPENBB_AUTO_BUILD", True))
 
     @property
-    def CHARTING_EXTENSION(self) -> str:
-        """Charting extension: specifies which charting extension to use"""
-        return self._environ.get("OPENBB_CHARTING_EXTENSION", "openbb_charting")
-
-    @property
     def DEBUG_MODE(self) -> bool:
         """Debug mode: enables debug mode"""
         return self.str2bool(self._environ.get("OPENBB_DEBUG_MODE", False))


### PR DESCRIPTION
1. **Why**?:

    - Since the charting extension is now an OBBject extension (and the former ChartingService infra was removed), there is no need to have this env variable anymore.

2. **What**?:

    - Removed the env var handling from the `Env` singleton.

3. **Impact**:

    - No impact - it's not being used anywhere in the code base.

4. **Testing Done**:

    - NA