### PR TITLE
[Bug fix] - Handle multiple items with arbitrary type

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -571,7 +571,9 @@ class MethodDefinition:
                     type_ = MethodDefinition.get_type(field)
                     default = MethodDefinition.get_default(field)
                     extra = MethodDefinition.get_extra(field)
-                    new_type = MethodDefinition.get_expanded_type(field_name, extra)
+                    new_type = MethodDefinition.get_expanded_type(
+                        field_name, type_, extra
+                    )
                     updated_type = type_ if new_type is ... else Union[type_, new_type]
 
                     formatted[field_name] = Parameter(
@@ -782,10 +784,12 @@ class MethodDefinition:
         return code
 
     @classmethod
-    def get_expanded_type(cls, field_name: str, extra: Optional[dict] = None) -> object:
+    def get_expanded_type(
+        cls, field_name: str, type_: type, extra: Optional[dict] = None
+    ) -> object:
         """Expand the original field type."""
         if extra and "multiple_items_allowed" in extra:
-            return List[str]
+            return List[type_]
         return cls.TYPE_EXPANSION.get(field_name, ...)
 
     @classmethod

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -572,7 +572,7 @@ class MethodDefinition:
                     default = MethodDefinition.get_default(field)
                     extra = MethodDefinition.get_extra(field)
                     new_type = MethodDefinition.get_expanded_type(
-                        field_name, type_, extra
+                        field_name, extra, type_
                     )
                     updated_type = type_ if new_type is ... else Union[type_, new_type]
 
@@ -785,11 +785,18 @@ class MethodDefinition:
 
     @classmethod
     def get_expanded_type(
-        cls, field_name: str, type_: type, extra: Optional[dict] = None
+        cls,
+        field_name: str,
+        extra: Optional[dict] = None,
+        original_type: Optional[type] = None,
     ) -> object:
         """Expand the original field type."""
         if extra and "multiple_items_allowed" in extra:
-            return List[type_]
+            if original_type is None:
+                raise ValueError(
+                    "multiple_items_allowed requires the original type to be specified."
+                )
+            return List[original_type]
         return cls.TYPE_EXPANSION.get(field_name, ...)
 
     @classmethod

--- a/openbb_platform/core/openbb_core/app/static/utils/decorators.py
+++ b/openbb_platform/core/openbb_core/app/static/utils/decorators.py
@@ -80,9 +80,9 @@ def exception_handler(func: Callable[P, R]) -> Callable[P, R]:
                 ).with_traceback(tb) from None
 
             # If the error is not a ValidationError, then it is a generic exception
-            type_ = getattr(e, "original", e).__class__.__name__
+            error_type = getattr(e, "original", e).__class__.__name__
             raise OpenBBError(
-                f"\nType -> {type_}\n\nDetail -> {str(e)}"
+                f"\nType -> {error_type}\n\nDetail -> {str(e)}"
             ).with_traceback(tb) from None
 
     return wrapper

--- a/openbb_platform/core/openbb_core/app/static/utils/decorators.py
+++ b/openbb_platform/core/openbb_core/app/static/utils/decorators.py
@@ -80,8 +80,9 @@ def exception_handler(func: Callable[P, R]) -> Callable[P, R]:
                 ).with_traceback(tb) from None
 
             # If the error is not a ValidationError, then it is a generic exception
+            type_ = getattr(e, "original", e).__class__.__name__
             raise OpenBBError(
-                f"\nType -> {e.original.__class__.__name__}\n\nDetail -> {str(e)}"
+                f"\nType -> {type_}\n\nDetail -> {str(e)}"
             ).with_traceback(tb) from None
 
     return wrapper

--- a/openbb_platform/core/openbb_core/app/static/utils/filters.py
+++ b/openbb_platform/core/openbb_core/app/static/utils/filters.py
@@ -29,7 +29,9 @@ def filter_inputs(
                     if field in kwargs.get(p, {}):
                         current = kwargs[p][field]
                         new = (
-                            ",".join(current) if isinstance(current, list) else current
+                            ",".join(map(str, current))
+                            if isinstance(current, list)
+                            else current
                         )
 
                         if provider and provider not in props[PROPERTY]:

--- a/openbb_platform/core/openbb_core/provider/standard_models/spot.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/spot.py
@@ -3,7 +3,7 @@
 from datetime import (
     date as dateType,
 )
-from typing import List, Literal, Optional, Union
+from typing import Optional, Union
 
 from pydantic import Field
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/spot.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/spot.py
@@ -3,7 +3,7 @@
 from datetime import (
     date as dateType,
 )
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from pydantic import Field, field_validator
 
@@ -26,24 +26,13 @@ class SpotRateQueryParams(QueryParams):
         default=None,
         description=QUERY_DESCRIPTIONS.get("end_date", ""),
     )
