### PR TITLE
[BugFix] Multiple Symbols Allowed, `etf.info(provider="tmx")`

### DIFF
--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_info.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_info.py
@@ -16,6 +16,8 @@ from pydantic import Field, field_validator
 class TmxEtfInfoQueryParams(EtfInfoQueryParams):
     """TMX ETF Info Query Params"""
 
+    __json_schema_extra__ = {"symbol": ["multiple_items_allowed"]}
+
     use_cache: bool = Field(
         default=True,
         description="Whether to use a cached request. All ETF data comes from a single JSON file that is updated daily."


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Multiple symbols are supported for `etf.info()`

2. **What**? (1-3 sentences or a bullet point list):

    - Adds: `    __json_schema_extra__ = {"symbol": ["multiple_items_allowed"]}`

3. **Impact** (1-2 sentences or a bullet point list):

    - N/A

4. **Testing Done**:

    - Multiple symbols now work.
    - `obb.etf.info("COMM.TO,DISC.TO", provider="tmx")`
