### PR TITLE
[BugFix] Disable Intrinio `InstitutionalOwnership` model

### DIFF
--- a/openbb_platform/extensions/equity/integration/test_equity_api.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_api.py
@@ -503,13 +503,14 @@ def test_equity_ownership_insider_trading(params, headers):
                 "provider": "fmp",
             }
         ),
-        (
-            {
-                "provider": "intrinio",
-                "symbol": "AAPL",
-                "limit": 100,
-            }
-        ),
+        # Disabled due to unreliable Intrinio endpoint
+        # (
+        #     {
+        #         "provider": "intrinio",
+        #         "symbol": "AAPL",
+        #         "limit": 100,
+        #     }
+        # ),
     ],
 )
 @pytest.mark.integration

--- a/openbb_platform/extensions/equity/integration/test_equity_python.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_python.py
@@ -466,13 +466,14 @@ def test_equity_ownership_insider_trading(params, obb):
                 "provider": "fmp",
             }
         ),
-        (
-            {
-                "provider": "intrinio",
-                "symbol": "AAPL",
-                "limit": 100,
-            }
-        ),
+        # Disabled due to unreliable Intrinio endpoint
+        # (
+        #     {
+        #         "provider": "intrinio",
+        #         "symbol": "AAPL",
+        #         "limit": 100,
+        #     }
+        # ),
     ],
 )
 @pytest.mark.integration

