### PR TITLE
[BugFix] Display EconDB as source for macro

### DIFF
--- a/openbb_terminal/miscellaneous/sources/openbb_default.json
+++ b/openbb_terminal/miscellaneous/sources/openbb_default.json
@@ -527,6 +527,7 @@
     "revenue": ["OECD"],
     "spending": ["OECD"],
     "trust": ["OECD"],
+    "macro": ["EconDB"],
     "treasury": ["FED"],
     "fred": ["FRED"],
     "index": ["YahooFinance"]


### PR DESCRIPTION
Why? (1-3 sentences or a bullet point list):
EconDB should be displayed same as other data sources

What? (1-3 sentences or a bullet point list):
Add EconDB to openbb_default.json 

Impact (1-2 sentences or a bullet point list):
terminal.py economy main screen, associate EconDB source with macro command

Testing Done:
Manually launch terminal application and observe change has desired effect and run several "macro \<args\>" commands.