-    maturity: List[float] = Field(
-        default=[10.0], description="The maturities in years."
+    maturity: Union[float, str] = Field(
+        default="10.0", description="The maturities in years."
     )
     category: List[Literal["par_yield", "spot_rate"]] = Field(
         default=["spot_rate"],
         description="The category.",
     )
-
-    @field_validator("maturity")
-    @classmethod
-    def maturity_validate(cls, v):
-        """Validate maturity."""
-        for i in v:
-            if not isinstance(i, float):
-                raise ValueError("`maturity` must be a float")
-            if not 1 <= i <= 100:
-                raise ValueError("`maturity` must be between 1 and 100")
-        return v
 
 
 class SpotRateData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/spot.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/spot.py
@@ -27,11 +27,12 @@ class SpotRateQueryParams(QueryParams):
         description=QUERY_DESCRIPTIONS.get("end_date", ""),
     )
     maturity: Union[float, str] = Field(
-        default=10.0, description="The maturities in years."
+        default=10.0, description="Maturities in years."
     )
-    category: List[Literal["par_yield", "spot_rate"]] = Field(
-        default=["spot_rate"],
-        description="The category.",
+    category: str = Field(
+        default="spot_rate",
+        description="Rate category. Options: spot_rate, par_yield.",
+        choices=["par_yield", "spot_rate"],
     )
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/spot.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/spot.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import List, Literal, Optional, Union
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -27,7 +27,7 @@ class SpotRateQueryParams(QueryParams):
         description=QUERY_DESCRIPTIONS.get("end_date", ""),
     )
     maturity: Union[float, str] = Field(
-        default="10.0", description="The maturities in years."
+        default=10.0, description="The maturities in years."
     )
     category: List[Literal["par_yield", "spot_rate"]] = Field(
         default=["spot_rate"],

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
@@ -341,7 +341,7 @@ def test_fixedincome_corporate_commercial_paper(params, headers):
                 "start_date": "2023-01-01",
                 "end_date": "2023-06-06",
                 "maturity": [10.0],
-                "category": ["spot_rate"],
+                "category": "spot_rate",
                 "provider": "fred",
             }
         ),
@@ -358,7 +358,7 @@ def test_fixedincome_corporate_commercial_paper(params, headers):
                 "start_date": None,
                 "end_date": None,
                 "maturity": "1,5.5,10",
-                "category": ["spot_rate"],
+                "category": "spot_rate,par_yield",
             }
         ),
     ],

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
@@ -347,12 +347,18 @@ def test_fixedincome_corporate_commercial_paper(params, headers):
         ),
         (
             {
+                "start_date": None,
+                "end_date": None,
                 "maturity": 5.5,
+                "category": ["spot_rate"],
             }
         ),
         (
             {
+                "start_date": None,
+                "end_date": None,
                 "maturity": "1,5.5,10",
+                "category": ["spot_rate"],
             }
         ),
     ],

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
@@ -344,7 +344,17 @@ def test_fixedincome_corporate_commercial_paper(params, headers):
                 "category": ["spot_rate"],
                 "provider": "fred",
             }
-        )
+        ),
+        (
+            {
+                "maturity": 5.5,
+            }
+        ),
+        (
+            {
+                "maturity": "1,5.5,10",
+            }
+        ),
     ],
 )
 @pytest.mark.integration

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
@@ -318,12 +318,18 @@ def test_fixedincome_corporate_commercial_paper(params, obb):
         ),
         (
             {
+                "start_date": None,
+                "end_date": None,
                 "maturity": 5.5,
+                "category": ["spot_rate"],
             }
         ),
         (
             {
+                "start_date": None,
+                "end_date": None,
                 "maturity": "1,5.5,10",
+                "category": ["spot_rate"],
             }
         ),
     ],

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
@@ -312,7 +312,7 @@ def test_fixedincome_corporate_commercial_paper(params, obb):
                 "start_date": "2023-01-01",
                 "end_date": "2023-06-06",
                 "maturity": [10.0],
