### PR TITLE
[Bugfix] - Lower case validator in standard models

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
@@ -77,7 +77,7 @@ class AnalystEstimatesData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
@@ -1,7 +1,7 @@
 """Analyst Estimates Standard Model."""
 
 from datetime import date as dateType
-from typing import List, Literal, Set, Union
+from typing import List, Literal, Optional, Set, Union
 
 from pydantic import Field, field_validator
 
@@ -24,9 +24,15 @@ class AnalystEstimatesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+    def to_upper(cls, v: str) -> str:
+        """Convert field to uppercase."""
         return v.upper()
+
+    @field_validator("period", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class AnalystEstimatesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/analyst_estimates.py
@@ -78,7 +78,7 @@ class AnalystEstimatesData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)]) if v else None

--- a/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet.py
@@ -26,8 +26,15 @@ class BalanceSheetQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
+        """Convert field to uppercase."""
         return v.upper()
+
+    @field_validator("period", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class BalanceSheetData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet_growth.py
@@ -21,7 +21,7 @@ class BalanceSheetGrowthQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -130,7 +130,7 @@ class BalanceSheetGrowthData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/balance_sheet_growth.py
@@ -22,7 +22,7 @@ class BalanceSheetGrowthQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -131,7 +131,7 @@ class BalanceSheetGrowthData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)]) if v else None

--- a/openbb_platform/core/openbb_core/provider/standard_models/calendar_ipo.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/calendar_ipo.py
@@ -34,7 +34,7 @@ class CalendarIpoQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper() if v else None
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/calendar_ipo.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/calendar_ipo.py
@@ -35,7 +35,7 @@ class CalendarIpoQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper() if v else None
 
     @field_validator("start_date", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/cash_flow.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cash_flow.py
@@ -24,9 +24,15 @@ class CashFlowStatementQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
-        """Convert symbol to uppercase."""
+    def to_upper(cls, v: str):
+        """Convert field to uppercase."""
         return v.upper()
+
+    @field_validator("period", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class CashFlowStatementData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/cash_flow_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cash_flow_growth.py
@@ -21,7 +21,7 @@ class CashFlowStatementGrowthQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -117,7 +117,7 @@ class CashFlowStatementGrowthData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/cash_flow_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cash_flow_growth.py
@@ -22,7 +22,7 @@ class CashFlowStatementGrowthQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -118,7 +118,7 @@ class CashFlowStatementGrowthData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)]) if v else None

--- a/openbb_platform/core/openbb_core/provider/standard_models/cik_map.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cik_map.py
@@ -19,7 +19,7 @@ class CikMapQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/cik_map.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cik_map.py
@@ -20,7 +20,7 @@ class CikMapQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/company_filings.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/company_filings.py
@@ -35,7 +35,7 @@ class CompanyFilingsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/company_filings.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/company_filings.py
@@ -36,7 +36,7 @@ class CompanyFilingsQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)]) if v else None

--- a/openbb_platform/core/openbb_core/provider/standard_models/company_overview.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/company_overview.py
@@ -21,7 +21,7 @@ class CompanyOverviewQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -101,7 +101,7 @@ class CompanyOverviewData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/company_overview.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/company_overview.py
@@ -20,7 +20,7 @@ class CompanyOverviewQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -100,7 +100,7 @@ class CompanyOverviewData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/cp.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/cp.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -38,6 +38,12 @@ class CommercialPaperParams(QueryParams):
         default="aa",
         description="The grade.",
     )
