### PR TITLE
[Enhancement] Slightly Change The Order of intrinio Cash Flow

### DIFF
--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/balance_sheet.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/balance_sheet.py
@@ -1,6 +1,7 @@
 """Intrinio Balance Sheet Model."""
 
 # pylint: disable=unused-argument
+
 import warnings
 from typing import Any, Dict, List, Literal, Optional
 
@@ -482,7 +483,7 @@ class IntrinioBalanceSheetFetcher(
             for sub_item in item["financials"]:
                 field_name = sub_item["data_tag"]["tag"]
                 unit = sub_item["data_tag"].get("unit", "")
-                if unit and "share" not in unit:
+                if unit and len(unit) == 3:
                     units.append(unit)
                 sub_dict[field_name] = (
                     float(sub_item["value"])

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/cash_flow.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/cash_flow.py
@@ -1,6 +1,7 @@
 """Intrinio Cash Flow Statement Model."""
 
 # pylint: disable=unused-argument
+
 import warnings
 from typing import Any, Dict, List, Literal, Optional
 
@@ -89,6 +90,12 @@ class IntrinioCashFlowStatementData(CashFlowStatementData):
         description="The currency in which the balance sheet is reported.",
         default=None,
     )
+    net_income_continuing_operations: Optional[float] = Field(
+        default=None, description="Net Income (Continuing Operations)"
+    )
+    net_income_discontinued_operations: Optional[float] = Field(
+        default=None, description="Net Income (Discontinued Operations)"
+    )
     net_income: Optional[float] = Field(
         default=None, description="Consolidated Net Income."
     )
@@ -118,12 +125,6 @@ class IntrinioCashFlowStatementData(CashFlowStatementData):
     )
     net_cash_from_discontinued_operating_activities: Optional[float] = Field(
         default=None, description="Net Cash from Discontinued Operating Activities"
-    )
-    net_income_continuing_operations: Optional[float] = Field(
-        default=None, description="Net Income (Continuing Operations)"
-    )
-    net_income_discontinued_operations: Optional[float] = Field(
-        default=None, description="Net Income (Discontinued Operations)"
     )
     net_cash_from_operating_activities: Optional[float] = Field(
         default=None, description="Net Cash from Operating Activities"
@@ -220,7 +221,7 @@ class IntrinioCashFlowStatementData(CashFlowStatementData):
 
     @model_validator(mode="before")
     @classmethod
-    def replace_zero(cls, values):  # pylint: disable=no-self-argument
+    def replace_zero(cls, values):
         """Check for zero values and replace with None."""
         return (
             {k: None if v == 0 else v for k, v in values.items()}
@@ -282,10 +283,10 @@ class IntrinioCashFlowStatementFetcher(
             """Return the response."""
             statement_data = await response.json()
             return {
-                "period_ending": statement_data["fundamental"]["end_date"],
-                "fiscal_period": statement_data["fundamental"]["fiscal_period"],
-                "fiscal_year": statement_data["fundamental"]["fiscal_year"],
-                "financials": statement_data["standardized_financials"],
+                "period_ending": statement_data["fundamental"]["end_date"],  # type: ignore
+                "fiscal_period": statement_data["fundamental"]["fiscal_period"],  # type: ignore
+                "fiscal_year": statement_data["fundamental"]["fiscal_year"],  # type: ignore
+                "financials": statement_data["standardized_financials"],  # type: ignore
             }
 
         intrinio_id = f"{query.symbol}-{statement_code}"
@@ -308,7 +309,7 @@ class IntrinioCashFlowStatementFetcher(
 
             for sub_item in item["financials"]:
                 unit = sub_item["data_tag"].get("unit", "")
-                if unit and "share" not in unit:
+                if unit and len(unit) == 3:
                     units.append(unit)
                 field_name = sub_item["data_tag"]["tag"]
                 sub_dict[field_name] = (

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
@@ -1,5 +1,7 @@
 """Intrinio Equity Historical Price Model."""
 
+# pylint: disable = unused-argument
+
 from datetime import datetime, time
 from typing import Any, Dict, List, Literal, Optional
 
@@ -49,9 +51,9 @@ class IntrinioEquityHistoricalQueryParams(EquityHistoricalQueryParams):
     _interval_size: Literal["1m", "5m", "10m", "15m", "30m", "60m", "1h"] = PrivateAttr(
         default=None
     )
-    _frequency: Literal["daily", "weekly", "monthly", "quarterly", "yearly"] = (
-        PrivateAttr(default=None)
-    )
+    _frequency: Literal[
+        "daily", "weekly", "monthly", "quarterly", "yearly"
+    ] = PrivateAttr(default=None)
 
     # pylint: disable=protected-access
     @model_validator(mode="after")
@@ -221,7 +223,6 @@ class IntrinioEquityHistoricalFetcher(
 
         return await amake_requests([url], callback, **kwargs)
 
-    # pylint: disable=unused-argument
     @staticmethod
     def transform_data(
         query: IntrinioEquityHistoricalQueryParams,

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
@@ -51,9 +51,9 @@ class IntrinioEquityHistoricalQueryParams(EquityHistoricalQueryParams):
     _interval_size: Literal["1m", "5m", "10m", "15m", "30m", "60m", "1h"] = PrivateAttr(
         default=None
     )
-    _frequency: Literal[
-        "daily", "weekly", "monthly", "quarterly", "yearly"
-    ] = PrivateAttr(default=None)
+    _frequency: Literal["daily", "weekly", "monthly", "quarterly", "yearly"] = (
+        PrivateAttr(default=None)
+    )
 
     # pylint: disable=protected-access
     @model_validator(mode="after")

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/income_statement.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/income_statement.py
@@ -227,11 +227,11 @@ class IntrinioIncomeStatementData(IncomeStatementData):
     deposits_interest_expense: Optional[float] = Field(
         default=None, description="Deposits interest expense"
     )
-    federal_funds_purchased_and_securities_sold_interest_expense: Optional[
-        float
-    ] = Field(
-        default=None,
-        description="Federal funds purchased and securities sold interest expense",
+    federal_funds_purchased_and_securities_sold_interest_expense: Optional[float] = (
+        Field(
+            default=None,
+            description="Federal funds purchased and securities sold interest expense",
+        )
     )
     other_interest_expense: Optional[float] = Field(
         default=None, description="Other interest expense"

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/income_statement.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/income_statement.py
@@ -1,6 +1,7 @@
 """Intrinio Income Statement Model."""
 
 # pylint: disable=unused-argument
+
 import warnings
 from typing import Any, Dict, List, Literal, Optional
 
@@ -226,11 +227,11 @@ class IntrinioIncomeStatementData(IncomeStatementData):
     deposits_interest_expense: Optional[float] = Field(
         default=None, description="Deposits interest expense"
     )
-    federal_funds_purchased_and_securities_sold_interest_expense: Optional[float] = (
-        Field(
-            default=None,
-            description="Federal funds purchased and securities sold interest expense",
-        )
+    federal_funds_purchased_and_securities_sold_interest_expense: Optional[
+        float
+    ] = Field(
+        default=None,
+        description="Federal funds purchased and securities sold interest expense",
     )
     other_interest_expense: Optional[float] = Field(
         default=None, description="Other interest expense"
@@ -472,7 +473,7 @@ class IntrinioIncomeStatementFetcher(
 
             for sub_item in item["financials"]:
                 unit = sub_item["data_tag"].get("unit", "")
-                if unit and "share" not in unit:
+                if unit and len(unit) == 3:
                     units.append(unit)
                 field_name = sub_item["data_tag"]["tag"]
                 sub_dict[field_name] = (


### PR DESCRIPTION

1. **Why**? (1-3 sentences or a bullet point list):

    - As per @minhhoang1023, we are moving a couple of items in Intrinio's cashflow statement to be on top of Net Income:
      - Net Income Continuing Operations
      - Net Income Discontinued Operations

2. **What**? (1-3 sentences or a bullet point list):

    - Move those in fields up in the model definition.
    - Some linting things.

3. **Impact** (1-2 sentences or a bullet point list):

    - Corrected order of fields, no impact on the operation.

4. **Testing Done**:

Before:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/ef211c6d-cf85-4456-b3c1-afe7a1cce6a2)

After:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/6132cefc-7928-4e29-9b27-6c4ee4267681)