-                "category": ["spot_rate"],
+                "category": "spot_rate",
                 "provider": "fred",
             }
         ),
@@ -329,7 +329,7 @@ def test_fixedincome_corporate_commercial_paper(params, obb):
                 "start_date": None,
                 "end_date": None,
                 "maturity": "1,5.5,10",
-                "category": ["spot_rate"],
+                "category": "spot_rate,par_yield",
             }
         ),
     ],

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
@@ -315,7 +315,17 @@ def test_fixedincome_corporate_commercial_paper(params, obb):
                 "category": ["spot_rate"],
                 "provider": "fred",
             }
-        )
+        ),
+        (
+            {
+                "maturity": 5.5,
+            }
+        ),
+        (
+            {
+                "maturity": "1,5.5,10",
+            }
+        ),
     ],
 )
 @pytest.mark.integration

--- a/openbb_platform/extensions/tests/utils/helpers.py
+++ b/openbb_platform/extensions/tests/utils/helpers.py
@@ -89,13 +89,13 @@ def list_openbb_extensions() -> Tuple[Set[str], Set[str], Set[str]]:
     obbject_extensions = set()
     entry_points_dict = entry_points()
 
-    for entry_point in entry_points_dict["openbb_core_extension"]:
+    for entry_point in entry_points_dict.get("openbb_core_extension", []):
         core_extensions.add(f"{entry_point.name}")
 
-    for entry_point in entry_points_dict["openbb_provider_extension"]:
+    for entry_point in entry_points_dict.get("openbb_provider_extension", []):
         provider_extensions.add(f"{entry_point.name}")
 
-    for entry_point in entry_points_dict["openbb_obbject_extension"]:
+    for entry_point in entry_points_dict.get("openbb_obbject_extension", []):
         obbject_extensions.add(f"{entry_point.name}")
 
     return core_extensions, provider_extensions, obbject_extensions

--- a/openbb_platform/openbb/package/equity_estimates.py
+++ b/openbb_platform/openbb/package/equity_estimates.py
@@ -401,7 +401,7 @@ class ROUTER_equity_estimates(Container):
     def price_target(
         self,
         symbol: Annotated[
-            Union[str, None, List[str]],
+            Union[str, None, List[Optional[str]]],
             OpenBBCustomParameter(
                 description="Symbol to get data for. Multiple items allowed for provider(s): benzinga."
             ),
@@ -417,7 +417,7 @@ class ROUTER_equity_estimates(Container):
 
         Parameters
         ----------
-        symbol : Union[str, None, List[str]]
+        symbol : Union[str, None, List[Optional[str]]]
             Symbol to get data for. Multiple items allowed for provider(s): benzinga.
         limit : int
             The number of data entries to return.

--- a/openbb_platform/openbb/package/fixedincome_corporate.py
+++ b/openbb_platform/openbb/package/fixedincome_corporate.py
@@ -421,13 +421,15 @@ class ROUTER_fixedincome_corporate(Container):
         maturity: Annotated[
             Union[float, str, List[Union[float, str]]],
             OpenBBCustomParameter(
-                description="The maturities in years. Multiple items allowed for provider(s): fred."
+                description="Maturities in years. Multiple items allowed for provider(s): fred."
             ),
         ] = 10.0,
         category: Annotated[
-            List[Literal["par_yield", "spot_rate"]],
-            OpenBBCustomParameter(description="The category."),
-        ] = ["spot_rate"],
+            Union[str, List[str]],
+            OpenBBCustomParameter(
+                description="Rate category. Options: spot_rate, par_yield. Multiple items allowed for provider(s): fred."
+            ),
+        ] = "spot_rate",
         provider: Optional[Literal["fred"]] = None,
         **kwargs
     ) -> OBBject:
@@ -446,9 +448,9 @@ class ROUTER_fixedincome_corporate(Container):
         end_date : Union[datetime.date, None, str]
             End date of the data, in YYYY-MM-DD format.
         maturity : Union[float, str, List[Union[float, str]]]
-            The maturities in years. Multiple items allowed for provider(s): fred.
-        category : List[Literal['par_yield', 'spot_rate']]
-            The category.
+            Maturities in years. Multiple items allowed for provider(s): fred.
+        category : Union[str, List[str]]
+            Rate category. Options: spot_rate, par_yield. Multiple items allowed for provider(s): fred.
         provider : Optional[Literal['fred']]
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'fred' if there is
@@ -498,6 +500,12 @@ class ROUTER_fixedincome_corporate(Container):
                     "category": category,
                 },
                 extra_params=kwargs,