+
+    @field_validator("maturity", "category", "grade", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class CommercialPaperData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/crypto_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/crypto_historical.py
@@ -36,7 +36,7 @@ class CryptoHistoricalQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def validate_symbol(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase and remove '-'."""
+        """Convert field to uppercase and remove '-'."""
         if isinstance(v, str):
             return v.upper().replace("-", "")
         return ",".join([symbol.upper().replace("-", "") for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/currency_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/currency_historical.py
@@ -37,7 +37,7 @@ class CurrencyHistoricalQueryParams(QueryParams):
     def validate_symbol(
         cls, v: Union[str, List[str], Set[str]]
     ):  # pylint: disable=E0213
-        """Convert symbol to uppercase and remove '-'."""
+        """Convert field to uppercase and remove '-'."""
         if isinstance(v, str):
             return v.upper().replace("-", "")
         return ",".join([symbol.upper().replace("-", "") for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/earnings_call_transcript.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/earnings_call_transcript.py
@@ -21,7 +21,7 @@ class EarningsCallTranscriptQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -37,7 +37,7 @@ class EarningsCallTranscriptData(Data):
 
     @field_validator("symbol", mode="before")
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/earnings_call_transcript.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/earnings_call_transcript.py
@@ -22,7 +22,7 @@ class EarningsCallTranscriptQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -38,7 +38,7 @@ class EarningsCallTranscriptData(Data):
     @field_validator("symbol", mode="before")
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/ecb_interest_rates.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/ecb_interest_rates.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -30,6 +30,12 @@ class EuropeanCentralBankInterestRatesParams(QueryParams):
         default="lending",
         description="The type of interest rate.",
     )
+
+    @field_validator("interest_rate_type", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class EuropeanCentralBankInterestRatesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_ftd.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_ftd.py
@@ -23,7 +23,7 @@ class EquityFtdQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_ftd.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_ftd.py
@@ -24,7 +24,7 @@ class EquityFtdQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
@@ -37,7 +37,7 @@ class EquityHistoricalQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("interval", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
@@ -36,9 +36,15 @@ class EquityHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
+
+    @field_validator("interval", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class EquityHistoricalData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_historical.py
@@ -40,12 +40,6 @@ class EquityHistoricalQueryParams(QueryParams):
         """Convert field to uppercase."""
         return v.upper()
 
-    @field_validator("interval", mode="before", check_fields=False)
-    @classmethod
-    def to_lower(cls, v: Optional[str]) -> Optional[str]:
-        """Convert field to lowercase."""
-        return v.lower() if v else v
-
 
 class EquityHistoricalData(Data):
     """Equity Historical Price Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_info.py
@@ -21,7 +21,7 @@ class EquityInfoQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -145,7 +145,7 @@ class EquityInfoData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_info.py
@@ -20,7 +20,7 @@ class EquityInfoQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -144,7 +144,7 @@ class EquityInfoData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_nbbo.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_nbbo.py
@@ -17,7 +17,7 @@ class EquityNBBOQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_nbbo.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_nbbo.py
@@ -16,7 +16,7 @@ class EquityNBBOQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
@@ -16,8 +16,6 @@ from openbb_core.provider.utils.descriptions import (
 class EquityOwnershipQueryParams(QueryParams):
     """Equity Ownership Query."""
 
-    __validator_dict__ = {"check_single": ("symbol",)}
-
     symbol: str = Field(description=QUERY_DESCRIPTIONS.get("symbol", ""))
     date: Optional[dateType] = Field(
         default=None, description=QUERY_DESCRIPTIONS.get("date", "")

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
@@ -33,7 +33,7 @@ class EquityOwnershipQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_ownership.py
@@ -34,7 +34,7 @@ class EquityOwnershipQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_peers.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_peers.py
@@ -17,7 +17,7 @@ class EquityPeersQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_peers.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_peers.py
@@ -16,7 +16,7 @@ class EquityPeersQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_performance.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_performance.py
@@ -1,6 +1,8 @@
 """Equity Performance Standard Model."""
 
-from pydantic import Field
+from typing import Literal, Optional
+
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -10,10 +12,16 @@ from openbb_core.provider.utils.descriptions import DATA_DESCRIPTIONS
 class EquityPerformanceQueryParams(QueryParams):
     """Equity Performance Query."""
 
-    sort: str = Field(
+    sort: Literal["asc", "desc"] = Field(
         default="desc",
         description="Sort order. Possible values: 'asc', 'desc'. Default: 'desc'.",
     )
+
+    @field_validator("sort", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class EquityPerformanceData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_quote.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_quote.py
@@ -24,7 +24,7 @@ class EquityQuoteQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_quote.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_quote.py
@@ -23,7 +23,7 @@ class EquityQuoteQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_screener.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_screener.py
@@ -22,7 +22,7 @@ class EquityScreenerData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_screener.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_screener.py
@@ -21,7 +21,7 @@ class EquityScreenerData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_valuation_multiples.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_valuation_multiples.py
@@ -20,7 +20,7 @@ class EquityValuationMultiplesQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_valuation_multiples.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_valuation_multiples.py
@@ -19,7 +19,7 @@ class EquityValuationMultiplesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/esg_risk_rating.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/esg_risk_rating.py
@@ -20,7 +20,7 @@ class ESGRiskRatingQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -40,7 +40,7 @@ class ESGRiskRatingData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/esg_risk_rating.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/esg_risk_rating.py
@@ -19,7 +19,7 @@ class ESGRiskRatingQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -39,7 +39,7 @@ class ESGRiskRatingData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/esg_score.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/esg_score.py
@@ -24,7 +24,7 @@ class ESGScoreQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -48,7 +48,7 @@ class ESGScoreData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/esg_score.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/esg_score.py
@@ -23,7 +23,7 @@ class ESGScoreQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -47,7 +47,7 @@ class ESGScoreData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_countries.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_countries.py
@@ -15,7 +15,7 @@ class EtfCountriesQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_countries.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_countries.py
@@ -14,7 +14,7 @@ class EtfCountriesQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_equity_exposure.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_equity_exposure.py
@@ -16,7 +16,7 @@ class EtfEquityExposureQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_equity_exposure.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_equity_exposure.py
@@ -17,7 +17,7 @@ class EtfEquityExposureQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_historical.py
@@ -32,7 +32,7 @@ class EtfHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase and remove '-'."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_historical.py
@@ -33,7 +33,7 @@ class EtfHistoricalQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase and remove '-'."""
+        """Convert field to uppercase and remove '-'."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_historical_nav.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_historical_nav.py
@@ -19,7 +19,7 @@ class EtfHistoricalNavQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_historical_nav.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_historical_nav.py
@@ -20,7 +20,7 @@ class EtfHistoricalNavQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_info.py
@@ -20,7 +20,7 @@ class EtfInfoQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_info.py
@@ -19,7 +19,7 @@ class EtfInfoQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_performance.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_performance.py
@@ -1,8 +1,9 @@
 """ETF Performance Standard Model."""
 
 from datetime import date as dateType
+from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -15,7 +16,7 @@ from openbb_core.provider.utils.descriptions import (
 class ETFPerformanceQueryParams(QueryParams):
     """ETF Performance Query."""
 
-    sort: str = Field(
+    sort: Literal["asc", "desc"] = Field(
         default="desc",
         description="Sort order. Possible values: 'asc', 'desc'. Default: 'desc'.",
     )
@@ -23,6 +24,12 @@ class ETFPerformanceQueryParams(QueryParams):
         default=10,
         description=QUERY_DESCRIPTIONS.get("limit", ""),
     )
+
+    @field_validator("sort", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class ETFPerformanceData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_sectors.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_sectors.py
@@ -17,7 +17,7 @@ class EtfSectorsQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_sectors.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_sectors.py
@@ -16,7 +16,7 @@ class EtfSectorsQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/executive_compensation.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/executive_compensation.py
@@ -31,7 +31,7 @@ class ExecutiveCompensationQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -62,7 +62,7 @@ class ExecutiveCompensationData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/executive_compensation.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/executive_compensation.py
@@ -32,7 +32,7 @@ class ExecutiveCompensationQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -63,7 +63,7 @@ class ExecutiveCompensationData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/ffrmc.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/ffrmc.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -30,6 +30,12 @@ class SelectedTreasuryConstantMaturityQueryParams(QueryParams):
         default="10y",
         description="The maturity",
     )
+
+    @field_validator("maturity", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class SelectedTreasuryConstantMaturityData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/financial_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/financial_attributes.py
@@ -3,7 +3,7 @@
 from datetime import date as dateType
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -36,6 +36,12 @@ class FinancialAttributesQueryParams(QueryParams):
     sort: Optional[Literal["asc", "desc"]] = Field(
         default="desc", description="Sort order."
     )
+
+    @field_validator("period", "sort", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class FinancialAttributesData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
@@ -29,6 +29,12 @@ class FinancialRatiosQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("period", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class FinancialRatiosData(Data):
     """Financial Ratios Standard Model."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
@@ -25,7 +25,7 @@ class FinancialRatiosQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/financial_ratios.py
@@ -26,7 +26,7 @@ class FinancialRatiosQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("period", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/form_13FHR.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/form_13FHR.py
@@ -38,7 +38,7 @@ class Form13FHRQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return str(v).upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/form_13FHR.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/form_13FHR.py
@@ -37,7 +37,7 @@ class Form13FHRQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return str(v).upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/form_13FHR.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/form_13FHR.py
@@ -15,8 +15,6 @@ from openbb_core.provider.utils.descriptions import (
 class Form13FHRQueryParams(QueryParams):
     """Form 13F-HR Query."""
 
-    __validator_dict__ = {"check_single": ("symbol")}
-
     symbol: str = Field(
         description=QUERY_DESCRIPTIONS.get("symbol", "")
         + " A CIK or Symbol can be used."

--- a/openbb_platform/core/openbb_core/provider/standard_models/fred_series.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/fred_series.py
@@ -31,7 +31,7 @@ class SeriesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/fred_series.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/fred_series.py
@@ -32,7 +32,7 @@ class SeriesQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_curve.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_curve.py
@@ -25,7 +25,7 @@ class FuturesCurveQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_curve.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_curve.py
@@ -24,7 +24,7 @@ class FuturesCurveQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
@@ -33,7 +33,7 @@ class FuturesHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
@@ -34,7 +34,7 @@ class FuturesHistoricalQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/gdp_forecast.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/gdp_forecast.py
@@ -3,7 +3,7 @@
 from datetime import date as dateType
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -31,6 +31,12 @@ class GdpForecastQueryParams(QueryParams):
         default="real",
         description="Type of GDP to get forecast of. Either nominal or real.",
     )
+
+    @field_validator("period", "type", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class GdpForecastData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/gdp_nominal.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/gdp_nominal.py
@@ -3,7 +3,7 @@
 from datetime import date as dateType
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -27,6 +27,12 @@ class GdpNominalQueryParams(QueryParams):
     end_date: Optional[dateType] = Field(
         default=None, description=QUERY_DESCRIPTIONS.get("end_date")
     )
+
+    @field_validator("units", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class GdpNominalData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/gdp_real.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/gdp_real.py
@@ -3,7 +3,7 @@
 from datetime import date as dateType
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -29,6 +29,12 @@ class GdpRealQueryParams(QueryParams):
     end_date: Optional[dateType] = Field(
         default=None, description=QUERY_DESCRIPTIONS.get("end_date")
     )
+
+    @field_validator("units", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class GdpRealData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
@@ -48,7 +48,7 @@ class HistoricalAttributesQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("frequency", "sort", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
@@ -47,7 +47,7 @@ class HistoricalAttributesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_attributes.py
@@ -51,6 +51,12 @@ class HistoricalAttributesQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("frequency", "sort", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class HistoricalAttributesData(Data):
     """Historical Attributes Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
@@ -25,7 +25,7 @@ class HistoricalDividendsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_dividends.py
@@ -26,7 +26,7 @@ class HistoricalDividendsQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_employees.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_employees.py
@@ -20,7 +20,7 @@ class HistoricalEmployeesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -66,7 +66,7 @@ class HistoricalEmployeesData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_employees.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_employees.py
@@ -21,7 +21,7 @@ class HistoricalEmployeesQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -67,7 +67,7 @@ class HistoricalEmployeesData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_eps.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_eps.py
@@ -22,7 +22,7 @@ class HistoricalEpsQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_eps.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_eps.py
@@ -21,7 +21,7 @@ class HistoricalEpsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_splits.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_splits.py
@@ -20,7 +20,7 @@ class HistoricalSplitsQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/historical_splits.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/historical_splits.py
@@ -19,7 +19,7 @@ class HistoricalSplitsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/hqm.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/hqm.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -26,6 +26,12 @@ class HighQualityMarketCorporateBondQueryParams(QueryParams):
         default="spot",
         description="The yield curve type.",
     )
+
+    @field_validator("yield_curve", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class HighQualityMarketCorporateBondData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/ice_bofa.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/ice_bofa.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -30,6 +30,12 @@ class ICEBofAQueryParams(QueryParams):
         default="yield",
         description="The type of series.",
     )
+
+    @field_validator("index_type", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class ICEBofAData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
@@ -30,6 +30,12 @@ class IncomeStatementQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("period", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class IncomeStatementData(Data):
     """Income Statement Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
@@ -27,7 +27,7 @@ class IncomeStatementQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("period", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement.py
@@ -26,7 +26,7 @@ class IncomeStatementQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
@@ -28,6 +28,12 @@ class IncomeStatementGrowthQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("period", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class IncomeStatementGrowthData(Data):
     """Income Statement Growth Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
@@ -25,7 +25,7 @@ class IncomeStatementGrowthQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("period", mode="before", check_fields=False)
@@ -117,7 +117,7 @@ class IncomeStatementGrowthData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)]) if v else None

--- a/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/income_statement_growth.py
@@ -24,7 +24,7 @@ class IncomeStatementGrowthQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -116,7 +116,7 @@ class IncomeStatementGrowthData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
@@ -42,7 +42,7 @@ class IndexHistoricalQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
@@ -46,6 +46,12 @@ class IndexHistoricalQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("interval", "sort", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class IndexHistoricalData(Data):
     """Index Historical Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
@@ -46,7 +46,7 @@ class IndexHistoricalQueryParams(QueryParams):
         """Convert field to uppercase."""
         return v.upper()
 
-    @field_validator("interval", "sort", mode="before", check_fields=False)
+    @field_validator("sort", mode="before", check_fields=False)
     @classmethod
     def to_lower(cls, v: Optional[str]) -> Optional[str]:
         """Convert field to lowercase."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_historical.py
@@ -43,7 +43,7 @@ class IndexHistoricalQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("interval", "sort", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_info.py
@@ -19,7 +19,7 @@ class IndexInfoQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_info.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_info.py
@@ -20,7 +20,7 @@ class IndexInfoQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_sectors.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_sectors.py
@@ -14,7 +14,7 @@ class IndexSectorsQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/index_sectors.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/index_sectors.py
@@ -15,7 +15,7 @@ class IndexSectorsQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/insider_trading.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/insider_trading.py
@@ -30,7 +30,7 @@ class InsiderTradingQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/insider_trading.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/insider_trading.py
@@ -29,7 +29,7 @@ class InsiderTradingQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/institutional_ownership.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/institutional_ownership.py
@@ -21,7 +21,7 @@ class InstitutionalOwnershipQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -38,7 +38,7 @@ class InstitutionalOwnershipData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/institutional_ownership.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/institutional_ownership.py
@@ -20,7 +20,7 @@ class InstitutionalOwnershipQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -37,7 +37,7 @@ class InstitutionalOwnershipData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/key_executives.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/key_executives.py
@@ -17,7 +17,7 @@ class KeyExecutivesQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/key_executives.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/key_executives.py
@@ -16,7 +16,7 @@ class KeyExecutivesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
@@ -29,6 +29,12 @@ class KeyMetricsQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("period", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class KeyMetricsData(Data):
     """Key Metrics Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
@@ -25,7 +25,7 @@ class KeyMetricsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -51,7 +51,7 @@ class KeyMetricsData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/key_metrics.py
@@ -26,7 +26,7 @@ class KeyMetricsQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("period", mode="before", check_fields=False)
@@ -52,7 +52,7 @@ class KeyMetricsData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)]) if v else None

--- a/openbb_platform/core/openbb_core/provider/standard_models/latest_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/latest_attributes.py
@@ -28,7 +28,7 @@ class LatestAttributesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/latest_attributes.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/latest_attributes.py
@@ -29,7 +29,7 @@ class LatestAttributesQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/lbma_fixing.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/lbma_fixing.py
@@ -36,6 +36,12 @@ class LbmaFixingQueryParams(QueryParams):
         description=QUERY_DESCRIPTIONS.get("end_date", ""),
     )
 
+    @field_validator("asset", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class LbmaFixingData(Data):
     """LBMA Fixing Data.  Historical fixing prices in USD, GBP and EUR."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/market_indices.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/market_indices.py
@@ -31,7 +31,7 @@ class MarketIndicesQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/market_indices.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/market_indices.py
@@ -30,7 +30,7 @@ class MarketIndicesQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/moody.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/moody.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -30,6 +30,12 @@ class MoodyCorporateBondIndexQueryParams(QueryParams):
         default="aaa",
         description="The type of series.",
     )
+
+    @field_validator("index_type", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class MoodyCorporateBondIndexData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/options_chains.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/options_chains.py
@@ -23,7 +23,7 @@ class OptionsChainsQueryParams(QueryParams):
 
     @classmethod
     @field_validator("symbol", mode="before", check_fields=False)
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/options_unusual.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/options_unusual.py
@@ -21,6 +21,7 @@ class OptionsUnusualQueryParams(QueryParams):
     )
 
     @field_validator("symbol", mode="before", check_fields=False)
+    @classmethod
     def upper_symbol(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper() if v else None

--- a/openbb_platform/core/openbb_core/provider/standard_models/options_unusual.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/options_unusual.py
@@ -22,7 +22,7 @@ class OptionsUnusualQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper() if v else None
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/options_unusual.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/options_unusual.py
@@ -23,7 +23,7 @@ class OptionsUnusualQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper() if v else None
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/price_target.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/price_target.py
@@ -30,7 +30,7 @@ class PriceTargetQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper() if v else None
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/price_target.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/price_target.py
@@ -29,7 +29,7 @@ class PriceTargetQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper() if v else None
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/price_target_consensus.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/price_target_consensus.py
@@ -19,7 +19,7 @@ class PriceTargetConsensusQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -43,7 +43,7 @@ class PriceTargetConsensusData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/price_target_consensus.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/price_target_consensus.py
@@ -20,7 +20,7 @@ class PriceTargetConsensusQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -44,7 +44,7 @@ class PriceTargetConsensusData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/recent_performance.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/recent_performance.py
@@ -17,7 +17,7 @@ class RecentPerformanceQueryParams(QueryParams):
     @field_validator("symbol")
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/recent_performance.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/recent_performance.py
@@ -16,7 +16,7 @@ class RecentPerformanceQueryParams(QueryParams):
 
     @field_validator("symbol")
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
@@ -36,7 +36,7 @@ class ReportedFinancialsQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("period", "statement_type", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
@@ -35,7 +35,7 @@ class ReportedFinancialsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/reported_financials.py
@@ -39,6 +39,12 @@ class ReportedFinancialsQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("period", "statement_type", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class ReportedFinancialsData(Data):
     """Reported Financials Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
@@ -26,7 +26,7 @@ class RevenueBusinessLineQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("period", "structure", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
@@ -25,7 +25,7 @@ class RevenueBusinessLineQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_business_line.py
@@ -29,6 +29,12 @@ class RevenueBusinessLineQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("period", "structure", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class RevenueBusinessLineData(Data):
     """Revenue by Business Line Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
@@ -26,7 +26,7 @@ class RevenueGeographicQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
     @field_validator("period", "structure", mode="before", check_fields=False)

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
@@ -29,6 +29,12 @@ class RevenueGeographicQueryParams(QueryParams):
         """Convert symbol to uppercase."""
         return v.upper()
 
+    @field_validator("period", "structure", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class RevenueGeographicData(Data):
     """Revenue by Geographic Segments Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/revenue_geographic.py
@@ -25,7 +25,7 @@ class RevenueGeographicQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str):
+    def to_upper(cls, v: str):
         """Convert symbol to uppercase."""
         return v.upper()
 

--- a/openbb_platform/core/openbb_core/provider/standard_models/share_statistics.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/share_statistics.py
@@ -20,7 +20,7 @@ class ShareStatisticsQueryParams(QueryParams):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: str) -> str:
+    def to_upper(cls, v: str) -> str:
         """Convert symbol to uppercase."""
         return v.upper()
 
@@ -49,7 +49,7 @@ class ShareStatisticsData(Data):
 
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
-    def upper_symbol(cls, v: Union[str, List[str], Set[str]]):
+    def to_upper(cls, v: Union[str, List[str], Set[str]]):
         """Convert symbol to uppercase."""
         if isinstance(v, str):
             return v.upper()

--- a/openbb_platform/core/openbb_core/provider/standard_models/share_statistics.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/share_statistics.py
@@ -21,7 +21,7 @@ class ShareStatisticsQueryParams(QueryParams):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: str) -> str:
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         return v.upper()
 
 
@@ -50,7 +50,7 @@ class ShareStatisticsData(Data):
     @field_validator("symbol", mode="before", check_fields=False)
     @classmethod
     def to_upper(cls, v: Union[str, List[str], Set[str]]):
-        """Convert symbol to uppercase."""
+        """Convert field to uppercase."""
         if isinstance(v, str):
             return v.upper()
         return ",".join([symbol.upper() for symbol in list(v)])

--- a/openbb_platform/core/openbb_core/provider/standard_models/spot.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/spot.py
@@ -45,6 +45,12 @@ class SpotRateQueryParams(QueryParams):
                 raise ValueError("`maturity` must be between 1 and 100")
         return v
 
+    @field_validator("category", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
+
 
 class SpotRateData(Data):
     """Spot Rate Data."""

--- a/openbb_platform/core/openbb_core/provider/standard_models/tbffr.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/tbffr.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -30,6 +30,12 @@ class SelectedTreasuryBillQueryParams(QueryParams):
         default="3m",
         description="The maturity",
     )
+
+    @field_validator("maturity", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class SelectedTreasuryBillData(Data):

--- a/openbb_platform/core/openbb_core/provider/standard_models/tmc.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/tmc.py
@@ -5,7 +5,7 @@ from datetime import (
 )
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -30,6 +30,12 @@ class TreasuryConstantMaturityQueryParams(QueryParams):
         default="3m",
         description="The maturity",
     )
+
+    @field_validator("maturity", mode="before", check_fields=False)
+    @classmethod
+    def to_lower(cls, v: Optional[str]) -> Optional[str]:
+        """Convert field to lowercase."""
+        return v.lower() if v else v
 
 
 class TreasuryConstantMaturityData(Data):


### PR DESCRIPTION
1. **Why**?

    - Allow users to send anycase inputs to case insensitive fields, like `sort: Literal["asc", "desc"]` should support `"Asc"`

2. **What**?

    - Create `to_lower` validator to include standard model fields that can handle this feature
    - Renamed some `upper_symbol` validators to `to_upper` for consistency across files and future use cases besides `symbol`

3. **Impact**:

    - If there are provider models that don't support lower case fields they will break, so I made sure only included literals or obvious non breaking fields like `sort` or `period`

4. **Testing Done**:

    - Unittests

    - Gradually this should be extended to provider fields, but will keep this contained for this PR