### PR TITLE
[BugFix] Fix incomplete argument display when debug mode is off for `ValidationError`

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/utils/decorators.py
+++ b/openbb_platform/core/openbb_core/app/static/utils/decorators.py
@@ -62,7 +62,8 @@ def exception_handler(func: Callable[P, R]) -> Callable[P, R]:
 
                 validation_error = f"{e.error_count()} validations errors in {e.title}"
                 for error in e.errors():
-                    arg_error = f"Arg {error['loc'][0]} ->\n"
+                    arg = ".".join(map(str, error["loc"]))
+                    arg_error = f"Arg {arg} ->\n"
                     error_details = (
                         f"  {error['msg']} "
                         f"[validation_error_type={error['type']}, "


### PR DESCRIPTION
# [BugFix] Fix incomplete argument display when debug mode is off

1. **Why**?

    To provide complete information about the argument when handling `ValidationError` in non-debug mode.

2. **What**?

    Fixes the issue of not showing the complete argument details for `ValidationError` in non-debug mode.

3. **Impact**:

    Minimal (Score = 4)

4. **Testing Done**:

    Tested with various function calls when debug mode is off

5. **Any other information**:

    * Before - ![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/88149434/45929cf0-282d-4db8-96b9-c02a455b0fd9)
    
    * After - ![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/88149434/21345097-19c2-4ebf-8e4b-57f5dc87a26f)