-                extra_info={"maturity": {"multiple_items_allowed": ["fred"]}},
+                extra_info={
+                    "maturity": {"multiple_items_allowed": ["fred"]},
+                    "category": {
+                        "choices": ["par_yield", "spot_rate"],
+                        "multiple_items_allowed": ["fred"],
+                    },
+                },
             )
         )

--- a/openbb_platform/openbb/package/fixedincome_corporate.py
+++ b/openbb_platform/openbb/package/fixedincome_corporate.py
@@ -423,7 +423,7 @@ class ROUTER_fixedincome_corporate(Container):
             OpenBBCustomParameter(
                 description="The maturities in years. Multiple items allowed for provider(s): fred."
             ),
-        ] = "10.0",
+        ] = 10.0,
         category: Annotated[
             List[Literal["par_yield", "spot_rate"]],
             OpenBBCustomParameter(description="The category."),

--- a/openbb_platform/openbb/package/fixedincome_corporate.py
+++ b/openbb_platform/openbb/package/fixedincome_corporate.py
@@ -419,8 +419,11 @@ class ROUTER_fixedincome_corporate(Container):
             ),
         ] = None,
         maturity: Annotated[
-            List[float], OpenBBCustomParameter(description="The maturities in years.")
-        ] = [10.0],
+            Union[float, str, List[Union[float, str]]],
+            OpenBBCustomParameter(
+                description="The maturities in years. Multiple items allowed for provider(s): fred."
+            ),
+        ] = "10.0",
         category: Annotated[
             List[Literal["par_yield", "spot_rate"]],
             OpenBBCustomParameter(description="The category."),
@@ -442,8 +445,8 @@ class ROUTER_fixedincome_corporate(Container):
             Start date of the data, in YYYY-MM-DD format.
         end_date : Union[datetime.date, None, str]
             End date of the data, in YYYY-MM-DD format.
-        maturity : List[float]
-            The maturities in years.
+        maturity : Union[float, str, List[Union[float, str]]]
+            The maturities in years. Multiple items allowed for provider(s): fred.
         category : List[Literal['par_yield', 'spot_rate']]
             The category.
         provider : Optional[Literal['fred']]
@@ -495,5 +498,6 @@ class ROUTER_fixedincome_corporate(Container):
                     "category": category,
                 },
                 extra_params=kwargs,
+                extra_info={"maturity": {"multiple_items_allowed": ["fred"]}},
             )
         )

