### PR TITLE
[BugFix] Update Nasdaq Econ Calendar Headers

### DIFF
--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/economic_calendar.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/economic_calendar.py
@@ -12,7 +12,7 @@ from openbb_core.provider.standard_models.economic_calendar import (
     EconomicCalendarData,
     EconomicCalendarQueryParams,
 )
-from openbb_nasdaq.utils.helpers import HEADERS, date_range, remove_html_tags
+from openbb_nasdaq.utils.helpers import IPO_HEADERS, date_range, remove_html_tags
 from pydantic import Field, field_validator
 
 
@@ -107,7 +107,7 @@ class NasdaqEconomicCalendarFetcher(
 
         def get_calendar_data(date: str, data: List[Dict]) -> None:
             url = f"https://api.nasdaq.com/api/calendar/economicevents?date={date}"
-            r = requests.get(url, headers=HEADERS, timeout=5)
+            r = requests.get(url, headers=IPO_HEADERS, timeout=5)
             r_json = r.json()
             if "data" in r_json and "rows" in r_json["data"]:
                 response = r_json["data"]["rows"]


### PR DESCRIPTION

1. **Why**?:

    - While doing some testing in Colab, I noticed the economic calendar from Nasdaq wasn't returning, but all the other calendars are. Locally, was fine, but not on Colab. 

2. **What**? :

    - It was using a different schema for the request headers, changed it to be like the other ones.

3. **Impact** :

    - N/A

4. **Testing Done**:

    - Could only test locally, will not know for certain until a nightly build, but still works locally!