--- a/openbb_platform/openbb/package/crypto.py
+++ b/openbb_platform/openbb/package/crypto.py
@@ -58,7 +58,7 @@ class ROUTER_crypto(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CryptoSearch

--- a/openbb_platform/openbb/package/crypto_price.py
+++ b/openbb_platform/openbb/package/crypto_price.py
@@ -82,7 +82,7 @@ class ROUTER_crypto_price(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CryptoHistorical

--- a/openbb_platform/openbb/package/currency.py
+++ b/openbb_platform/openbb/package/currency.py
@@ -72,7 +72,7 @@ class ROUTER_currency(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CurrencyPairs

--- a/openbb_platform/openbb/package/currency_price.py
+++ b/openbb_platform/openbb/package/currency_price.py
@@ -85,7 +85,7 @@ class ROUTER_currency_price(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CurrencyHistorical

--- a/openbb_platform/openbb/package/derivatives_options.py
+++ b/openbb_platform/openbb/package/derivatives_options.py
@@ -53,7 +53,7 @@ class ROUTER_derivatives_options(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         OptionsChains
@@ -209,7 +209,7 @@ class ROUTER_derivatives_options(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         OptionsUnusual

--- a/openbb_platform/openbb/package/economy.py
+++ b/openbb_platform/openbb/package/economy.py
@@ -79,7 +79,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EconomicCalendar
@@ -195,7 +195,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CLI
@@ -313,7 +313,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         ConsumerPriceIndex
@@ -461,7 +461,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         FredRegional
@@ -560,7 +560,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         FredSearch
@@ -730,7 +730,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         FredSeries
@@ -833,7 +833,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         LTIR
@@ -920,7 +920,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         MoneyMeasures
@@ -992,7 +992,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         RiskPremium
@@ -1079,7 +1079,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         STIR
@@ -1168,7 +1168,7 @@ class ROUTER_economy(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         Unemployment

--- a/openbb_platform/openbb/package/economy_gdp.py
+++ b/openbb_platform/openbb/package/economy_gdp.py
@@ -82,7 +82,7 @@ class ROUTER_economy_gdp(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         GdpForecast
@@ -171,7 +171,7 @@ class ROUTER_economy_gdp(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         GdpNominal
@@ -259,7 +259,7 @@ class ROUTER_economy_gdp(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         GdpReal

--- a/openbb_platform/openbb/package/equity.py
+++ b/openbb_platform/openbb/package/equity.py
@@ -99,7 +99,7 @@ class ROUTER_equity(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         MarketSnapshots
@@ -257,7 +257,7 @@ class ROUTER_equity(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityInfo
@@ -470,7 +470,7 @@ class ROUTER_equity(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityScreener
@@ -573,7 +573,7 @@ class ROUTER_equity(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquitySearch

--- a/openbb_platform/openbb/package/equity_calendar.py
+++ b/openbb_platform/openbb/package/equity_calendar.py
@@ -65,7 +65,7 @@ class ROUTER_equity_calendar(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CalendarDividend
@@ -158,7 +158,7 @@ class ROUTER_equity_calendar(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CalendarEarnings
@@ -272,7 +272,7 @@ class ROUTER_equity_calendar(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CalendarIpo
@@ -430,7 +430,7 @@ class ROUTER_equity_calendar(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CalendarSplits

--- a/openbb_platform/openbb/package/equity_compare.py
+++ b/openbb_platform/openbb/package/equity_compare.py
@@ -53,7 +53,7 @@ class ROUTER_equity_compare(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityPeers

--- a/openbb_platform/openbb/package/equity_discovery.py
+++ b/openbb_platform/openbb/package/equity_discovery.py
@@ -61,7 +61,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityActive
@@ -143,7 +143,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityAggressiveSmallCaps
@@ -254,7 +254,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         DiscoveryFilings
@@ -335,7 +335,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityGainers
@@ -417,7 +417,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         GrowthTechEquities
@@ -499,7 +499,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityLosers
@@ -581,7 +581,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityUndervaluedGrowth
@@ -663,7 +663,7 @@ class ROUTER_equity_discovery(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityUndervaluedLargeCaps

--- a/openbb_platform/openbb/package/equity_estimates.py
+++ b/openbb_platform/openbb/package/equity_estimates.py
@@ -74,7 +74,7 @@ class ROUTER_equity_estimates(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         AnalystSearch
@@ -227,7 +227,7 @@ class ROUTER_equity_estimates(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         PriceTargetConsensus
@@ -321,7 +321,7 @@ class ROUTER_equity_estimates(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         AnalystEstimates
@@ -459,7 +459,7 @@ class ROUTER_equity_estimates(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         PriceTarget

--- a/openbb_platform/openbb/package/equity_fundamental.py
+++ b/openbb_platform/openbb/package/equity_fundamental.py
@@ -117,7 +117,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         BalanceSheet
@@ -440,7 +440,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         BalanceSheetGrowth
@@ -625,7 +625,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CashFlowStatement
@@ -856,7 +856,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CashFlowStatementGrowth
@@ -1002,7 +1002,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         HistoricalDividends
@@ -1085,7 +1085,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         HistoricalEmployees
@@ -1195,7 +1195,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CompanyFilings
@@ -1361,7 +1361,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         HistoricalAttributes
@@ -1443,7 +1443,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         HistoricalEps
@@ -1524,7 +1524,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         HistoricalSplits
@@ -1632,7 +1632,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         IncomeStatement
@@ -1963,7 +1963,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         IncomeStatementGrowth
@@ -2095,7 +2095,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         LatestAttributes
@@ -2167,7 +2167,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         KeyExecutives
@@ -2265,7 +2265,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         ExecutiveCompensation
@@ -2372,7 +2372,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         KeyMetrics
@@ -2624,7 +2624,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityValuationMultiples
@@ -2812,7 +2812,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CompanyOverview
@@ -2965,7 +2965,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         FinancialRatios
@@ -3169,7 +3169,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         ReportedFinancials
@@ -3255,7 +3255,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         RevenueGeographic
@@ -3340,7 +3340,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         RevenueBusinessLine
@@ -3419,7 +3419,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SearchAttributes
@@ -3511,7 +3511,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         TrailingDividendYield
@@ -3583,7 +3583,7 @@ class ROUTER_equity_fundamental(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EarningsCallTranscript

--- a/openbb_platform/openbb/package/equity_ownership.py
+++ b/openbb_platform/openbb/package/equity_ownership.py
@@ -70,7 +70,7 @@ class ROUTER_equity_ownership(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         InsiderTrading
@@ -165,7 +165,7 @@ class ROUTER_equity_ownership(Container):
         symbol: Annotated[
             str, OpenBBCustomParameter(description="Symbol to get data for.")
         ],
-        provider: Optional[Literal["fmp", "intrinio"]] = None,
+        provider: Optional[Literal["fmp"]] = None,
         **kwargs
     ) -> OBBject:
         """Get data about institutional ownership for a given company over time.
@@ -174,7 +174,7 @@ class ROUTER_equity_ownership(Container):
         ----------
         symbol : str
             Symbol to get data for.
-        provider : Optional[Literal['fmp', 'intrinio']]
+        provider : Optional[Literal['fmp']]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fmp' if there is
             no default.
@@ -182,21 +182,19 @@ class ROUTER_equity_ownership(Container):
             Include current quarter data. (provider: fmp)
         date : Optional[datetime.date]
             A specific date to get data for. (provider: fmp)
-        limit : Optional[int]
-            The number of data entries to return. (provider: intrinio)
 
         Returns
         -------
         OBBject
             results : List[InstitutionalOwnership]
                 Serializable results.
-            provider : Optional[Literal['fmp', 'intrinio']]
+            provider : Optional[Literal['fmp']]
                 Provider name.
             warnings : Optional[List[Warning_]]
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         InstitutionalOwnership
@@ -273,24 +271,6 @@ class ROUTER_equity_ownership(Container):
             Put-call ratio on the previous reporting date. (provider: fmp)
         put_call_ratio_change : Optional[float]
             Change in the put-call ratio between the current and previous reporting dates. (provider: fmp)
-        name : Optional[str]
-            Name of the institutional owner. (provider: intrinio)
-        value : Optional[float]
-            Value of the institutional owner. (provider: intrinio)
-        amount : Optional[float]
-            Amount of the institutional owner. (provider: intrinio)
-        sole_voting_authority : Optional[float]
-            Sole voting authority of the institutional owner. (provider: intrinio)
-        shared_voting_authority : Optional[float]
-            Shared voting authority of the institutional owner. (provider: intrinio)
-        no_voting_authority : Optional[float]
-            No voting authority of the institutional owner. (provider: intrinio)
-        previous_amount : Optional[float]
-            Previous amount of the institutional owner. (provider: intrinio)
-        amount_change : Optional[float]
-            Amount change of the institutional owner. (provider: intrinio)
-        amount_percent_change : Optional[float]
-            Amount percent change of the institutional owner. (provider: intrinio)
 
         Example
         -------
@@ -305,7 +285,7 @@ class ROUTER_equity_ownership(Container):
                     "provider": self._get_provider(
                         provider,
                         "/equity/ownership/institutional",
-                        ("fmp", "intrinio"),
+                        ("fmp",),
                     )
                 },
                 standard_params={
@@ -359,7 +339,7 @@ class ROUTER_equity_ownership(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityOwnership
@@ -503,7 +483,7 @@ class ROUTER_equity_ownership(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         ShareStatistics

--- a/openbb_platform/openbb/package/equity_price.py
+++ b/openbb_platform/openbb/package/equity_price.py
@@ -103,7 +103,7 @@ class ROUTER_equity_price(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityHistorical
@@ -261,7 +261,7 @@ class ROUTER_equity_price(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityNBBO
@@ -286,7 +286,7 @@ class ROUTER_equity_price(Container):
             The exchange tape. (provider: polygon)
         conditions : Optional[Union[str, List[int], List[str]]]
             A list of condition codes. (provider: polygon)
-        indicators : Optional[List]
+        indicators : Optional[List[int]]
             A list of indicator codes. (provider: polygon)
         sequence_num : Optional[int]
 
@@ -368,7 +368,7 @@ class ROUTER_equity_price(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         PricePerformance
@@ -465,7 +465,7 @@ class ROUTER_equity_price(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityQuote

--- a/openbb_platform/openbb/package/equity_shorts.py
+++ b/openbb_platform/openbb/package/equity_shorts.py
@@ -59,7 +59,7 @@ class ROUTER_equity_shorts(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EquityFTD

--- a/openbb_platform/openbb/package/etf.py
+++ b/openbb_platform/openbb/package/etf.py
@@ -63,7 +63,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfCountries
@@ -130,7 +130,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfEquityExposure
@@ -220,7 +220,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfHistorical
@@ -307,7 +307,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfHoldings
@@ -535,7 +535,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfHoldingsDate
@@ -601,7 +601,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfHoldingsPerformance
@@ -696,7 +696,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfInfo
@@ -857,7 +857,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         PricePerformance
@@ -956,7 +956,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfSearch
@@ -1045,7 +1045,7 @@ class ROUTER_etf(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EtfSectors

--- a/openbb_platform/openbb/package/fixedincome.py
+++ b/openbb_platform/openbb/package/fixedincome.py
@@ -99,7 +99,7 @@ class ROUTER_fixedincome(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SOFR

--- a/openbb_platform/openbb/package/fixedincome_corporate.py
+++ b/openbb_platform/openbb/package/fixedincome_corporate.py
@@ -89,7 +89,7 @@ class ROUTER_fixedincome_corporate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CommercialPaper
@@ -171,7 +171,7 @@ class ROUTER_fixedincome_corporate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         HighQualityMarketCorporateBond
@@ -275,7 +275,7 @@ class ROUTER_fixedincome_corporate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         ICEBofA
@@ -367,7 +367,7 @@ class ROUTER_fixedincome_corporate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         MoodyCorporateBondIndex
@@ -462,7 +462,7 @@ class ROUTER_fixedincome_corporate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SpotRate

--- a/openbb_platform/openbb/package/fixedincome_government.py
+++ b/openbb_platform/openbb/package/fixedincome_government.py
@@ -63,7 +63,7 @@ class ROUTER_fixedincome_government(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         TreasuryRates
@@ -162,7 +162,7 @@ class ROUTER_fixedincome_government(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         USYieldCurve

--- a/openbb_platform/openbb/package/fixedincome_rate.py
+++ b/openbb_platform/openbb/package/fixedincome_rate.py
@@ -76,7 +76,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         AMERIBOR
@@ -161,7 +161,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         DiscountWindowPrimaryCreditRate
@@ -252,7 +252,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         EuropeanCentralBankInterestRates
@@ -337,7 +337,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         FEDFUNDS
@@ -404,7 +404,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         PROJECTIONS
@@ -498,7 +498,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         ESTR
@@ -580,7 +580,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         IORB
@@ -664,7 +664,7 @@ class ROUTER_fixedincome_rate(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SONIA

--- a/openbb_platform/openbb/package/fixedincome_spreads.py
+++ b/openbb_platform/openbb/package/fixedincome_spreads.py
@@ -76,7 +76,7 @@ class ROUTER_fixedincome_spreads(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         TreasuryConstantMaturity
@@ -166,7 +166,7 @@ class ROUTER_fixedincome_spreads(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SelectedTreasuryConstantMaturity
@@ -257,7 +257,7 @@ class ROUTER_fixedincome_spreads(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SelectedTreasuryBill

--- a/openbb_platform/openbb/package/index.py
+++ b/openbb_platform/openbb/package/index.py
@@ -49,7 +49,7 @@ class ROUTER_index(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         AvailableIndices
@@ -120,7 +120,7 @@ class ROUTER_index(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         IndexConstituents
@@ -248,7 +248,7 @@ class ROUTER_index(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         MarketIndices

--- a/openbb_platform/openbb/package/news.py
+++ b/openbb_platform/openbb/package/news.py
@@ -111,7 +111,7 @@ class ROUTER_news(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CompanyNews
@@ -288,7 +288,7 @@ class ROUTER_news(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         WorldNews

--- a/openbb_platform/openbb/package/regulators_sec.py
+++ b/openbb_platform/openbb/package/regulators_sec.py
@@ -55,7 +55,7 @@ class ROUTER_regulators_sec(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         CikMap
@@ -125,7 +125,7 @@ class ROUTER_regulators_sec(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         InstitutionsSearch
@@ -184,7 +184,7 @@ class ROUTER_regulators_sec(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         RssLitigation
@@ -261,12 +261,12 @@ class ROUTER_regulators_sec(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SchemaFiles
         -----------
-        files : Optional[List]
+        files : Optional[List[str]]
             Dictionary of URLs to SEC Schema Files (provider: sec)
 
         Example
@@ -347,7 +347,7 @@ class ROUTER_regulators_sec(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SicSearch
@@ -421,7 +421,7 @@ class ROUTER_regulators_sec(Container):
                 List of warnings.
             chart : Optional[Chart]
                 Chart object.
-            extra: Dict[str, Any]
+            extra : Dict[str, Any]
                 Extra info.
 
         SymbolMap

--- a/openbb_platform/providers/intrinio/openbb_intrinio/__init__.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/__init__.py
@@ -22,9 +22,10 @@ from openbb_intrinio.models.historical_dividends import (
 from openbb_intrinio.models.income_statement import IntrinioIncomeStatementFetcher
 from openbb_intrinio.models.index_historical import IntrinioIndexHistoricalFetcher
 from openbb_intrinio.models.insider_trading import IntrinioInsiderTradingFetcher
-from openbb_intrinio.models.institutional_ownership import (
-    IntrinioInstitutionalOwnershipFetcher,
-)
+
+# from openbb_intrinio.models.institutional_ownership import (
+#     IntrinioInstitutionalOwnershipFetcher,
+# )
 from openbb_intrinio.models.key_metrics import IntrinioKeyMetricsFetcher
 from openbb_intrinio.models.latest_attributes import IntrinioLatestAttributesFetcher
 from openbb_intrinio.models.market_indices import IntrinioMarketIndicesFetcher
@@ -61,7 +62,7 @@ intrinio_provider = Provider(
         "IncomeStatement": IntrinioIncomeStatementFetcher,
         "IndexHistorical": IntrinioIndexHistoricalFetcher,
         "InsiderTrading": IntrinioInsiderTradingFetcher,
-        "InstitutionalOwnership": IntrinioInstitutionalOwnershipFetcher,
+        # "InstitutionalOwnership": IntrinioInstitutionalOwnershipFetcher, # Disabled due to unreliable Intrinio endpoint
         "KeyMetrics": IntrinioKeyMetricsFetcher,
         "LatestAttributes": IntrinioLatestAttributesFetcher,
         "MarketIndices": IntrinioMarketIndicesFetcher,

--- a/openbb_platform/providers/intrinio/tests/test_intrinio_fetchers.py
+++ b/openbb_platform/providers/intrinio/tests/test_intrinio_fetchers.py
@@ -24,9 +24,10 @@ from openbb_intrinio.models.historical_dividends import (
 from openbb_intrinio.models.income_statement import IntrinioIncomeStatementFetcher
 from openbb_intrinio.models.index_historical import IntrinioIndexHistoricalFetcher
 from openbb_intrinio.models.insider_trading import IntrinioInsiderTradingFetcher
-from openbb_intrinio.models.institutional_ownership import (
-    IntrinioInstitutionalOwnershipFetcher,
-)
+
+# from openbb_intrinio.models.institutional_ownership import (
+#     IntrinioInstitutionalOwnershipFetcher,
+# )
 from openbb_intrinio.models.key_metrics import IntrinioKeyMetricsFetcher
 from openbb_intrinio.models.latest_attributes import IntrinioLatestAttributesFetcher
 from openbb_intrinio.models.market_indices import IntrinioMarketIndicesFetcher
@@ -297,13 +298,14 @@ def test_intrinio_insider_trading_fetcher(credentials=test_credentials):
     assert result is None
 
 
-@pytest.mark.record_http
-def test_intrinio_institutional_ownership_fetcher(credentials=test_credentials):
-    params = {"symbol": "AAPL"}
+# Disabled due to unreliable Intrinio endpoint
+# @pytest.mark.record_http
+# def test_intrinio_institutional_ownership_fetcher(credentials=test_credentials):
+#     params = {"symbol": "AAPL"}
 
-    fetcher = IntrinioInstitutionalOwnershipFetcher()
-    result = fetcher.test(params, credentials)
-    assert result is None
+#     fetcher = IntrinioInstitutionalOwnershipFetcher()
+#     result = fetcher.test(params, credentials)
+#     assert result is None
 
 
 @pytest.mark.record_http


### PR DESCRIPTION
# [BugFix] Disable Intrinio `InstitutionalOwnership` model

1. **Why**?

    To disable the Intrinio endpoint because it is unreliable currently.

2. **What**?

    Disables the fetcher in the provider init, tests, and equity API and Python interface tests.

3. **Impact**

    - Minimal
    
    - Impact Analysis breakdown:
        - _UX_ = 1
        - _Performance_ = 0
        - _Compatibility_ = 1
        - _Security_ = 1
        - _Scalability_ = 0
        - _Maintenance_ = 1
        - _Compliance_ = 0
        - _Dependency_ = 1

    - **Total Impact Score** = 5

4. **Testing Done**:

    Tested by checking the `obb.coverage.providers`, `obb.coverage.commands` and the fetcher and unit tests.

6. **Any other information** (optional)

    All static files are updated due to a minor tweak in the package builder. This tweak is adding an extra space after `:` in the `Returns` section.