--- a/openbb_platform/openbb/package/news.py
+++ b/openbb_platform/openbb/package/news.py
@@ -26,7 +26,7 @@ class ROUTER_news(Container):
     def company(
         self,
         symbol: Annotated[
-            Union[str, None, List[str]],
+            Union[str, None, List[Optional[str]]],
             OpenBBCustomParameter(
                 description="Symbol to get data for. This endpoint will accept multiple symbols separated by commas. Multiple items allowed for provider(s): benzinga, fmp, intrinio, polygon, tiingo, yfinance."
             ),
@@ -56,7 +56,7 @@ class ROUTER_news(Container):
 
         Parameters
         ----------
-        symbol : Union[str, None, List[str]]
+        symbol : Union[str, None, List[Optional[str]]]
             Symbol to get data for. This endpoint will accept multiple symbols separated by commas. Multiple items allowed for provider(s): benzinga, fmp, intrinio, polygon, tiingo, yfinance.
         start_date : Union[datetime.date, None, str]
             Start date of the data, in YYYY-MM-DD format.

--- a/openbb_platform/providers/fred/openbb_fred/models/spot.py
+++ b/openbb_platform/providers/fred/openbb_fred/models/spot.py
@@ -15,7 +15,10 @@ from pydantic import field_validator
 class FREDSpotRateQueryParams(SpotRateQueryParams):
     """FRED Spot Rate Query."""
 
-    __json_schema_extra__ = {"maturity": ["multiple_items_allowed"]}
+    __json_schema_extra__ = {
+        "maturity": ["multiple_items_allowed"],
+        "category": ["multiple_items_allowed"],
+    }
 
 
 class FREDSpotRateData(SpotRateData):
@@ -68,7 +71,7 @@ class FREDSpotRateFetcher(
 
         series = get_spot_series_id(
             maturity=maturity,
-            category=query.category,
+            category=query.category.split(","),
         )
 
         data = []

--- a/openbb_platform/providers/fred/openbb_fred/models/spot.py
+++ b/openbb_platform/providers/fred/openbb_fred/models/spot.py
@@ -1,6 +1,6 @@
 """FRED Spot Rate Model."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from openbb_core.provider.abstract.fetcher import Fetcher
 from openbb_core.provider.standard_models.spot import (

--- a/openbb_platform/providers/fred/openbb_fred/models/spot.py
+++ b/openbb_platform/providers/fred/openbb_fred/models/spot.py
@@ -63,7 +63,7 @@ class FREDSpotRateFetcher(
             if isinstance(query.maturity, str)
             else [query.maturity]
         )
-        if any([m < 1 or m >= 100 for m in maturity]):
+        if any([m < 1 or m > 100 for m in maturity]):
             raise ValueError("Maturity must be between 1 and 100")
 
         series = get_spot_series_id(

--- a/openbb_platform/providers/fred/openbb_fred/models/spot.py
+++ b/openbb_platform/providers/fred/openbb_fred/models/spot.py
@@ -63,7 +63,7 @@ class FREDSpotRateFetcher(
             if isinstance(query.maturity, str)
             else [query.maturity]
         )
-        if all(1 <= m <= 100 for m in maturity):
+        if any(1 > m > 100 for m in maturity):
             raise ValueError("Maturity must be between 1 and 100")
 
         series = get_spot_series_id(

--- a/openbb_platform/providers/fred/openbb_fred/models/spot.py
+++ b/openbb_platform/providers/fred/openbb_fred/models/spot.py
@@ -63,7 +63,7 @@ class FREDSpotRateFetcher(
             if isinstance(query.maturity, str)
             else [query.maturity]
         )
-        if any([m < 1 or m > 100 for m in maturity]):
+        if all(1 <= m <= 100 for m in maturity):
             raise ValueError("Maturity must be between 1 and 100")
 
         series = get_spot_series_id(

--- a/openbb_platform/providers/fred/openbb_fred/utils/fred_helpers.py
+++ b/openbb_platform/providers/fred/openbb_fred/utils/fred_helpers.py
@@ -51,6 +51,16 @@ YIELD_CURVE_SERIES_CORPORATE_PAR = {
 }
 
 
+def comma_to_float_list(v: str) -> List[float]:
+    """Convert comma-separated string to list of floats."""
+    try:
+        return [float(m) for m in v.split(",")]
+    except ValueError as e:
+        raise ValueError(
+            "'maturity' must be a float or a comma-separated string of floats"
+        ) from e
+
+
 def all_cpi_options(harmonized: bool = False) -> List[dict]:
     """Get all CPI options."""
     data = []

--- a/openbb_platform/providers/fred/openbb_fred/utils/fred_helpers.py
+++ b/openbb_platform/providers/fred/openbb_fred/utils/fred_helpers.py
@@ -146,6 +146,7 @@ def get_ice_bofa_series_id(
     units = "index" if type_ == "total_return" else "percent"
 
     for s in series:
+        # pylint: disable=too-many-boolean-expressions
         if (
             s["Type"] == type_
             and s["Units"] == units


### PR DESCRIPTION
1. **Why**?

    - Multiple items only support str type
         - fields with type `str` is converted to `Union[str, List[str]]`
         - fields with type `float/int` should be converted to `Union[float/int, List[float/int]]`


2. **What**?

    - Use `List[<original_type>]` instead of `List[str]`
    - Update `obb.fixedincome.corporate.spot_rates` accordingly
    - Fixes `@handle_exceptions` bug when `original` attribute is not present
    - Removes dangerous default `[10.0]` from `maturity`
    - Removes dangerous default `["spot_rate"]` from `category`
    - Use comma separated string for both `maturity` and `category`
    
3. **Impact**:

    - Arbitrary types allowed for multiple items

4. **Testing Done**:

* Run integration tests added in this PR

Also,
```python
obb.fixedincome.corporate.spot_rates().to_df()
obb.fixedincome.corporate.spot_rates(maturity=["1", 5.5]).to_df()
obb.fixedincome.corporate.spot_rates(maturity="1,5.5").to_df()
obb.fixedincome.corporate.spot_rates(maturity=5.5).to_df()
obb.fixedincome.corporate.spot_rates(category="spot_rate").to_df()
obb.fixedincome.corporate.spot_rates(category="spot_rate,par_yield").to_df()
```