### PR TITLE
[BugFix] Remove charting extension preference from user settings

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/preferences.py
+++ b/openbb_platform/core/openbb_core/app/model/preferences.py
@@ -13,7 +13,6 @@ class Preferences(BaseModel):
     export_directory: str = str(Path.home() / "OpenBBUserData" / "exports")
     user_styles_directory: str = str(Path.home() / "OpenBBUserData" / "styles" / "user")
     cache_directory: str = str(Path.home() / "OpenBBUserData" / "cache")
-    charting_extension: Literal["openbb_charting"] = "openbb_charting"
     chart_style: Literal["dark", "light"] = "dark"
     plot_enable_pywry: bool = True
     plot_pywry_width: PositiveInt = 1400


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Deprecated user preference.

2. **What**?:

    -  Remove charting extension preference from user settings

3. **Impact**:

    - NA

4. **Testing Done**:

    - Launching the Platform 
    - Checking user preferences
