### PR TITLE
[Enhancement] Sync `reference.json` and Platform function docstring

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -939,11 +939,10 @@ class DocstringGenerator:
     def get_OBBject_description(
         results_type: str,
         providers: Optional[str],
-        target: Literal["docstring", "website"] = "docstring",
     ) -> str:
         """Get the command output description."""
         available_providers = providers or "Optional[str]"
-        indent = 2 if target == "docstring" else 0
+        indent = 2
 
         obbject_description = (
             f"{create_indent(indent)}OBBject\n"
@@ -1358,7 +1357,7 @@ class ReferenceGenerator:
                     # Should be removed if TYPE_EXPANSION is updated to include this
                     field_type = f"Union[{field_type}, List[{field_type}]]"
 
-            default_value = "" if field_info.default is PydanticUndefined else str(field_info.default)  # fmt: skip
+            default_value = "" if field_info.default is PydanticUndefined else field_info.default  # fmt: skip
 
             provider_field_params.append(
                 {
@@ -1371,6 +1370,56 @@ class ReferenceGenerator:
             )
 
         return provider_field_params
+
+    @staticmethod
+    def get_obbject_returns_fields(
+        model: str,
+        providers: str,
+    ) -> List[Dict[str, str]]:
+        """Get the fields of the OBBject returns object for the given standard_model.
+
+        Args
+        ----
+            model (str):
+                Standard model of the returned object.
+            providers (str):
+                Available providers for the model.
+
+        Returns
+        -------
+            List[Dict[str, str]]:
+                List of dictionaries containing the field name, type, description, default
+                and optionality of each field.
+        """
+        obbject_list = [
+            {
+                "name": "results",
+                "type": f"List[{model}]",
+                "description": "Serializable results.",
+            },
+            {
+                "name": "provider",
+                "type": f"Optional[{providers}]",
+                "description": "Provider name.",
+            },
+            {
+                "name": "warnings",
+                "type": "Optional[List[Warning_]]",
+                "description": "List of warnings.",
+            },
+            {
+                "name": "chart",
+                "type": "Optional[Chart]",
+                "description": "Chart object.",
+            },
+            {
+                "name": "extra",
+                "type": "Dict[str, Any]",
+                "description": "Extra info.",
+            },
+        ]
+
+        return obbject_list
 
     @staticmethod
     def get_post_method_parameters_info(
@@ -1429,7 +1478,7 @@ class ReferenceGenerator:
         return parameters_list
 
     @staticmethod
-    def get_post_method_returns_info(docstring: str) -> str:
+    def get_post_method_returns_info(docstring: str) -> List[Dict[str, str]]:
         """Get the returns information for the POST method endpoints.
 
         Parameters
@@ -1439,10 +1488,11 @@ class ReferenceGenerator:
 
         Returns
         -------
-            Dict[str, str]:
-                Dictionary containing the name, type, description of the return value
+            List[Dict[str, str]]:
+                Single element list having a dictionary containing the name, type,
+                description of the return value
         """
-        return_info = ""
+        returns_list = []
 
         # Define a regex pattern to match the Returns section
         # This pattern captures the model name inside "OBBject[]" and its description
@@ -1456,15 +1506,17 @@ class ReferenceGenerator:
             content_inside_brackets = re.search(
                 r"OBBject\[\s*((?:[^\[\]]|\[[^\[\]]*\])*)\s*\]", return_type
             )
-            return_type_content = content_inside_brackets.group(1)  # type: ignore
+            return_type = content_inside_brackets.group(1)  # type: ignore
 
-            return_info = (
-                f"OBBject\n"
-                f"{create_indent(1)}results : {return_type_content}\n"
-                f"{create_indent(2)}{description}"
-            )
+            returns_list = [
+                {
+                    "name": "results",
+                    "type": return_type,
+                    "description": description,
+                }
+            ]
 
-        return return_info
+        return returns_list
 
     @classmethod
     def get_reference_data(cls) -> Dict[str, Dict[str, Any]]:
@@ -1489,7 +1541,7 @@ class ReferenceGenerator:
             # Route method is used to distinguish between GET and POST methods
             route_method = getattr(route, "methods", None)
             # Route endpoint is the callable function
-            route_func = getattr(route, "endpoint", None)
+            route_func = getattr(route, "endpoint", lambda: None)
             # Attribute contains the model and examples info for the endpoint
             openapi_extra = getattr(route, "openapi_extra", {})
             # Standard model is used as the key for the ProviderInterface Map dictionary
@@ -1504,7 +1556,9 @@ class ReferenceGenerator:
             # Add endpoint examples
             examples = openapi_extra.get("examples", [])
             reference[path]["examples"] = cls.get_endpoint_examples(
-                path, route_func, examples  # type: ignore
+                path,
+                route_func,
+                examples,  # type: ignore
             )
             # Add data for the endpoints having a standard model
             if route_method == {"GET"}:
@@ -1548,10 +1602,8 @@ class ReferenceGenerator:
                 # Add endpoint returns data
                 # Currently only OBBject object is returned
                 providers = provider_parameter_fields["type"]
-                reference[path]["returns"]["OBBject"] = (
-                    DocstringGenerator.get_OBBject_description(
-                        standard_model, providers, "website"
-                    )
+                reference[path]["returns"]["OBBject"] = cls.get_obbject_returns_fields(
+                    standard_model, providers
                 )
             # Add data for the endpoints without a standard model (data processing endpoints)
             elif route_method == {"POST"}:

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -926,7 +926,7 @@ class DocstringGenerator:
 
             if "openbb_" in str(_type):
                 _type = (
-                    str(_type).split(".", maxsplit=1)[0]
+                    str(_type).split(".", maxsplit=1)[0].split("openbb_")[0]
                     + str(_type).rsplit(".", maxsplit=1)[-1]
                 )
 

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -19,14 +19,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -65,7 +65,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "49999",
+                    "default": 49999,
                     "optional": true
                 }
             ],
@@ -81,7 +81,7 @@
                     "name": "exchanges",
                     "type": "List[str]",
                     "description": "To limit the query to a subset of exchanges e.g. ['POLONIEX', 'GDAX']",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -96,7 +96,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CryptoHistorical\n        Serializable results.\n    provider : Literal['fmp', 'polygon', 'tiingo', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CryptoHistorical]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'polygon', 'tiingo', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -144,9 +170,9 @@
                 },
                 {
                     "name": "vwap",
-                    "type": "float, Gt(gt=0)",
+                    "type": "Annotated[float, Gt(gt=0)]",
                     "description": "Volume Weighted Average Price over the period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -155,30 +181,30 @@
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change in the price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "polygon": [
                 {
                     "name": "transactions",
-                    "type": "int, Gt(gt=0)",
+                    "type": "Annotated[int, Gt(gt=0)]",
                     "description": "Number of transactions for the symbol in the time period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -187,14 +213,14 @@
                     "name": "transactions",
                     "type": "int",
                     "description": "Number of transactions for the symbol in the time period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_notional",
                     "type": "float",
                     "description": "The last size done for the asset on the specific date in the quote currency. The volume of the asset on the specific date in the quote currency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -215,7 +241,7 @@
                     "name": "query",
                     "type": "str",
                     "description": "Search query.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -229,7 +255,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CryptoSearch\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CryptoSearch]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -244,7 +296,7 @@
                     "name": "name",
                     "type": "str",
                     "description": "Name of the crypto.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -253,21 +305,21 @@
                     "name": "currency",
                     "type": "str",
                     "description": "The currency the crypto trades for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "The exchange code the crypto trades on.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_name",
                     "type": "str",
                     "description": "The short name of the exchange the crypto trades on.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -294,14 +346,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -340,7 +392,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "49999",
+                    "default": 49999,
                     "optional": true
                 }
             ],
@@ -364,7 +416,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CurrencyHistorical\n        Serializable results.\n    provider : Literal['fmp', 'polygon', 'tiingo', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CurrencyHistorical]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'polygon', 'tiingo', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -407,14 +485,14 @@
                     "name": "volume",
                     "type": "float",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "vwap",
-                    "type": "float, Gt(gt=0)",
+                    "type": "Annotated[float, Gt(gt=0)]",
                     "description": "Volume Weighted Average Price over the period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -423,30 +501,30 @@
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change in the price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "polygon": [
                 {
                     "name": "transactions",
-                    "type": "int, Gt(gt=0)",
+                    "type": "Annotated[int, Gt(gt=0)]",
                     "description": "Number of transactions for the symbol in the time period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -479,14 +557,14 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol of the pair to search.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -500,7 +578,7 @@
                     "name": "active",
                     "type": "bool",
                     "description": "Specify if the tickers returned should be actively traded on the queried date.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -519,15 +597,41 @@
                 },
                 {
                     "name": "limit",
-                    "type": "int, Gt(gt=0)",
+                    "type": "Annotated[int, Gt(gt=0)]",
                     "description": "The number of data entries to return.",
-                    "default": "1000",
+                    "default": 1000,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CurrencyPairs\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CurrencyPairs]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -558,14 +662,14 @@
                     "name": "stock_exchange",
                     "type": "str",
                     "description": "Stock exchange of the currency pair.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_short_name",
                     "type": "str",
                     "description": "Short name of the stock exchange of the currency pair.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -611,28 +715,28 @@
                     "name": "currency_symbol",
                     "type": "str",
                     "description": "The symbol of the quote currency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_name",
                     "type": "str",
                     "description": "Name of the quote currency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "base_currency_symbol",
                     "type": "str",
                     "description": "The symbol of the base currency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "base_currency_name",
                     "type": "str",
                     "description": "Name of the base currency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -646,7 +750,7 @@
                     "name": "delisted_utc",
                     "type": "datetime",
                     "description": "The delisted timestamp in UTC.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -680,7 +784,7 @@
                     "name": "counter_currencies",
                     "type": "Union[str, List[str]]",
                     "description": "An optional list of counter currency symbols to filter for. None returns all.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -694,7 +798,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CurrencySnapshots\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CurrencySnapshots]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -723,42 +853,42 @@
                     "name": "open",
                     "type": "float",
                     "description": "The open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "high",
                     "type": "float",
                     "description": "The high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "low",
                     "type": "float",
                     "description": "The low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close",
                     "type": "float",
                     "description": "The close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_close",
                     "type": "float",
                     "description": "The previous close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -767,49 +897,49 @@
                     "name": "change",
                     "type": "float",
                     "description": "The change in the price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "The change in the price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ma50",
                     "type": "float",
                     "description": "The 50-day moving average.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ma200",
                     "type": "float",
                     "description": "The 200-day moving average.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_high",
                     "type": "float",
                     "description": "The 52-week high.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_low",
                     "type": "float",
                     "description": "The 52-week low.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_rate_timestamp",
                     "type": "datetime",
                     "description": "The timestamp of the last rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -845,13 +975,39 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "The end-of-day date for options chains data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : OptionsChains\n        Serializable results.\n    provider : Literal['intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[OptionsChains]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -859,7 +1015,7 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data. Here, it is the underlying symbol for the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -873,7 +1029,7 @@
                     "name": "eod_date",
                     "type": "date",
                     "description": "Date for which the options chains are returned.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -901,259 +1057,259 @@
                     "name": "open_interest",
                     "type": "int",
                     "description": "Open interest on the contract.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "theoretical_price",
                     "type": "float",
                     "description": "Theoretical value of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_trade_price",
                     "type": "float",
                     "description": "Last trade price of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tick",
                     "type": "str",
                     "description": "Whether the last tick was up or down in price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid",
                     "type": "float",
                     "description": "Current bid price for the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid_size",
                     "type": "int",
                     "description": "Bid size for the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask",
                     "type": "float",
                     "description": "Current ask price for the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask_size",
                     "type": "int",
                     "description": "Ask size for the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mark",
                     "type": "float",
                     "description": "The mid-price between the latest bid and ask.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "open",
                     "type": "float",
                     "description": "The open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "open_bid",
                     "type": "float",
                     "description": "The opening bid price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "open_ask",
                     "type": "float",
                     "description": "The opening ask price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "high",
                     "type": "float",
                     "description": "The high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid_high",
                     "type": "float",
                     "description": "The highest bid price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask_high",
                     "type": "float",
                     "description": "The highest ask price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "low",
                     "type": "float",
                     "description": "The low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid_low",
                     "type": "float",
                     "description": "The lowest bid price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask_low",
                     "type": "float",
                     "description": "The lowest ask price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close",
                     "type": "float",
                     "description": "The close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_size",
                     "type": "int",
                     "description": "The closing trade size for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_time",
                     "type": "datetime",
                     "description": "The time of the closing price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_bid",
                     "type": "float",
                     "description": "The closing bid price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_bid_size",
                     "type": "int",
                     "description": "The closing bid size for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_bid_time",
                     "type": "datetime",
                     "description": "The time of the bid closing price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_ask",
                     "type": "float",
                     "description": "The closing ask price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_ask_size",
                     "type": "int",
                     "description": "The closing ask size for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_ask_time",
                     "type": "datetime",
                     "description": "The time of the ask closing price for the option that day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_close",
                     "type": "float",
                     "description": "The previous close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "The change in the price of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change, in normalizezd percentage points, of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "implied_volatility",
                     "type": "float",
                     "description": "Implied volatility of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "delta",
                     "type": "float",
                     "description": "Delta of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gamma",
                     "type": "float",
                     "description": "Gamma of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "theta",
                     "type": "float",
                     "description": "Theta of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "vega",
                     "type": "float",
                     "description": "Vega of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rho",
                     "type": "float",
                     "description": "Rho of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -1162,7 +1318,7 @@
                     "name": "exercise_style",
                     "type": "str",
                     "description": "The exercise style of the option, American or European.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -1182,7 +1338,7 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol to get data for. (the underlying symbol)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1198,49 +1354,49 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format. If no symbol is supplied, requests are only allowed for a single date. Use the start_date for the target date. Intrinio appears to have data beginning Feb/2022, but is unclear when it actually began.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format. If a symbol is not supplied, do not include an end date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "trade_type",
                     "type": "Literal['block', 'sweep', 'large']",
                     "description": "The type of unusual activity to query for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sentiment",
                     "type": "Literal['bullish', 'bearish', 'neutral']",
                     "description": "The sentiment type to query for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "min_value",
                     "type": "Union[float, int]",
                     "description": "The inclusive minimum total value for the unusual activity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "max_value",
                     "type": "Union[float, int]",
                     "description": "The inclusive maximum total value for the unusual activity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return. A typical day for all symbols will yield 50-80K records. The API will paginate at 1000 records. The high default limit (100K) is to be able to reliably capture the most days. The high absolute limit (1.25M) is to allow for outlier days. Queries at the absolute limit will take a long time, and might be unreliable. Apply filters to improve performance.",
-                    "default": "100000",
+                    "default": 100000,
                     "optional": true
                 },
                 {
@@ -1253,7 +1409,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : OptionsUnusual\n        Serializable results.\n    provider : Literal['intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[OptionsUnusual]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -1261,7 +1443,7 @@
                     "name": "underlying_symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data. (the underlying symbol)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1319,7 +1501,7 @@
                     "name": "underlying_price_at_execution",
                     "type": "float",
                     "description": "Price of the underlying security at execution of trade.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1360,21 +1542,21 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "expiration",
                     "type": "str",
                     "description": "Future expiry date with format YYYY-MM",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1396,7 +1578,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : FuturesHistorical\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[FuturesHistorical]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -1467,7 +1675,7 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1481,7 +1689,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : FuturesCurve\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[FuturesCurve]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -1496,7 +1730,7 @@
                     "name": "price",
                     "type": "float",
                     "description": "The close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -1524,14 +1758,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1560,7 +1794,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : GdpForecast\n        Serializable results.\n    provider : Literal['oecd']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[GdpForecast]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['oecd']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -1568,14 +1828,14 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "Nominal GDP value on the date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -1603,14 +1863,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1632,7 +1892,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : GdpNominal\n        Serializable results.\n    provider : Literal['oecd']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[GdpNominal]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['oecd']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -1640,14 +1926,14 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "Nominal GDP value on the date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -1675,14 +1961,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1704,7 +1990,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : GdpReal\n        Serializable results.\n    provider : Literal['oecd']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[GdpReal]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['oecd']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -1712,14 +2024,14 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "Nominal GDP value on the date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -1740,14 +2052,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1764,27 +2076,53 @@
                     "name": "country",
                     "type": "Union[str, List[str]]",
                     "description": "Country of the event. Multiple items allowed for provider(s): tradingeconomics.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "importance",
                     "type": "Literal['Low', 'Medium', 'High']",
                     "description": "Importance of the event.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "group",
                     "type": "Literal['interest rate', 'inflation', 'bonds', 'consumer', 'gdp', 'government', 'housing', 'labour', 'markets', 'money', 'prices', 'trade', 'business']",
                     "description": "Grouping of events",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EconomicCalendar\n        Serializable results.\n    provider : Literal['fmp', 'tradingeconomics']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EconomicCalendar]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'tradingeconomics']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -1792,98 +2130,98 @@
                     "name": "date",
                     "type": "datetime",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "Country of event.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "event",
                     "type": "str",
                     "description": "Event name.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reference",
                     "type": "str",
                     "description": "Abbreviated period for which released data refers to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "source",
                     "type": "str",
                     "description": "Source of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sourceurl",
                     "type": "str",
                     "description": "Source URL.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "actual",
                     "type": "Union[str, float]",
                     "description": "Latest released value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "previous",
                     "type": "Union[str, float]",
                     "description": "Value for the previous period after the revision (if revision is applicable).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "consensus",
                     "type": "Union[str, float]",
                     "description": "Average forecast among a representative group of economists.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "forecast",
                     "type": "Union[str, float]",
                     "description": "Trading Economics projections",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "url",
                     "type": "str",
                     "description": "Trading Economics URL",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "importance",
                     "type": "Union[Literal[0, 1, 2, 3], str]",
                     "description": "Importance of the event. 1-Low, 2-Medium, 3-High",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unit",
                     "type": "str",
                     "description": "Unit of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -1892,28 +2230,28 @@
                     "name": "change",
                     "type": "float",
                     "description": "Value change since previous.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Percentage change since previous.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "updated_at",
                     "type": "datetime",
                     "description": "Last updated timestamp.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "created_at",
                     "type": "datetime",
                     "description": "Created at timestamp.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -1955,21 +2293,21 @@
                     "name": "harmonized",
                     "type": "bool",
                     "description": "Whether you wish to obtain harmonized data.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -1983,7 +2321,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : ConsumerPriceIndex\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[ConsumerPriceIndex]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2019,7 +2383,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : RiskPremium\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[RiskPremium]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2034,21 +2424,21 @@
                     "name": "continent",
                     "type": "str",
                     "description": "Continent of the country.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_equity_risk_premium",
-                    "type": "float, Gt(gt=0)",
+                    "type": "Annotated[float, Gt(gt=0)]",
                     "description": "Total equity risk premium for the country.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country_risk_premium",
-                    "type": "float, Ge(ge=0)",
+                    "type": "Annotated[float, Ge(ge=0)]",
                     "description": "Country-specific risk premium.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2069,7 +2459,7 @@
                     "name": "query",
                     "type": "str",
                     "description": "The search word(s).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2085,69 +2475,95 @@
                     "name": "is_release",
                     "type": "bool",
                     "description": "Is release? If True, other search filter variables are ignored. If no query text or release_id is supplied, this defaults to True.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "release_id",
                     "type": "Union[int, str]",
                     "description": "A specific release ID to target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return. (1-1000)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "offset",
-                    "type": "int, Ge(ge=0)",
+                    "type": "Annotated[int, Ge(ge=0)]",
                     "description": "Offset the results in conjunction with limit.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 },
                 {
                     "name": "filter_variable",
                     "type": "Literal[None, 'frequency', 'units', 'seasonal_adjustment']",
                     "description": "Filter by an attribute.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filter_value",
                     "type": "str",
                     "description": "String value to filter the variable by. Used in conjunction with filter_variable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tag_names",
                     "type": "str",
                     "description": "A semicolon delimited list of tag names that series match all of. Example: 'japan;imports'",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exclude_tag_names",
                     "type": "str",
                     "description": "A semicolon delimited list of tag names that series match none of. Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "series_id",
                     "type": "str",
                     "description": "A FRED Series ID to return series group information for. This returns the required information to query for regional data. Not all series that are in FRED have geographical data. Entering a value for series_id will override all other parameters. Multiple series_ids can be separated by commas.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : FredSearch\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[FredSearch]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2155,112 +2571,112 @@
                     "name": "release_id",
                     "type": "Union[int, str]",
                     "description": "The release ID for queries.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "series_id",
                     "type": "str",
                     "description": "The series ID for the item in the release.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "name",
                     "type": "str",
                     "description": "The name of the release.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "title",
                     "type": "str",
                     "description": "The title of the series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "observation_start",
                     "type": "date",
                     "description": "The date of the first observation in the series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "observation_end",
                     "type": "date",
                     "description": "The date of the last observation in the series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "frequency",
                     "type": "str",
                     "description": "The frequency of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "frequency_short",
                     "type": "str",
                     "description": "Short form of the data frequency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "units",
                     "type": "str",
                     "description": "The units of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "units_short",
                     "type": "str",
                     "description": "Short form of the data units.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "seasonal_adjustment",
                     "type": "str",
                     "description": "The seasonal adjustment of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "seasonal_adjustment_short",
                     "type": "str",
                     "description": "Short form of the data seasonal adjustment.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_updated",
                     "type": "datetime",
                     "description": "The datetime of the last update to the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "notes",
                     "type": "str",
                     "description": "Description of the release.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "press_release",
                     "type": "bool",
                     "description": "If the release is a press release.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "url",
                     "type": "str",
                     "description": "URL to the release.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2269,28 +2685,28 @@
                     "name": "popularity",
                     "type": "int",
                     "description": "Popularity of the series",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "group_popularity",
                     "type": "int",
                     "description": "Group popularity of the release",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "region_type",
                     "type": "str",
                     "description": "The region type of the series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "series_group",
                     "type": "Union[int, str]",
                     "description": "The series group ID of the series. This value is used to query for regional data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -2317,21 +2733,21 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "100000",
+                    "default": 100000,
                     "optional": true
                 },
                 {
@@ -2347,7 +2763,7 @@
                     "name": "frequency",
                     "type": "Literal[None, 'a', 'q', 'm', 'w', 'd', 'wef', 'weth', 'wew', 'wetu', 'wem', 'wesu', 'wesa', 'bwew', 'bwem']",
                     "description": "Frequency aggregation to convert high frequency data to lower frequency.       None = No change       a = Annual       q = Quarterly       m = Monthly       w = Weekly       d = Daily       wef = Weekly, Ending Friday       weth = Weekly, Ending Thursday       wew = Weekly, Ending Wednesday       wetu = Weekly, Ending Tuesday       wem = Weekly, Ending Monday       wesu = Weekly, Ending Sunday       wesa = Weekly, Ending Saturday       bwew = Biweekly, Ending Wednesday       bwem = Biweekly, Ending Monday",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2361,7 +2777,7 @@
                     "name": "transform",
                     "type": "Literal[None, 'chg', 'ch1', 'pch', 'pc1', 'pca', 'cch', 'cca', 'log']",
                     "description": "Transformation type       None = No transformation       chg = Change       ch1 = Change from Year Ago       pch = Percent Change       pc1 = Percent Change from Year Ago       pca = Compounded Annual Rate of Change       cch = Continuously Compounded Rate of Change       cca = Continuously Compounded Annual Rate of Change       log = Natural Log",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2370,20 +2786,46 @@
                     "name": "all_pages",
                     "type": "bool",
                     "description": "Returns all pages of data from the API call at once.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "sleep",
                     "type": "float",
                     "description": "Time to sleep between requests to avoid rate limiting.",
-                    "default": "1.0",
+                    "default": 1.0,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : FredSeries\n        Serializable results.\n    provider : Literal['fred', 'intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[FredSeries]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred', 'intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2401,7 +2843,7 @@
                     "name": "value",
                     "type": "float",
                     "description": "Value of the index.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -2421,21 +2863,21 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adjusted",
                     "type": "bool",
                     "description": "Whether to return seasonally adjusted data.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -2449,7 +2891,33 @@
             "federal_reserve": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : MoneyMeasures\n        Serializable results.\n    provider : Literal['federal_reserve']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[MoneyMeasures]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['federal_reserve']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2478,35 +2946,35 @@
                     "name": "currency",
                     "type": "float",
                     "description": "Value of currency in circulation in billions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "demand_deposits",
                     "type": "float",
                     "description": "Value of demand deposits in billions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "retail_money_market_funds",
                     "type": "float",
                     "description": "Value of retail money market funds in billions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_liquid_deposits",
                     "type": "float",
                     "description": "Value of other liquid deposits in billions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "small_denomination_time_deposits",
                     "type": "float",
                     "description": "Value of small denomination time deposits in billions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2527,14 +2995,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2578,13 +3046,39 @@
                     "name": "seasonal_adjustment",
                     "type": "bool",
                     "description": "Whether to get seasonally adjusted unemployment. Defaults to False.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : Unemployment\n        Serializable results.\n    provider : Literal['oecd']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[Unemployment]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['oecd']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2592,21 +3086,21 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "Unemployment rate (given as a whole number, i.e 10=10%)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "Country for which unemployment rate is given",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2627,14 +3121,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2656,7 +3150,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CLI\n        Serializable results.\n    provider : Literal['oecd']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CLI]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['oecd']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2664,21 +3184,21 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "CLI value",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "Country for which CLI is given",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2699,14 +3219,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2735,7 +3255,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : STIR\n        Serializable results.\n    provider : Literal['oecd']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[STIR]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['oecd']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2743,21 +3289,21 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "Interest rate (given as a whole number, i.e 10=10%)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "Country for which interest rate is given",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2778,14 +3324,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2814,7 +3360,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : LTIR\n        Serializable results.\n    provider : Literal['oecd']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[LTIR]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['oecd']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2822,21 +3394,21 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "Interest rate (given as a whole number, i.e 10=10%)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "Country for which interest rate is given",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -2864,21 +3436,21 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "100000",
+                    "default": 100000,
                     "optional": true
                 },
                 {
@@ -2894,14 +3466,14 @@
                     "name": "is_series_group",
                     "type": "bool",
                     "description": "When True, the symbol provided is for a series_group, else it is for a series ID.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "region_type",
                     "type": "Literal['bea', 'msa', 'frb', 'necta', 'state', 'country', 'county', 'censusregion']",
                     "description": "The type of regional data. Parameter is only valid when `is_series_group` is True.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2915,14 +3487,14 @@
                     "name": "units",
                     "type": "str",
                     "description": "The units of the data. This should match the units returned from searching by series ID. An incorrect field will not necessarily return an error. Parameter is only valid when `is_series_group` is True.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "frequency",
                     "type": "Literal['d', 'w', 'bw', 'm', 'q', 'sa', 'a', 'wef', 'weth', 'wew', 'wetu', 'wem', 'wesu', 'wesa', 'bwew', 'bwem']",
                     "description": "Frequency aggregation to convert high frequency data to lower frequency.     Parameter is only valid when `is_series_group` is True.       a = Annual       sa= Semiannual       q = Quarterly       m = Monthly       w = Weekly       d = Daily       wef = Weekly, Ending Friday       weth = Weekly, Ending Thursday       wew = Weekly, Ending Wednesday       wetu = Weekly, Ending Tuesday       wem = Weekly, Ending Monday       wesu = Weekly, Ending Sunday       wesa = Weekly, Ending Saturday       bwew = Biweekly, Ending Wednesday       bwem = Biweekly, Ending Monday",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -2942,7 +3514,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : FredRegional\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[FredRegional]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -2973,7 +3571,7 @@
                     "name": "value",
                     "type": "Union[float, int]",
                     "description": "The obersvation value. The units are defined in the search results by series ID.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -3000,28 +3598,28 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "100",
+                    "default": 100,
                     "optional": true
                 },
                 {
@@ -3037,27 +3635,53 @@
                     "name": "status",
                     "type": "Literal['upcoming', 'priced', 'withdrawn']",
                     "description": "Status of the IPO. [upcoming, priced, or withdrawn]",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "min_value",
                     "type": "int",
                     "description": "Return IPOs with an offer dollar amount greater than the given amount.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "max_value",
                     "type": "int",
                     "description": "Return IPOs with an offer dollar amount less than the given amount.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CalendarIpo\n        Serializable results.\n    provider : Literal['intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CalendarIpo]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -3065,14 +3689,14 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ipo_date",
                     "type": "date",
                     "description": "The date of the IPO, when the stock first trades on a major exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -3080,141 +3704,141 @@
                 {
                     "name": "status",
                     "type": "Literal['upcoming', 'priced', 'withdrawn']",
-                    "description": "The status of the IPO. Upcoming IPOs have not taken place yet but are expected to.       Priced IPOs have taken place.       Withdrawn IPOs were expected to take place, but were subsequently withdrawn and did not take place",
-                    "default": "None",
+                    "description": "The status of the IPO. Upcoming IPOs have not taken place yet but are expected to. Priced IPOs have taken place. Withdrawn IPOs were expected to take place, but were subsequently withdrawn.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
-                    "description": "The acronym of the stock exchange that the company is going to trade publicly on.       Typically NYSE or NASDAQ.",
-                    "default": "None",
+                    "description": "The acronym of the stock exchange that the company is going to trade publicly on. Typically NYSE or NASDAQ.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "offer_amount",
                     "type": "float",
                     "description": "The total dollar amount of shares offered in the IPO. Typically this is share price * share count",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_price",
                     "type": "float",
                     "description": "The price per share at which the IPO was offered.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_price_lowest",
                     "type": "float",
-                    "description": "The expected lowest price per share at which the IPO will be offered.       Before an IPO is priced, companies typically provide a range of prices per share at which       they expect to offer the IPO (typically available for upcoming IPOs).",
-                    "default": "None",
+                    "description": "The expected lowest price per share at which the IPO will be offered. Before an IPO is priced, companies typically provide a range of prices per share at which they expect to offer the IPO (typically available for upcoming IPOs).",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_price_highest",
                     "type": "float",
-                    "description": "The expected highest price per share at which the IPO will be offered.       Before an IPO is priced, companies typically provide a range of prices per share at which       they expect to offer the IPO (typically available for upcoming IPOs).",
-                    "default": "None",
+                    "description": "The expected highest price per share at which the IPO will be offered. Before an IPO is priced, companies typically provide a range of prices per share at which they expect to offer the IPO (typically available for upcoming IPOs).",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_count",
                     "type": "int",
                     "description": "The number of shares offered in the IPO.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_count_lowest",
                     "type": "int",
-                    "description": "The expected lowest number of shares that will be offered in the IPO. Before an IPO is priced,       companies typically provide a range of shares that they expect to offer in the IPO       (typically available for upcoming IPOs).",
-                    "default": "None",
+                    "description": "The expected lowest number of shares that will be offered in the IPO. Before an IPO is priced, companies typically provide a range of shares that they expect to offer in the IPO (typically available for upcoming IPOs).",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_count_highest",
                     "type": "int",
-                    "description": "The expected highest number of shares that will be offered in the IPO. Before an IPO is priced,       companies typically provide a range of shares that they expect to offer in the IPO       (typically available for upcoming IPOs).",
-                    "default": "None",
+                    "description": "The expected highest number of shares that will be offered in the IPO. Before an IPO is priced, companies typically provide a range of shares that they expect to offer in the IPO (typically available for upcoming IPOs).",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "announcement_url",
                     "type": "str",
                     "description": "The URL to the company's announcement of the IPO",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sec_report_url",
                     "type": "str",
-                    "description": "The URL to the company's S-1, S-1/A, F-1, or F-1/A SEC filing,       which is required to be filed before an IPO takes place.",
-                    "default": "None",
+                    "description": "The URL to the company's S-1, S-1/A, F-1, or F-1/A SEC filing, which is required to be filed before an IPO takes place.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "open_price",
                     "type": "float",
                     "description": "The opening price at the beginning of the first trading day (only available for priced IPOs).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_price",
                     "type": "float",
                     "description": "The closing price at the end of the first trading day (only available for priced IPOs).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The volume at the end of the first trading day (only available for priced IPOs).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "day_change",
                     "type": "float",
-                    "description": "The percentage change between the open price and the close price on the first trading day       (only available for priced IPOs).",
-                    "default": "None",
+                    "description": "The percentage change between the open price and the close price on the first trading day (only available for priced IPOs).",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "week_change",
                     "type": "float",
-                    "description": "The percentage change between the open price on the first trading day and the close price approximately       a week after the first trading day (only available for priced IPOs).",
-                    "default": "None",
+                    "description": "The percentage change between the open price on the first trading day and the close price approximately a week after the first trading day (only available for priced IPOs).",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "month_change",
                     "type": "float",
-                    "description": "The percentage change between the open price on the first trading day and the close price approximately       a month after the first trading day (only available for priced IPOs).",
-                    "default": "None",
+                    "description": "The percentage change between the open price on the first trading day and the close price approximately a month after the first trading day (only available for priced IPOs).",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "id",
                     "type": "str",
                     "description": "The Intrinio ID of the IPO.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "company",
-                    "type": "openbb_intrinio.utils.references.IntrinioCompany",
+                    "type": "IntrinioCompany",
                     "description": "The company that is going public via the IPO.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "security",
-                    "type": "openbb_intrinio.utils.references.IntrinioSecurity",
+                    "type": "IntrinioSecurity",
                     "description": "The primary Security for the Company that is going public via the IPO",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -3234,14 +3858,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -3255,7 +3879,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CalendarDividend\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CalendarDividend]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -3277,35 +3927,35 @@
                     "name": "amount",
                     "type": "float",
                     "description": "The dividend amount per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "name",
                     "type": "str",
                     "description": "Name of the entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "record_date",
                     "type": "date",
                     "description": "The record date of ownership for eligibility.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payment_date",
                     "type": "date",
                     "description": "The payment date of the dividend.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "declaration_date",
                     "type": "date",
                     "description": "Declaration date of the dividend.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -3314,14 +3964,14 @@
                     "name": "adjusted_amount",
                     "type": "float",
                     "description": "The adjusted-dividend amount.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "label",
                     "type": "str",
                     "description": "Ex-dividend date formatted for display.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -3341,14 +3991,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -3362,7 +4012,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CalendarSplits\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CalendarSplits]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -3419,14 +4095,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -3440,7 +4116,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CalendarEarnings\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CalendarEarnings]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -3462,21 +4164,21 @@
                     "name": "name",
                     "type": "str",
                     "description": "Name of the entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps_previous",
                     "type": "float",
                     "description": "The earnings-per-share from the same previously reported period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps_consensus",
                     "type": "float",
                     "description": "The analyst conesus earnings-per-share estimate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -3485,42 +4187,42 @@
                     "name": "eps_actual",
                     "type": "float",
                     "description": "The actual earnings per share announced.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue_actual",
                     "type": "float",
                     "description": "The actual reported revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue_consensus",
                     "type": "float",
                     "description": "The revenue forecast consensus.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_ending",
                     "type": "date",
                     "description": "The fiscal period end date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reporting_time",
                     "type": "str",
                     "description": "The reporting time - e.g. after market close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "updated_date",
                     "type": "date",
                     "description": "The date the data was updated last.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -3554,7 +4256,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityPeers\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityPeers]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -3583,14 +4311,14 @@
                     "name": "symbol",
                     "type": "Union[str, List[str]]",
                     "description": "Symbol to get data for. Multiple items allowed for provider(s): benzinga.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "200",
+                    "default": 200,
                     "optional": true
                 },
                 {
@@ -3606,70 +4334,70 @@
                     "name": "page",
                     "type": "int",
                     "description": "Page offset. For optimization, performance and technical reasons, page offsets are limited from 0 - 100000. Limit the query results by other parameters such as date. Used in conjunction with the limit and date parameters.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 },
                 {
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "Date for calendar data, shorthand for date_from and date_to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "updated",
                     "type": "Union[date, int]",
                     "description": "Records last Updated Unix timestamp (UTC). This will force the sort order to be Greater Than or Equal to the timestamp indicated. The date can be a date string or a Unix timestamp. The date string must be in the format of YYYY-MM-DD.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "importance",
                     "type": "int",
                     "description": "Importance level to filter by. Uses Greater Than or Equal To the importance indicated",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "action",
                     "type": "Literal['downgrades', 'maintains', 'reinstates', 'reiterates', 'upgrades', 'assumes', 'initiates', 'terminates', 'removes', 'suspends', 'firm_dissolved']",
                     "description": "Filter by a specific action_company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "analyst_ids",
                     "type": "Union[str, List[str]]",
                     "description": "Comma-separated list of analyst (person) IDs. Omitting will bring back all available analysts.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "firm_ids",
                     "type": "Union[str, List[str]]",
                     "description": "Comma-separated list of firm IDs.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fields",
                     "type": "Union[str, List[str]]",
                     "description": "Comma-separated list of fields to include in the response. See https://docs.benzinga.io/benzinga-apis/calendar/get-ratings to learn about the available fields.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -3678,13 +4406,39 @@
                     "name": "with_grade",
                     "type": "bool",
                     "description": "Include upgrades and downgrades in the response.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : PriceTarget\n        Serializable results.\n    provider : Literal['benzinga', 'fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[PriceTarget]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['benzinga', 'fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -3699,7 +4453,7 @@
                     "name": "published_time",
                     "type": "datetime.time",
                     "description": "Time of the original rating, UTC.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -3713,91 +4467,91 @@
                     "name": "exchange",
                     "type": "str",
                     "description": "Exchange where the company is traded.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "company_name",
                     "type": "str",
                     "description": "Name of company that is the subject of rating.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "analyst_name",
                     "type": "str",
                     "description": "Analyst name.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "analyst_firm",
                     "type": "str",
                     "description": "Name of the analyst firm that published the price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency the data is denominated in.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_target",
                     "type": "float",
                     "description": "The current price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_price_target",
                     "type": "float",
                     "description": "Adjusted price target for splits and stock dividends.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_target_previous",
                     "type": "float",
                     "description": "Previous price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "previous_adj_price_target",
                     "type": "float",
                     "description": "Previous adjusted price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_when_posted",
                     "type": "float",
                     "description": "Price when posted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rating_current",
                     "type": "str",
                     "description": "The analyst's rating for the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rating_previous",
                     "type": "str",
                     "description": "Previous analyst rating for the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "action",
                     "type": "str",
                     "description": "Description of the change in rating from firm's last rating.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -3806,56 +4560,56 @@
                     "name": "action_change",
                     "type": "Literal['Announces', 'Maintains', 'Lowers', 'Raises', 'Removes', 'Adjusts']",
                     "description": "Description of the change in price target from firm's last price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "importance",
                     "type": "Literal[0, 1, 2, 3, 4, 5]",
                     "description": "Subjective Basis of How Important Event is to Market. 5 = High",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "notes",
                     "type": "str",
                     "description": "Notes of the price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "analyst_id",
                     "type": "str",
                     "description": "Id of the analyst.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "url_news",
                     "type": "str",
                     "description": "URL for analyst ratings news articles for this ticker on Benzinga.com.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "url_analyst",
                     "type": "str",
                     "description": "URL for analyst ratings page for this ticker on Benzinga.com.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "id",
                     "type": "str",
                     "description": "Unique ID of this entry.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_updated",
                     "type": "datetime",
                     "description": "Last updated timestamp, UTC.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -3864,28 +4618,28 @@
                     "name": "news_url",
                     "type": "str",
                     "description": "News URL of the price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "news_title",
                     "type": "str",
                     "description": "News title of the price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "news_publisher",
                     "type": "str",
                     "description": "News publisher of the price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "news_base_url",
                     "type": "str",
                     "description": "News base URL of the price target.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -3919,7 +4673,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "30",
+                    "default": 30,
                     "optional": true
                 },
                 {
@@ -3933,7 +4687,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : AnalystEstimates\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[AnalystEstimates]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -4124,7 +4904,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : PriceTargetConsensus\n        Serializable results.\n    provider : Literal['fmp', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[PriceTargetConsensus]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -4139,28 +4945,28 @@
                     "name": "target_high",
                     "type": "float",
                     "description": "High target of the price target consensus.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "target_low",
                     "type": "float",
                     "description": "Low target of the price target consensus.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "target_consensus",
                     "type": "float",
                     "description": "Consensus target of the price target consensus.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "target_median",
                     "type": "float",
                     "description": "Median target of the price target consensus.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -4170,35 +4976,35 @@
                     "name": "recommendation",
                     "type": "str",
                     "description": "Recommendation - buy, sell, etc.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "recommendation_mean",
                     "type": "float",
                     "description": "Mean recommendation score where 1 is strong buy and 5 is strong sell.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "number_of_analysts",
                     "type": "int",
                     "description": "Number of analysts providing opinions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_price",
                     "type": "float",
                     "description": "Current price of the stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency the stock is priced in.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -4218,14 +5024,14 @@
                     "name": "analyst_name",
                     "type": "str",
                     "description": "A comma separated list of analyst names to bring back. Omitting will bring back all available analysts.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "firm_name",
                     "type": "str",
                     "description": "A comma separated list of firm names to bring back. Omitting will bring back all available firms.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -4241,41 +5047,67 @@
                     "name": "analyst_ids",
                     "type": "Union[str, List[str]]",
                     "description": "A comma separated list of analyst IDs to bring back.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "firm_ids",
                     "type": "Union[str, List[str]]",
                     "description": "A comma separated list of firm IDs to bring back.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "Number of results returned. Limit 1000.",
-                    "default": "100",
+                    "default": 100,
                     "optional": true
                 },
                 {
                     "name": "page",
                     "type": "int",
                     "description": "Page offset. For optimization, performance and technical reasons, page offsets are limited from 0 - 100000. Limit the query results by other parameters such as date.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 },
                 {
                     "name": "fields",
                     "type": "Union[str, List[str]]",
                     "description": "Comma-separated list of fields to include in the response. See https://docs.benzinga.io/benzinga-apis/calendar/get-ratings to learn about the available fields.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : AnalystSearch\n        Serializable results.\n    provider : Literal['benzinga']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[AnalystSearch]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['benzinga']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -4283,28 +5115,28 @@
                     "name": "last_updated",
                     "type": "datetime",
                     "description": "Date of the last update.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "firm_name",
                     "type": "str",
                     "description": "Firm name of the analyst.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "name_first",
                     "type": "str",
                     "description": "Analyst first name.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "name_last",
                     "type": "str",
                     "description": "Analyst last name.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -4320,273 +5152,273 @@
                     "name": "analyst_id",
                     "type": "str",
                     "description": "ID of the analyst.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "firm_id",
                     "type": "str",
                     "description": "ID of the analyst firm.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "smart_score",
                     "type": "float",
                     "description": "A weighted average of the total_ratings_percentile, overall_avg_return_percentile, and overall_success_rate",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "overall_success_rate",
                     "type": "float",
                     "description": "The percentage (normalized) of gain/loss ratings that resulted in a gain overall.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "overall_avg_return_percentile",
                     "type": "float",
                     "description": "The percentile (normalized) of this analyst's overall average return per rating in comparison to other analysts' overall average returns per rating.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_ratings_percentile",
                     "type": "float",
                     "description": "The percentile (normalized) of this analyst's total number of ratings in comparison to the total number of ratings published by all other analysts",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_ratings",
                     "type": "int",
                     "description": "Number of recommendations made by this analyst.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "overall_gain_count",
                     "type": "int",
                     "description": "The number of ratings that have gained value since the date of recommendation",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "overall_loss_count",
                     "type": "int",
                     "description": "The number of ratings that have lost value since the date of recommendation",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "overall_average_return",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating since the date of recommendation",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "overall_std_dev",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings since the date of recommendation",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gain_count_1m",
                     "type": "int",
                     "description": "The number of ratings that have gained value over the last month",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loss_count_1m",
                     "type": "int",
                     "description": "The number of ratings that have lost value over the last month",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_return_1m",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating over the last month",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "std_dev_1m",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last month",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gain_count_3m",
                     "type": "int",
                     "description": "The number of ratings that have gained value over the last 3 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loss_count_3m",
                     "type": "int",
                     "description": "The number of ratings that have lost value over the last 3 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_return_3m",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating over the last 3 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "std_dev_3m",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 3 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gain_count_6m",
                     "type": "int",
                     "description": "The number of ratings that have gained value over the last 6 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loss_count_6m",
                     "type": "int",
                     "description": "The number of ratings that have lost value over the last 6 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_return_6m",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating over the last 6 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "std_dev_6m",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 6 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gain_count_9m",
                     "type": "int",
                     "description": "The number of ratings that have gained value over the last 9 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loss_count_9m",
                     "type": "int",
                     "description": "The number of ratings that have lost value over the last 9 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_return_9m",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating over the last 9 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "std_dev_9m",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 9 months",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gain_count_1y",
                     "type": "int",
                     "description": "The number of ratings that have gained value over the last 1 year",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loss_count_1y",
                     "type": "int",
                     "description": "The number of ratings that have lost value over the last 1 year",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_return_1y",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating over the last 1 year",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "std_dev_1y",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 1 year",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gain_count_2y",
                     "type": "int",
                     "description": "The number of ratings that have gained value over the last 2 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loss_count_2y",
                     "type": "int",
                     "description": "The number of ratings that have lost value over the last 2 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_return_2y",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating over the last 2 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "std_dev_2y",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 2 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gain_count_3y",
                     "type": "int",
                     "description": "The number of ratings that have gained value over the last 3 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loss_count_3y",
                     "type": "int",
                     "description": "The number of ratings that have lost value over the last 3 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_return_3y",
                     "type": "float",
                     "description": "The average percent (normalized) price difference per rating over the last 3 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "std_dev_3y",
                     "type": "float",
                     "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 3 years",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -4620,7 +5452,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityGainers\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityGainers]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -4686,7 +5544,7 @@
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "PE Ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -4720,7 +5578,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityLosers\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityLosers]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -4786,7 +5670,7 @@
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "PE Ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -4820,7 +5704,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityActive\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityActive]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -4886,7 +5796,7 @@
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "PE Ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -4920,7 +5830,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityUndervaluedLargeCaps\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityUndervaluedLargeCaps]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -4972,21 +5908,21 @@
                     "name": "market_cap",
                     "type": "float",
                     "description": "Market Cap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "avg_volume_3_months",
                     "type": "float",
                     "description": "Average volume over the last 3 months in millions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "PE Ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -5020,7 +5956,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityUndervaluedGrowth\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityUndervaluedGrowth]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -5072,21 +6034,21 @@
                     "name": "market_cap",
                     "type": "float",
                     "description": "Market Cap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "avg_volume_3_months",
                     "type": "float",
                     "description": "Average volume over the last 3 months in millions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "PE Ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -5120,7 +6082,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityAggressiveSmallCaps\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityAggressiveSmallCaps]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -5172,21 +6160,21 @@
                     "name": "market_cap",
                     "type": "float",
                     "description": "Market Cap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "avg_volume_3_months",
                     "type": "float",
                     "description": "Average volume over the last 3 months in millions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "PE Ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -5220,7 +6208,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : GrowthTechEquities\n        Serializable results.\n    provider : Literal['yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[GrowthTechEquities]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -5272,21 +6286,21 @@
                     "name": "market_cap",
                     "type": "float",
                     "description": "Market Cap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "avg_volume_3_months",
                     "type": "float",
                     "description": "Average volume over the last 3 months in millions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "PE Ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -5306,28 +6320,28 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "form_type",
                     "type": "str",
                     "description": "Filter by form type. Visit https://www.sec.gov/forms for a list of supported form types.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "100",
+                    "default": 100,
                     "optional": true
                 },
                 {
@@ -5343,13 +6357,39 @@
                     "name": "is_done",
                     "type": "bool",
                     "description": "Flag for whether or not the filing is done.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : DiscoveryFilings\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[DiscoveryFilings]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -5427,7 +6467,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityValuationMultiples\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityValuationMultiples]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -5442,420 +6508,420 @@
                     "name": "revenue_per_share_ttm",
                     "type": "float",
                     "description": "Revenue per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_per_share_ttm",
                     "type": "float",
                     "description": "Net income per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_cash_flow_per_share_ttm",
                     "type": "float",
                     "description": "Operating cash flow per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_per_share_ttm",
                     "type": "float",
                     "description": "Free cash flow per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_per_share_ttm",
                     "type": "float",
                     "description": "Cash per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "book_value_per_share_ttm",
                     "type": "float",
                     "description": "Book value per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tangible_book_value_per_share_ttm",
                     "type": "float",
                     "description": "Tangible book value per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shareholders_equity_per_share_ttm",
                     "type": "float",
                     "description": "Shareholders equity per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_debt_per_share_ttm",
                     "type": "float",
                     "description": "Interest debt per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap_ttm",
                     "type": "float",
                     "description": "Market capitalization calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_value_ttm",
                     "type": "float",
                     "description": "Enterprise value calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe_ratio_ttm",
                     "type": "float",
                     "description": "Price-to-earnings ratio (P/E ratio) calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_sales_ratio_ttm",
                     "type": "float",
                     "description": "Price-to-sales ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pocf_ratio_ttm",
                     "type": "float",
                     "description": "Price-to-operating cash flow ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pfcf_ratio_ttm",
                     "type": "float",
                     "description": "Price-to-free cash flow ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pb_ratio_ttm",
                     "type": "float",
                     "description": "Price-to-book ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ptb_ratio_ttm",
                     "type": "float",
                     "description": "Price-to-tangible book ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ev_to_sales_ttm",
                     "type": "float",
                     "description": "Enterprise value-to-sales ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_value_over_ebitda_ttm",
                     "type": "float",
                     "description": "Enterprise value-to-EBITDA ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ev_to_operating_cash_flow_ttm",
                     "type": "float",
                     "description": "Enterprise value-to-operating cash flow ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ev_to_free_cash_flow_ttm",
                     "type": "float",
                     "description": "Enterprise value-to-free cash flow ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "earnings_yield_ttm",
                     "type": "float",
                     "description": "Earnings yield calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_yield_ttm",
                     "type": "float",
                     "description": "Free cash flow yield calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "debt_to_equity_ttm",
                     "type": "float",
                     "description": "Debt-to-equity ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "debt_to_assets_ttm",
                     "type": "float",
                     "description": "Debt-to-assets ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_debt_to_ebitda_ttm",
                     "type": "float",
                     "description": "Net debt-to-EBITDA ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_ratio_ttm",
                     "type": "float",
                     "description": "Current ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_coverage_ttm",
                     "type": "float",
                     "description": "Interest coverage calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_quality_ttm",
                     "type": "float",
                     "description": "Income quality calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield_ttm",
                     "type": "float",
                     "description": "Dividend yield calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield_percentage_ttm",
                     "type": "float",
                     "description": "Dividend yield percentage calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_to_market_cap_ttm",
                     "type": "float",
                     "description": "Dividend to market capitalization ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_per_share_ttm",
                     "type": "float",
                     "description": "Dividend per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payout_ratio_ttm",
                     "type": "float",
                     "description": "Payout ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sales_general_and_administrative_to_revenue_ttm",
                     "type": "float",
                     "description": "Sales general and administrative expenses-to-revenue ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "research_and_development_to_revenue_ttm",
                     "type": "float",
                     "description": "Research and development expenses-to-revenue ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intangibles_to_total_assets_ttm",
                     "type": "float",
                     "description": "Intangibles-to-total assets ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_to_operating_cash_flow_ttm",
                     "type": "float",
                     "description": "Capital expenditures-to-operating cash flow ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_to_revenue_ttm",
                     "type": "float",
                     "description": "Capital expenditures-to-revenue ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_to_depreciation_ttm",
                     "type": "float",
                     "description": "Capital expenditures-to-depreciation ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "stock_based_compensation_to_revenue_ttm",
                     "type": "float",
                     "description": "Stock-based compensation-to-revenue ratio calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "graham_number_ttm",
                     "type": "float",
                     "description": "Graham number calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "roic_ttm",
                     "type": "float",
                     "description": "Return on invested capital calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_tangible_assets_ttm",
                     "type": "float",
                     "description": "Return on tangible assets calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "graham_net_net_ttm",
                     "type": "float",
                     "description": "Graham net-net working capital calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "working_capital_ttm",
                     "type": "float",
                     "description": "Working capital calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tangible_asset_value_ttm",
                     "type": "float",
                     "description": "Tangible asset value calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_current_asset_value_ttm",
                     "type": "float",
                     "description": "Net current asset value calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "invested_capital_ttm",
                     "type": "float",
                     "description": "Invested capital calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_receivables_ttm",
                     "type": "float",
                     "description": "Average receivables calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_payables_ttm",
                     "type": "float",
                     "description": "Average payables calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_inventory_ttm",
                     "type": "float",
                     "description": "Average inventory calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_sales_outstanding_ttm",
                     "type": "float",
                     "description": "Days sales outstanding calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_payables_outstanding_ttm",
                     "type": "float",
                     "description": "Days payables outstanding calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_of_inventory_on_hand_ttm",
                     "type": "float",
                     "description": "Days of inventory on hand calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "receivables_turnover_ttm",
                     "type": "float",
                     "description": "Receivables turnover calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payables_turnover_ttm",
                     "type": "float",
                     "description": "Payables turnover calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inventory_turnover_ttm",
                     "type": "float",
                     "description": "Inventory turnover calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "roe_ttm",
                     "type": "float",
                     "description": "Return on equity calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_per_share_ttm",
                     "type": "float",
                     "description": "Capital expenditures per share calculated as trailing twelve months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -5888,9 +6954,9 @@
                 },
                 {
                     "name": "limit",
-                    "type": "int, Ge(ge=0)",
+                    "type": "Annotated[int, Ge(ge=0)]",
                     "description": "The number of data entries to return.",
-                    "default": "5",
+                    "default": 5,
                     "optional": true
                 },
                 {
@@ -5907,7 +6973,7 @@
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The specific fiscal year. Reports do not go beyond 2008.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -5916,98 +6982,124 @@
                     "name": "filing_date",
                     "type": "date",
                     "description": "Filing date of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_lt",
                     "type": "date",
                     "description": "Filing date less than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_lte",
                     "type": "date",
                     "description": "Filing date less than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_gt",
                     "type": "date",
                     "description": "Filing date greater than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_gte",
                     "type": "date",
                     "description": "Filing date greater than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date",
                     "type": "date",
                     "description": "Period of report date of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_lt",
                     "type": "date",
                     "description": "Period of report date less than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_lte",
                     "type": "date",
                     "description": "Period of report date less than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_gt",
                     "type": "date",
                     "description": "Period of report date greater than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_gte",
                     "type": "date",
                     "description": "Period of report date greater than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "include_sources",
                     "type": "bool",
                     "description": "Whether to include the sources of the financial statement.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
                     "name": "order",
                     "type": "Literal['asc', 'desc']",
                     "description": "Order of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sort",
                     "type": "Literal['filing_date', 'period_of_report_date']",
                     "description": "Sort of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : BalanceSheet\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[BalanceSheet]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -6022,14 +7114,14 @@
                     "name": "fiscal_period",
                     "type": "str",
                     "description": "The fiscal period of the report.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The fiscal year of the fiscal period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -6038,350 +7130,350 @@
                     "name": "filing_date",
                     "type": "date",
                     "description": "The date when the filing was made.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accepted_date",
                     "type": "datetime",
                     "description": "The date and time when the filing was accepted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reported_currency",
                     "type": "str",
                     "description": "The currency in which the balance sheet was reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_and_cash_equivalents",
                     "type": "float",
                     "description": "Cash and cash equivalents.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_term_investments",
                     "type": "float",
                     "description": "Short term investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_and_short_term_investments",
                     "type": "float",
                     "description": "Cash and short term investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_receivables",
                     "type": "float",
                     "description": "Net receivables.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inventory",
                     "type": "float",
                     "description": "Inventory.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_assets",
                     "type": "float",
                     "description": "Other current assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_current_assets",
                     "type": "float",
                     "description": "Total current assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "plant_property_equipment_net",
                     "type": "float",
                     "description": "Plant property equipment net.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "goodwill",
                     "type": "float",
                     "description": "Goodwill.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intangible_assets",
                     "type": "float",
                     "description": "Intangible assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "goodwill_and_intangible_assets",
                     "type": "float",
                     "description": "Goodwill and intangible assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_investments",
                     "type": "float",
                     "description": "Long term investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tax_assets",
                     "type": "float",
                     "description": "Tax assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_assets",
                     "type": "float",
                     "description": "Other non current assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_current_assets",
                     "type": "float",
                     "description": "Total non current assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_assets",
                     "type": "float",
                     "description": "Other assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_assets",
                     "type": "float",
                     "description": "Total assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accounts_payable",
                     "type": "float",
                     "description": "Accounts payable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_term_debt",
                     "type": "float",
                     "description": "Short term debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tax_payables",
                     "type": "float",
                     "description": "Tax payables.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_deferred_revenue",
                     "type": "float",
                     "description": "Current deferred revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_liabilities",
                     "type": "float",
                     "description": "Other current liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_current_liabilities",
                     "type": "float",
                     "description": "Total current liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_debt",
                     "type": "float",
                     "description": "Long term debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deferred_revenue_non_current",
                     "type": "float",
                     "description": "Non current deferred revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deferred_tax_liabilities_non_current",
                     "type": "float",
                     "description": "Deferred tax liabilities non current.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_liabilities",
                     "type": "float",
                     "description": "Other non current liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_non_current_liabilities",
                     "type": "float",
                     "description": "Total non current liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_liabilities",
                     "type": "float",
                     "description": "Other liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capital_lease_obligations",
                     "type": "float",
                     "description": "Capital lease obligations.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_liabilities",
                     "type": "float",
                     "description": "Total liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "preferred_stock",
                     "type": "float",
                     "description": "Preferred stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "common_stock",
                     "type": "float",
                     "description": "Common stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "retained_earnings",
                     "type": "float",
                     "description": "Retained earnings.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accumulated_other_comprehensive_income",
                     "type": "float",
                     "description": "Accumulated other comprehensive income (loss).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_shareholders_equity",
                     "type": "float",
                     "description": "Other shareholders equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_total_shareholders_equity",
                     "type": "float",
                     "description": "Other total shareholders equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_common_equity",
                     "type": "float",
                     "description": "Total common equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_equity_non_controlling_interests",
                     "type": "float",
                     "description": "Total equity non controlling interests.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_liabilities_and_shareholders_equity",
                     "type": "float",
                     "description": "Total liabilities and shareholders equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "minority_interest",
                     "type": "float",
                     "description": "Minority interest.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_liabilities_and_total_equity",
                     "type": "float",
                     "description": "Total liabilities and total equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_investments",
                     "type": "float",
                     "description": "Total investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_debt",
                     "type": "float",
                     "description": "Total debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_debt",
                     "type": "float",
                     "description": "Net debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "link",
                     "type": "str",
                     "description": "Link to the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "final_link",
                     "type": "str",
                     "description": "Link to the filing document.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -6390,630 +7482,630 @@
                     "name": "reported_currency",
                     "type": "str",
                     "description": "The currency in which the balance sheet is reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_and_cash_equivalents",
                     "type": "float",
                     "description": "Cash and cash equivalents.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_and_due_from_banks",
                     "type": "float",
                     "description": "Cash and due from banks.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "restricted_cash",
                     "type": "float",
                     "description": "Restricted cash.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_term_investments",
                     "type": "float",
                     "description": "Short term investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "federal_funds_sold",
                     "type": "float",
                     "description": "Federal funds sold.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accounts_receivable",
                     "type": "float",
                     "description": "Accounts receivable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "note_and_lease_receivable",
                     "type": "float",
                     "description": "Note and lease receivable. (Vendor non-trade receivables)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inventories",
                     "type": "float",
                     "description": "Net Inventories.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "customer_and_other_receivables",
                     "type": "float",
                     "description": "Customer and other receivables.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_bearing_deposits_at_other_banks",
                     "type": "float",
                     "description": "Interest bearing deposits at other banks.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "time_deposits_placed_and_other_short_term_investments",
                     "type": "float",
                     "description": "Time deposits placed and other short term investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "trading_account_securities",
                     "type": "float",
                     "description": "Trading account securities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loans_and_leases",
                     "type": "float",
                     "description": "Loans and leases.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "allowance_for_loan_and_lease_losses",
                     "type": "float",
                     "description": "Allowance for loan and lease losses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_deferred_refundable_income_taxes",
                     "type": "float",
                     "description": "Current deferred refundable income taxes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_assets",
                     "type": "float",
                     "description": "Other current assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loans_and_leases_net_of_allowance",
                     "type": "float",
                     "description": "Loans and leases net of allowance.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accrued_investment_income",
                     "type": "float",
                     "description": "Accrued investment income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_non_operating_assets",
                     "type": "float",
                     "description": "Other current non-operating assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loans_held_for_sale",
                     "type": "float",
                     "description": "Loans held for sale.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prepaid_expenses",
                     "type": "float",
                     "description": "Prepaid expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_current_assets",
                     "type": "float",
                     "description": "Total current assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "plant_property_equipment_gross",
                     "type": "float",
                     "description": "Plant property equipment gross.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accumulated_depreciation",
                     "type": "float",
                     "description": "Accumulated depreciation.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "premises_and_equipment_net",
                     "type": "float",
                     "description": "Net premises and equipment.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "plant_property_equipment_net",
                     "type": "float",
                     "description": "Net plant property equipment.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_investments",
                     "type": "float",
                     "description": "Long term investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mortgage_servicing_rights",
                     "type": "float",
                     "description": "Mortgage servicing rights.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unearned_premiums_asset",
                     "type": "float",
                     "description": "Unearned premiums asset.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_current_note_lease_receivables",
                     "type": "float",
                     "description": "Non-current note lease receivables.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deferred_acquisition_cost",
                     "type": "float",
                     "description": "Deferred acquisition cost.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "goodwill",
                     "type": "float",
                     "description": "Goodwill.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "separate_account_business_assets",
                     "type": "float",
                     "description": "Separate account business assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_current_deferred_refundable_income_taxes",
                     "type": "float",
                     "description": "Noncurrent deferred refundable income taxes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intangible_assets",
                     "type": "float",
                     "description": "Intangible assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "employee_benefit_assets",
                     "type": "float",
                     "description": "Employee benefit assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_assets",
                     "type": "float",
                     "description": "Other assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_operating_assets",
                     "type": "float",
                     "description": "Other noncurrent operating assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_non_operating_assets",
                     "type": "float",
                     "description": "Other noncurrent non-operating assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_bearing_deposits",
                     "type": "float",
                     "description": "Interest bearing deposits.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_non_current_assets",
                     "type": "float",
                     "description": "Total noncurrent assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_assets",
                     "type": "float",
                     "description": "Total assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_interest_bearing_deposits",
                     "type": "float",
                     "description": "Non interest bearing deposits.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "federal_funds_purchased_and_securities_sold",
                     "type": "float",
                     "description": "Federal funds purchased and securities sold.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bankers_acceptance_outstanding",
                     "type": "float",
                     "description": "Bankers acceptance outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_term_debt",
                     "type": "float",
                     "description": "Short term debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accounts_payable",
                     "type": "float",
                     "description": "Accounts payable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_deferred_revenue",
                     "type": "float",
                     "description": "Current deferred revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_deferred_payable_income_tax_liabilities",
                     "type": "float",
                     "description": "Current deferred payable income tax liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accrued_interest_payable",
                     "type": "float",
                     "description": "Accrued interest payable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accrued_expenses",
                     "type": "float",
                     "description": "Accrued expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_short_term_payables",
                     "type": "float",
                     "description": "Other short term payables.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "customer_deposits",
                     "type": "float",
                     "description": "Customer deposits.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividends_payable",
                     "type": "float",
                     "description": "Dividends payable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "claims_and_claim_expense",
                     "type": "float",
                     "description": "Claims and claim expense.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "future_policy_benefits",
                     "type": "float",
                     "description": "Future policy benefits.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_employee_benefit_liabilities",
                     "type": "float",
                     "description": "Current employee benefit liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unearned_premiums_liability",
                     "type": "float",
                     "description": "Unearned premiums liability.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_taxes_payable",
                     "type": "float",
                     "description": "Other taxes payable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "policy_holder_funds",
                     "type": "float",
                     "description": "Policy holder funds.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_liabilities",
                     "type": "float",
                     "description": "Other current liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_non_operating_liabilities",
                     "type": "float",
                     "description": "Other current non-operating liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "separate_account_business_liabilities",
                     "type": "float",
                     "description": "Separate account business liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_current_liabilities",
                     "type": "float",
                     "description": "Total current liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_debt",
                     "type": "float",
                     "description": "Long term debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_long_term_liabilities",
                     "type": "float",
                     "description": "Other long term liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_current_deferred_revenue",
                     "type": "float",
                     "description": "Non-current deferred revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_current_deferred_payable_income_tax_liabilities",
                     "type": "float",
                     "description": "Non-current deferred payable income tax liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_current_employee_benefit_liabilities",
                     "type": "float",
                     "description": "Non-current employee benefit liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_operating_liabilities",
                     "type": "float",
                     "description": "Other non-current operating liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_non_operating_liabilities",
                     "type": "float",
                     "description": "Other non-current, non-operating liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_non_current_liabilities",
                     "type": "float",
                     "description": "Total non-current liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capital_lease_obligations",
                     "type": "float",
                     "description": "Capital lease obligations.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asset_retirement_reserve_litigation_obligation",
                     "type": "float",
                     "description": "Asset retirement reserve litigation obligation.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_liabilities",
                     "type": "float",
                     "description": "Total liabilities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "commitments_contingencies",
                     "type": "float",
                     "description": "Commitments contingencies.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "redeemable_non_controlling_interest",
                     "type": "float",
                     "description": "Redeemable non-controlling interest.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "preferred_stock",
                     "type": "float",
                     "description": "Preferred stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "common_stock",
                     "type": "float",
                     "description": "Common stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "retained_earnings",
                     "type": "float",
                     "description": "Retained earnings.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "treasury_stock",
                     "type": "float",
                     "description": "Treasury stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accumulated_other_comprehensive_income",
                     "type": "float",
                     "description": "Accumulated other comprehensive income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "participating_policy_holder_equity",
                     "type": "float",
                     "description": "Participating policy holder equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_equity_adjustments",
                     "type": "float",
                     "description": "Other equity adjustments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_common_equity",
                     "type": "float",
                     "description": "Total common equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_preferred_common_equity",
                     "type": "float",
                     "description": "Total preferred common equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_controlling_interest",
                     "type": "float",
                     "description": "Non-controlling interest.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_equity_non_controlling_interests",
                     "type": "float",
                     "description": "Total equity non-controlling interests.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_liabilities_shareholders_equity",
                     "type": "float",
                     "description": "Total liabilities and shareholders equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -7022,203 +8114,203 @@
                     "name": "accounts_receivable",
                     "type": "int",
                     "description": "Accounts receivable",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "marketable_securities",
                     "type": "int",
                     "description": "Marketable securities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prepaid_expenses",
                     "type": "int",
                     "description": "Prepaid expenses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_assets",
                     "type": "int",
                     "description": "Other current assets",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_current_assets",
                     "type": "int",
                     "description": "Total current assets",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "property_plant_equipment_net",
                     "type": "int",
                     "description": "Property plant and equipment net",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inventory",
                     "type": "int",
                     "description": "Inventory",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_assets",
                     "type": "int",
                     "description": "Other non-current assets",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_non_current_assets",
                     "type": "int",
                     "description": "Total non-current assets",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intangible_assets",
                     "type": "int",
                     "description": "Intangible assets",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_assets",
                     "type": "int",
                     "description": "Total assets",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accounts_payable",
                     "type": "int",
                     "description": "Accounts payable",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "employee_wages",
                     "type": "int",
                     "description": "Employee wages",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_current_liabilities",
                     "type": "int",
                     "description": "Other current liabilities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_current_liabilities",
                     "type": "int",
                     "description": "Total current liabilities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_current_liabilities",
                     "type": "int",
                     "description": "Other non-current liabilities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_non_current_liabilities",
                     "type": "int",
                     "description": "Total non-current liabilities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_debt",
                     "type": "int",
                     "description": "Long term debt",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_liabilities",
                     "type": "int",
                     "description": "Total liabilities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "minority_interest",
                     "type": "int",
                     "description": "Minority interest",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "temporary_equity_attributable_to_parent",
                     "type": "int",
                     "description": "Temporary equity attributable to parent",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "equity_attributable_to_parent",
                     "type": "int",
                     "description": "Equity attributable to parent",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "temporary_equity",
                     "type": "int",
                     "description": "Temporary equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "preferred_stock",
                     "type": "int",
                     "description": "Preferred stock",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "redeemable_non_controlling_interest",
                     "type": "int",
                     "description": "Redeemable non-controlling interest",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "redeemable_non_controlling_interest_other",
                     "type": "int",
                     "description": "Redeemable non-controlling interest other",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_stock_holders_equity",
                     "type": "int",
                     "description": "Total stock holders equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_liabilities_and_stock_holders_equity",
                     "type": "int",
                     "description": "Total liabilities and stockholders equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_equity",
                     "type": "int",
                     "description": "Total equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -7246,7 +8338,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "10",
+                    "default": 10,
                     "optional": true
                 },
                 {
@@ -7260,7 +8352,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : BalanceSheetGrowth\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[BalanceSheetGrowth]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -7268,7 +8386,7 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -7588,9 +8706,9 @@
                 },
                 {
                     "name": "limit",
-                    "type": "int, Ge(ge=0)",
+                    "type": "Annotated[int, Ge(ge=0)]",
                     "description": "The number of data entries to return.",
-                    "default": "5",
+                    "default": 5,
                     "optional": true
                 },
                 {
@@ -7607,7 +8725,7 @@
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The specific fiscal year. Reports do not go beyond 2008.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -7616,98 +8734,124 @@
                     "name": "filing_date",
                     "type": "date",
                     "description": "Filing date of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_lt",
                     "type": "date",
                     "description": "Filing date less than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_lte",
                     "type": "date",
                     "description": "Filing date less than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_gt",
                     "type": "date",
                     "description": "Filing date greater than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_gte",
                     "type": "date",
                     "description": "Filing date greater than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date",
                     "type": "date",
                     "description": "Period of report date of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_lt",
                     "type": "date",
                     "description": "Period of report date less than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_lte",
                     "type": "date",
                     "description": "Period of report date less than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_gt",
                     "type": "date",
                     "description": "Period of report date greater than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_gte",
                     "type": "date",
                     "description": "Period of report date greater than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "include_sources",
                     "type": "bool",
                     "description": "Whether to include the sources of the financial statement.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "order",
                     "type": "Literal[None, 'asc', 'desc']",
                     "description": "Order of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sort",
                     "type": "Literal[None, 'filing_date', 'period_of_report_date']",
                     "description": "Sort of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CashFlowStatement\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CashFlowStatement]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -7722,14 +8866,14 @@
                     "name": "fiscal_period",
                     "type": "str",
                     "description": "The fiscal period of the report.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The fiscal year of the fiscal period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -7738,245 +8882,245 @@
                     "name": "filing_date",
                     "type": "date",
                     "description": "The date of the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accepted_date",
                     "type": "datetime",
                     "description": "The date the filing was accepted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reported_currency",
                     "type": "str",
                     "description": "The currency in which the cash flow statement was reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income",
                     "type": "float",
                     "description": "Net income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "depreciation_and_amortization",
                     "type": "float",
                     "description": "Depreciation and amortization.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deferred_income_tax",
                     "type": "float",
                     "description": "Deferred income tax.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "stock_based_compensation",
                     "type": "float",
                     "description": "Stock-based compensation.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_in_working_capital",
                     "type": "float",
                     "description": "Change in working capital.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_in_account_receivables",
                     "type": "float",
                     "description": "Change in account receivables.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_in_inventory",
                     "type": "float",
                     "description": "Change in inventory.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_in_account_payable",
                     "type": "float",
                     "description": "Change in account payable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_in_other_working_capital",
                     "type": "float",
                     "description": "Change in other working capital.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_in_other_non_cash_items",
                     "type": "float",
                     "description": "Change in other non-cash items.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_operating_activities",
                     "type": "float",
                     "description": "Net cash from operating activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "purchase_of_property_plant_and_equipment",
                     "type": "float",
                     "description": "Purchase of property, plant and equipment.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "acquisitions",
                     "type": "float",
                     "description": "Acquisitions.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "purchase_of_investment_securities",
                     "type": "float",
                     "description": "Purchase of investment securities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sale_and_maturity_of_investments",
                     "type": "float",
                     "description": "Sale and maturity of investments.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_investing_activities",
                     "type": "float",
                     "description": "Other investing activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_investing_activities",
                     "type": "float",
                     "description": "Net cash from investing activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "repayment_of_debt",
                     "type": "float",
                     "description": "Repayment of debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuance_of_common_equity",
                     "type": "float",
                     "description": "Issuance of common equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "repurchase_of_common_equity",
                     "type": "float",
                     "description": "Repurchase of common equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payment_of_dividends",
                     "type": "float",
                     "description": "Payment of dividends.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_financing_activities",
                     "type": "float",
                     "description": "Other financing activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_financing_activities",
                     "type": "float",
                     "description": "Net cash from financing activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "effect_of_exchange_rate_changes_on_cash",
                     "type": "float",
                     "description": "Effect of exchange rate changes on cash.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_change_in_cash_and_equivalents",
                     "type": "float",
                     "description": "Net change in cash and equivalents.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_at_beginning_of_period",
                     "type": "float",
                     "description": "Cash at beginning of period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_at_end_of_period",
                     "type": "float",
                     "description": "Cash at end of period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_cash_flow",
                     "type": "float",
                     "description": "Operating cash flow.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capital_expenditure",
                     "type": "float",
                     "description": "Capital expenditure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow",
                     "type": "float",
                     "description": "None",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "link",
                     "type": "str",
                     "description": "Link to the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "final_link",
                     "type": "str",
                     "description": "Link to the filing document.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -7985,315 +9129,315 @@
                     "name": "reported_currency",
                     "type": "str",
                     "description": "The currency in which the balance sheet is reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_continuing_operations",
                     "type": "float",
                     "description": "Net Income (Continuing Operations)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_discontinued_operations",
                     "type": "float",
                     "description": "Net Income (Discontinued Operations)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income",
                     "type": "float",
                     "description": "Consolidated Net Income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "provision_for_loan_losses",
                     "type": "float",
                     "description": "Provision for Loan Losses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "provision_for_credit_losses",
                     "type": "float",
                     "description": "Provision for credit losses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "depreciation_expense",
                     "type": "float",
                     "description": "Depreciation Expense.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "amortization_expense",
                     "type": "float",
                     "description": "Amortization Expense.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_based_compensation",
                     "type": "float",
                     "description": "Share-based compensation.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_cash_adjustments_to_reconcile_net_income",
                     "type": "float",
                     "description": "Non-Cash Adjustments to Reconcile Net Income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "changes_in_operating_assets_and_liabilities",
                     "type": "float",
                     "description": "Changes in Operating Assets and Liabilities (Net)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_continuing_operating_activities",
                     "type": "float",
                     "description": "Net Cash from Continuing Operating Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_discontinued_operating_activities",
                     "type": "float",
                     "description": "Net Cash from Discontinued Operating Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_operating_activities",
                     "type": "float",
                     "description": "Net Cash from Operating Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "divestitures",
                     "type": "float",
                     "description": "Divestitures",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sale_of_property_plant_and_equipment",
                     "type": "float",
                     "description": "Sale of Property, Plant, and Equipment",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "acquisitions",
                     "type": "float",
                     "description": "Acquisitions",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "purchase_of_investments",
                     "type": "float",
                     "description": "Purchase of Investments",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "purchase_of_investment_securities",
                     "type": "float",
                     "description": "Purchase of Investment Securities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sale_and_maturity_of_investments",
                     "type": "float",
                     "description": "Sale and Maturity of Investments",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loans_held_for_sale",
                     "type": "float",
                     "description": "Loans Held for Sale (Net)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "purchase_of_property_plant_and_equipment",
                     "type": "float",
                     "description": "Purchase of Property, Plant, and Equipment",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_investing_activities",
                     "type": "float",
                     "description": "Other Investing Activities (Net)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_continuing_investing_activities",
                     "type": "float",
                     "description": "Net Cash from Continuing Investing Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_discontinued_investing_activities",
                     "type": "float",
                     "description": "Net Cash from Discontinued Investing Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_investing_activities",
                     "type": "float",
                     "description": "Net Cash from Investing Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payment_of_dividends",
                     "type": "float",
                     "description": "Payment of Dividends",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "repurchase_of_common_equity",
                     "type": "float",
                     "description": "Repurchase of Common Equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "repurchase_of_preferred_equity",
                     "type": "float",
                     "description": "Repurchase of Preferred Equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuance_of_common_equity",
                     "type": "float",
                     "description": "Issuance of Common Equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuance_of_preferred_equity",
                     "type": "float",
                     "description": "Issuance of Preferred Equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuance_of_debt",
                     "type": "float",
                     "description": "Issuance of Debt",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "repayment_of_debt",
                     "type": "float",
                     "description": "Repayment of Debt",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_financing_activities",
                     "type": "float",
                     "description": "Other Financing Activities (Net)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_interest_received",
                     "type": "float",
                     "description": "Cash Interest Received",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_change_in_deposits",
                     "type": "float",
                     "description": "Net Change in Deposits",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_increase_in_fed_funds_sold",
                     "type": "float",
                     "description": "Net Increase in Fed Funds Sold",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_continuing_financing_activities",
                     "type": "float",
                     "description": "Net Cash from Continuing Financing Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_discontinued_financing_activities",
                     "type": "float",
                     "description": "Net Cash from Discontinued Financing Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_from_financing_activities",
                     "type": "float",
                     "description": "Net Cash from Financing Activities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "effect_of_exchange_rate_changes",
                     "type": "float",
                     "description": "Effect of Exchange Rate Changes",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_net_changes_in_cash",
                     "type": "float",
                     "description": "Other Net Changes in Cash",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_change_in_cash_and_equivalents",
                     "type": "float",
                     "description": "Net Change in Cash and Equivalents",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_income_taxes_paid",
                     "type": "float",
                     "description": "Cash Income Taxes Paid",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_interest_paid",
                     "type": "float",
                     "description": "Cash Interest Paid",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -8302,91 +9446,91 @@
                     "name": "net_cash_flow_from_operating_activities_continuing",
                     "type": "int",
                     "description": "Net cash flow from operating activities continuing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_operating_activities_discontinued",
                     "type": "int",
                     "description": "Net cash flow from operating activities discontinued.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_operating_activities",
                     "type": "int",
                     "description": "Net cash flow from operating activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_investing_activities_continuing",
                     "type": "int",
                     "description": "Net cash flow from investing activities continuing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_investing_activities_discontinued",
                     "type": "int",
                     "description": "Net cash flow from investing activities discontinued.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_investing_activities",
                     "type": "int",
                     "description": "Net cash flow from investing activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_financing_activities_continuing",
                     "type": "int",
                     "description": "Net cash flow from financing activities continuing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_financing_activities_discontinued",
                     "type": "int",
                     "description": "Net cash flow from financing activities discontinued.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_from_financing_activities",
                     "type": "int",
                     "description": "Net cash flow from financing activities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_continuing",
                     "type": "int",
                     "description": "Net cash flow continuing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow_discontinued",
                     "type": "int",
                     "description": "Net cash flow discontinued.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_gains_losses",
                     "type": "int",
                     "description": "Exchange gains losses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_cash_flow",
                     "type": "int",
                     "description": "Net cash flow.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -8428,7 +9572,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return. Although the response object contains multiple results, because of the variance in the fields, year-to-year and quarter-to-quarter, it is recommended to view results in small chunks.",
-                    "default": "100",
+                    "default": 100,
                     "optional": true
                 },
                 {
@@ -8444,13 +9588,39 @@
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The specific fiscal year. Reports do not go beyond 2008.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : ReportedFinancials\n        Serializable results.\n    provider : Literal['intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[ReportedFinancials]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -8472,7 +9642,7 @@
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The fiscal year of the fiscal period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -8500,7 +9670,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "10",
+                    "default": 10,
                     "optional": true
                 },
                 {
@@ -8514,7 +9684,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CashFlowStatementGrowth\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CashFlowStatementGrowth]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -8522,7 +9718,7 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -8774,14 +9970,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -8798,14 +9994,40 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "100",
+                    "default": 100,
                     "optional": true
                 }
             ],
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : HistoricalDividends\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[HistoricalDividends]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -8843,21 +10065,21 @@
                     "name": "record_date",
                     "type": "date",
                     "description": "Record date of the historical dividends.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payment_date",
                     "type": "date",
                     "description": "Payment date of the historical dividends.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "declaration_date",
                     "type": "date",
                     "description": "Declaration date of the historical dividends.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -8866,21 +10088,21 @@
                     "name": "factor",
                     "type": "float",
                     "description": "factor by which to multiply stock prices before this date, in order to calculate historically-adjusted stock prices.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "The currency in which the dividend is paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "split_ratio",
                     "type": "float",
                     "description": "The ratio of the stock split, if a stock split occurred.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -8917,13 +10139,39 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : HistoricalEps\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[HistoricalEps]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -8931,7 +10179,7 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -8945,21 +10193,21 @@
                     "name": "announce_time",
                     "type": "str",
                     "description": "Timing of the earnings announcement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps_actual",
                     "type": "float",
                     "description": "Actual EPS from the earnings date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps_estimated",
                     "type": "float",
                     "description": "Estimated EPS for the earnings date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -8968,35 +10216,35 @@
                     "name": "revenue_estimated",
                     "type": "float",
                     "description": "Estimated consensus revenue for the reporting period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue_actual",
                     "type": "float",
                     "description": "The actual reported revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reporting_time",
                     "type": "str",
                     "description": "The reporting time - e.g. after market close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "updated_at",
                     "type": "date",
                     "description": "The date when the data was last updated.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_ending",
                     "type": "date",
                     "description": "The fiscal period end date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -9030,7 +10278,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : HistoricalEmployees\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[HistoricalEmployees]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -9122,7 +10396,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "1000",
+                    "default": 1000,
                     "optional": true
                 },
                 {
@@ -9136,7 +10410,33 @@
             "intrinio": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SearchAttributes\n        Serializable results.\n    provider : Literal['intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SearchAttributes]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -9172,49 +10472,49 @@
                     "name": "statement_type",
                     "type": "str",
                     "description": "Type of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "parent_name",
                     "type": "str",
                     "description": "Parent's name of the financial attribute.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sequence",
                     "type": "int",
                     "description": "Sequence of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "factor",
                     "type": "str",
                     "description": "Unit of the financial attribute.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "transaction",
                     "type": "str",
                     "description": "Transaction type (credit/debit) of the financial attribute.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "type",
                     "type": "str",
                     "description": "Type of the financial attribute.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unit",
                     "type": "str",
                     "description": "Unit of the financial attribute.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -9256,7 +10556,33 @@
             "intrinio": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : LatestAttributes\n        Serializable results.\n    provider : Literal['intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[LatestAttributes]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -9271,14 +10597,14 @@
                     "name": "tag",
                     "type": "str",
                     "description": "Tag name for the fetched data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "Union[str, float]",
                     "description": "The value of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -9313,14 +10639,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -9334,14 +10660,14 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "1000",
+                    "default": 1000,
                     "optional": true
                 },
                 {
                     "name": "tag_type",
                     "type": "str",
                     "description": "Filter by type, when applicable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -9362,7 +10688,33 @@
             "intrinio": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : HistoricalAttributes\n        Serializable results.\n    provider : Literal['intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[HistoricalAttributes]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -9384,14 +10736,14 @@
                     "name": "tag",
                     "type": "str",
                     "description": "Tag name for the fetched data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "The value of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -9424,9 +10776,9 @@
                 },
                 {
                     "name": "limit",
-                    "type": "int, Ge(ge=0)",
+                    "type": "Annotated[int, Ge(ge=0)]",
                     "description": "The number of data entries to return.",
-                    "default": "5",
+                    "default": 5,
                     "optional": true
                 },
                 {
@@ -9443,7 +10795,7 @@
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The specific fiscal year. Reports do not go beyond 2008.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -9452,98 +10804,124 @@
                     "name": "filing_date",
                     "type": "date",
                     "description": "Filing date of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_lt",
                     "type": "date",
                     "description": "Filing date less than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_lte",
                     "type": "date",
                     "description": "Filing date less than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_gt",
                     "type": "date",
                     "description": "Filing date greater than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date_gte",
                     "type": "date",
                     "description": "Filing date greater than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date",
                     "type": "date",
                     "description": "Period of report date of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_lt",
                     "type": "date",
                     "description": "Period of report date less than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_lte",
                     "type": "date",
                     "description": "Period of report date less than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_gt",
                     "type": "date",
                     "description": "Period of report date greater than the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "period_of_report_date_gte",
                     "type": "date",
                     "description": "Period of report date greater than or equal to the given date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "include_sources",
                     "type": "bool",
                     "description": "Whether to include the sources of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "order",
                     "type": "Literal['asc', 'desc']",
                     "description": "Order of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sort",
                     "type": "Literal['filing_date', 'period_of_report_date']",
                     "description": "Sort of the financial statement.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : IncomeStatement\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[IncomeStatement]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -9558,14 +10936,14 @@
                     "name": "fiscal_period",
                     "type": "str",
                     "description": "The fiscal period of the report.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The fiscal year of the fiscal period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -9574,231 +10952,231 @@
                     "name": "filing_date",
                     "type": "date",
                     "description": "The date when the filing was made.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accepted_date",
                     "type": "datetime",
                     "description": "The date and time when the filing was accepted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reported_currency",
                     "type": "str",
                     "description": "The currency in which the balance sheet was reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue",
                     "type": "float",
                     "description": "Total revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cost_of_revenue",
                     "type": "float",
                     "description": "Cost of revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_profit",
                     "type": "float",
                     "description": "Gross profit.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_profit_margin",
                     "type": "float",
                     "description": "Gross profit margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "general_and_admin_expense",
                     "type": "float",
                     "description": "General and administrative expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "research_and_development_expense",
                     "type": "float",
                     "description": "Research and development expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "selling_and_marketing_expense",
                     "type": "float",
                     "description": "Selling and marketing expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "selling_general_and_admin_expense",
                     "type": "float",
                     "description": "Selling, general and administrative expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_expenses",
                     "type": "float",
                     "description": "Other expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_operating_expenses",
                     "type": "float",
                     "description": "Total operating expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cost_and_expenses",
                     "type": "float",
                     "description": "Cost and expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_income",
                     "type": "float",
                     "description": "Interest income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_interest_expense",
                     "type": "float",
                     "description": "Total interest expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "depreciation_and_amortization",
                     "type": "float",
                     "description": "Depreciation and amortization.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebitda",
                     "type": "float",
                     "description": "EBITDA.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebitda_margin",
                     "type": "float",
                     "description": "EBITDA margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_operating_income",
                     "type": "float",
                     "description": "Total operating income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_income_margin",
                     "type": "float",
                     "description": "Operating income margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_other_income_expenses",
                     "type": "float",
                     "description": "Total other income and expenses.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_pre_tax_income",
                     "type": "float",
                     "description": "Total pre-tax income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pre_tax_income_margin",
                     "type": "float",
                     "description": "Pre-tax income margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_tax_expense",
                     "type": "float",
                     "description": "Income tax expense.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "consolidated_net_income",
                     "type": "float",
                     "description": "Consolidated net income.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_margin",
                     "type": "float",
                     "description": "Net income margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "basic_earnings_per_share",
                     "type": "float",
                     "description": "Basic earnings per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "diluted_earnings_per_share",
                     "type": "float",
                     "description": "Diluted earnings per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weighted_average_basic_shares_outstanding",
                     "type": "float",
                     "description": "Weighted average basic shares outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weighted_average_diluted_shares_outstanding",
                     "type": "float",
                     "description": "Weighted average diluted shares outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "link",
                     "type": "str",
                     "description": "Link to the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "final_link",
                     "type": "str",
                     "description": "Link to the filing document.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -9807,553 +11185,553 @@
                     "name": "reported_currency",
                     "type": "str",
                     "description": "The currency in which the balance sheet is reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue",
                     "type": "float",
                     "description": "Total revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_revenue",
                     "type": "float",
                     "description": "Total operating revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cost_of_revenue",
                     "type": "float",
                     "description": "Total cost of revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_cost_of_revenue",
                     "type": "float",
                     "description": "Total operating cost of revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_profit",
                     "type": "float",
                     "description": "Total gross profit",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_profit_margin",
                     "type": "float",
                     "description": "Gross margin ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "provision_for_credit_losses",
                     "type": "float",
                     "description": "Provision for credit losses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "research_and_development_expense",
                     "type": "float",
                     "description": "Research and development expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "selling_general_and_admin_expense",
                     "type": "float",
                     "description": "Selling, general, and admin expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "salaries_and_employee_benefits",
                     "type": "float",
                     "description": "Salaries and employee benefits",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "marketing_expense",
                     "type": "float",
                     "description": "Marketing expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_occupancy_and_equipment_expense",
                     "type": "float",
                     "description": "Net occupancy and equipment expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_operating_expenses",
                     "type": "float",
                     "description": "Other operating expenses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "depreciation_expense",
                     "type": "float",
                     "description": "Depreciation expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "amortization_expense",
                     "type": "float",
                     "description": "Amortization expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "amortization_of_deferred_policy_acquisition_costs",
                     "type": "float",
                     "description": "Amortization of deferred policy acquisition costs",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exploration_expense",
                     "type": "float",
                     "description": "Exploration expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "depletion_expense",
                     "type": "float",
                     "description": "Depletion expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_operating_expenses",
                     "type": "float",
                     "description": "Total operating expenses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_operating_income",
                     "type": "float",
                     "description": "Total operating income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deposits_and_money_market_investments_interest_income",
                     "type": "float",
                     "description": "Deposits and money market investments interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "federal_funds_sold_and_securities_borrowed_interest_income",
                     "type": "float",
                     "description": "Federal funds sold and securities borrowed interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "investment_securities_interest_income",
                     "type": "float",
                     "description": "Investment securities interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loans_and_leases_interest_income",
                     "type": "float",
                     "description": "Loans and leases interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "trading_account_interest_income",
                     "type": "float",
                     "description": "Trading account interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_interest_income",
                     "type": "float",
                     "description": "Other interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_non_interest_income",
                     "type": "float",
                     "description": "Total non-interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_and_investment_income",
                     "type": "float",
                     "description": "Interest and investment income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_term_borrowings_interest_expense",
                     "type": "float",
                     "description": "Short-term borrowings interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_debt_interest_expense",
                     "type": "float",
                     "description": "Long-term debt interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capitalized_lease_obligations_interest_expense",
                     "type": "float",
                     "description": "Capitalized lease obligations interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deposits_interest_expense",
                     "type": "float",
                     "description": "Deposits interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "federal_funds_purchased_and_securities_sold_interest_expense",
                     "type": "float",
                     "description": "Federal funds purchased and securities sold interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_interest_expense",
                     "type": "float",
                     "description": "Other interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_interest_expense",
                     "type": "float",
                     "description": "Total interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_interest_income",
                     "type": "float",
                     "description": "Net interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_non_interest_income",
                     "type": "float",
                     "description": "Other non-interest income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "investment_banking_income",
                     "type": "float",
                     "description": "Investment banking income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "trust_fees_by_commissions",
                     "type": "float",
                     "description": "Trust fees by commissions",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "premiums_earned",
                     "type": "float",
                     "description": "Premiums earned",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "insurance_policy_acquisition_costs",
                     "type": "float",
                     "description": "Insurance policy acquisition costs",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_and_future_benefits",
                     "type": "float",
                     "description": "Current and future benefits",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "property_and_liability_insurance_claims",
                     "type": "float",
                     "description": "Property and liability insurance claims",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_non_interest_expense",
                     "type": "float",
                     "description": "Total non-interest expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_realized_and_unrealized_capital_gains_on_investments",
                     "type": "float",
                     "description": "Net realized and unrealized capital gains on investments",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_gains",
                     "type": "float",
                     "description": "Other gains",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_operating_income",
                     "type": "float",
                     "description": "Non-operating income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_income",
                     "type": "float",
                     "description": "Other income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_revenue",
                     "type": "float",
                     "description": "Other revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "extraordinary_income",
                     "type": "float",
                     "description": "Extraordinary income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_other_income",
                     "type": "float",
                     "description": "Total other income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebitda",
                     "type": "float",
                     "description": "Earnings Before Interest, Taxes, Depreciation and Amortization.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebitda_margin",
                     "type": "float",
                     "description": "Margin on Earnings Before Interest, Taxes, Depreciation and Amortization.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_pre_tax_income",
                     "type": "float",
                     "description": "Total pre-tax income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebit",
                     "type": "float",
                     "description": "Earnings Before Interest and Taxes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pre_tax_income_margin",
                     "type": "float",
                     "description": "Pre-Tax Income Margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_tax_expense",
                     "type": "float",
                     "description": "Income tax expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "impairment_charge",
                     "type": "float",
                     "description": "Impairment charge",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "restructuring_charge",
                     "type": "float",
                     "description": "Restructuring charge",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "service_charges_on_deposit_accounts",
                     "type": "float",
                     "description": "Service charges on deposit accounts",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_service_charges",
                     "type": "float",
                     "description": "Other service charges",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_special_charges",
                     "type": "float",
                     "description": "Other special charges",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_cost_of_revenue",
                     "type": "float",
                     "description": "Other cost of revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_continuing_operations",
                     "type": "float",
                     "description": "Net income (continuing operations)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_discontinued_operations",
                     "type": "float",
                     "description": "Net income (discontinued operations)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "consolidated_net_income",
                     "type": "float",
                     "description": "Consolidated net income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_adjustments_to_consolidated_net_income",
                     "type": "float",
                     "description": "Other adjustments to consolidated net income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_adjustment_to_net_income_attributable_to_common_shareholders",
                     "type": "float",
                     "description": "Other adjustment to net income attributable to common shareholders",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_attributable_to_noncontrolling_interest",
                     "type": "float",
                     "description": "Net income attributable to noncontrolling interest",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_attributable_to_common_shareholders",
                     "type": "float",
                     "description": "Net income attributable to common shareholders",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "basic_earnings_per_share",
                     "type": "float",
                     "description": "Basic earnings per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "diluted_earnings_per_share",
                     "type": "float",
                     "description": "Diluted earnings per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "basic_and_diluted_earnings_per_share",
                     "type": "float",
                     "description": "Basic and diluted earnings per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_dividends_to_common_per_share",
                     "type": "float",
                     "description": "Cash dividends to common per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "preferred_stock_dividends_declared",
                     "type": "float",
                     "description": "Preferred stock dividends declared",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weighted_average_basic_shares_outstanding",
                     "type": "float",
                     "description": "Weighted average basic shares outstanding",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weighted_average_diluted_shares_outstanding",
                     "type": "float",
                     "description": "Weighted average diluted shares outstanding",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weighted_average_basic_and_diluted_shares_outstanding",
                     "type": "float",
                     "description": "Weighted average basic and diluted shares outstanding",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -10362,301 +11740,301 @@
                     "name": "revenue",
                     "type": "float",
                     "description": "Total Revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cost_of_revenue_goods",
                     "type": "float",
                     "description": "Cost of Revenue - Goods",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cost_of_revenue_services",
                     "type": "float",
                     "description": "Cost of Revenue - Services",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cost_of_revenue",
                     "type": "float",
                     "description": "Cost of Revenue",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_profit",
                     "type": "float",
                     "description": "Gross Profit",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "provisions_for_loan_lease_and_other_losses",
                     "type": "float",
                     "description": "Provisions for loan lease and other losses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "depreciation_and_amortization",
                     "type": "float",
                     "description": "Depreciation and Amortization",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_tax_expense_benefit_current",
                     "type": "float",
                     "description": "Income tax expense benefit current",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deferred_tax_benefit",
                     "type": "float",
                     "description": "Deferred tax benefit",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "benefits_costs_expenses",
                     "type": "float",
                     "description": "Benefits, costs and expenses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "selling_general_and_administrative_expense",
                     "type": "float",
                     "description": "Selling, general and administrative expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "research_and_development",
                     "type": "float",
                     "description": "Research and development",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "costs_and_expenses",
                     "type": "float",
                     "description": "Costs and expenses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_operating_expenses",
                     "type": "float",
                     "description": "Other Operating Expenses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_expenses",
                     "type": "float",
                     "description": "Operating expenses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_income",
                     "type": "float",
                     "description": "Operating Income/Loss",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_operating_income",
                     "type": "float",
                     "description": "Non Operating Income/Loss",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_and_dividend_income",
                     "type": "float",
                     "description": "Interest and Dividend Income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_interest_expense",
                     "type": "float",
                     "description": "Interest Expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_and_debt_expense",
                     "type": "float",
                     "description": "Interest and Debt Expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_interest_income",
                     "type": "float",
                     "description": "Interest Income Net",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_income_after_provision_for_losses",
                     "type": "float",
                     "description": "Interest Income After Provision for Losses",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_interest_expense",
                     "type": "float",
                     "description": "Non-Interest Expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "non_interest_income",
                     "type": "float",
                     "description": "Non-Interest Income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_from_discontinued_operations_net_of_tax_on_disposal",
                     "type": "float",
                     "description": "Income From Discontinued Operations Net of Tax on Disposal",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_from_discontinued_operations_net_of_tax",
                     "type": "float",
                     "description": "Income From Discontinued Operations Net of Tax",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_before_equity_method_investments",
                     "type": "float",
                     "description": "Income Before Equity Method Investments",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_from_equity_method_investments",
                     "type": "float",
                     "description": "Income From Equity Method Investments",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_pre_tax_income",
                     "type": "float",
                     "description": "Income Before Tax",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_tax_expense",
                     "type": "float",
                     "description": "Income Tax Expense",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_after_tax",
                     "type": "float",
                     "description": "Income After Tax",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "consolidated_net_income",
                     "type": "float",
                     "description": "Net Income/Loss",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_attributable_noncontrolling_interest",
                     "type": "float",
                     "description": "Net income (loss) attributable to noncontrolling interest",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_attributable_to_parent",
                     "type": "float",
                     "description": "Net income (loss) attributable to parent",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_attributable_to_common_shareholders",
                     "type": "float",
                     "description": "Net Income/Loss Available To Common Stockholders Basic",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "participating_securities_earnings",
                     "type": "float",
                     "description": "Participating Securities Distributed And Undistributed Earnings Loss Basic",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "undistributed_earnings_allocated_to_participating_securities",
                     "type": "float",
                     "description": "Undistributed Earnings Allocated To Participating Securities",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "common_stock_dividends",
                     "type": "float",
                     "description": "Common Stock Dividends",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "preferred_stock_dividends_and_other_adjustments",
                     "type": "float",
                     "description": "Preferred stock dividends and other adjustments",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "basic_earnings_per_share",
                     "type": "float",
                     "description": "Earnings Per Share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "diluted_earnings_per_share",
                     "type": "float",
                     "description": "Diluted Earnings Per Share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weighted_average_basic_shares_outstanding",
                     "type": "float",
                     "description": "Basic Average Shares",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weighted_average_diluted_shares_outstanding",
                     "type": "float",
                     "description": "Diluted Average Shares",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -10684,7 +12062,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "10",
+                    "default": 10,
                     "optional": true
                 },
                 {
@@ -10705,7 +12083,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : IncomeStatementGrowth\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[IncomeStatementGrowth]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -10713,7 +12117,7 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -10944,7 +12348,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "100",
+                    "default": 100,
                     "optional": true
                 },
                 {
@@ -10960,7 +12364,7 @@
                     "name": "with_ttm",
                     "type": "bool",
                     "description": "Include trailing twelve months (TTM) data.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ],
@@ -10968,7 +12372,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : KeyMetrics\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[KeyMetrics]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -10976,21 +12406,21 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap",
                     "type": "float",
                     "description": "Market capitalization",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe_ratio",
                     "type": "float",
                     "description": "Price-to-earnings ratio (P/E ratio)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -11013,392 +12443,392 @@
                     "name": "calendar_year",
                     "type": "int",
                     "description": "Calendar year.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue_per_share",
                     "type": "float",
                     "description": "Revenue per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_per_share",
                     "type": "float",
                     "description": "Net income per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_cash_flow_per_share",
                     "type": "float",
                     "description": "Operating cash flow per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_per_share",
                     "type": "float",
                     "description": "Free cash flow per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_per_share",
                     "type": "float",
                     "description": "Cash per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "book_value_per_share",
                     "type": "float",
                     "description": "Book value per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tangible_book_value_per_share",
                     "type": "float",
                     "description": "Tangible book value per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shareholders_equity_per_share",
                     "type": "float",
                     "description": "Shareholders equity per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_debt_per_share",
                     "type": "float",
                     "description": "Interest debt per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_value",
                     "type": "float",
                     "description": "Enterprise value",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_sales_ratio",
                     "type": "float",
                     "description": "Price-to-sales ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pocf_ratio",
                     "type": "float",
                     "description": "Price-to-operating cash flow ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pfcf_ratio",
                     "type": "float",
                     "description": "Price-to-free cash flow ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pb_ratio",
                     "type": "float",
                     "description": "Price-to-book ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ptb_ratio",
                     "type": "float",
                     "description": "Price-to-tangible book ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ev_to_sales",
                     "type": "float",
                     "description": "Enterprise value-to-sales ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_value_over_ebitda",
                     "type": "float",
                     "description": "Enterprise value-to-EBITDA ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ev_to_operating_cash_flow",
                     "type": "float",
                     "description": "Enterprise value-to-operating cash flow ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ev_to_free_cash_flow",
                     "type": "float",
                     "description": "Enterprise value-to-free cash flow ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "earnings_yield",
                     "type": "float",
                     "description": "Earnings yield",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_yield",
                     "type": "float",
                     "description": "Free cash flow yield",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "debt_to_equity",
                     "type": "float",
                     "description": "Debt-to-equity ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "debt_to_assets",
                     "type": "float",
                     "description": "Debt-to-assets ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_debt_to_ebitda",
                     "type": "float",
                     "description": "Net debt-to-EBITDA ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_ratio",
                     "type": "float",
                     "description": "Current ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_coverage",
                     "type": "float",
                     "description": "Interest coverage",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_quality",
                     "type": "float",
                     "description": "Income quality",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield",
                     "type": "float",
                     "description": "Dividend yield, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payout_ratio",
                     "type": "float",
                     "description": "Payout ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sales_general_and_administrative_to_revenue",
                     "type": "float",
                     "description": "Sales general and administrative expenses-to-revenue ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "research_and_development_to_revenue",
                     "type": "float",
                     "description": "Research and development expenses-to-revenue ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intangibles_to_total_assets",
                     "type": "float",
                     "description": "Intangibles-to-total assets ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_to_operating_cash_flow",
                     "type": "float",
                     "description": "Capital expenditures-to-operating cash flow ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_to_revenue",
                     "type": "float",
                     "description": "Capital expenditures-to-revenue ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_to_depreciation",
                     "type": "float",
                     "description": "Capital expenditures-to-depreciation ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "stock_based_compensation_to_revenue",
                     "type": "float",
                     "description": "Stock-based compensation-to-revenue ratio",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "graham_number",
                     "type": "float",
                     "description": "Graham number",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "roic",
                     "type": "float",
                     "description": "Return on invested capital",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_tangible_assets",
                     "type": "float",
                     "description": "Return on tangible assets",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "graham_net_net",
                     "type": "float",
                     "description": "Graham net-net working capital",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "working_capital",
                     "type": "float",
                     "description": "Working capital",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tangible_asset_value",
                     "type": "float",
                     "description": "Tangible asset value",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_current_asset_value",
                     "type": "float",
                     "description": "Net current asset value",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "invested_capital",
                     "type": "float",
                     "description": "Invested capital",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_receivables",
                     "type": "float",
                     "description": "Average receivables",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_payables",
                     "type": "float",
                     "description": "Average payables",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_inventory",
                     "type": "float",
                     "description": "Average inventory",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_sales_outstanding",
                     "type": "float",
                     "description": "Days sales outstanding",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_payables_outstanding",
                     "type": "float",
                     "description": "Days payables outstanding",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_of_inventory_on_hand",
                     "type": "float",
                     "description": "Days of inventory on hand",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "receivables_turnover",
                     "type": "float",
                     "description": "Receivables turnover",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payables_turnover",
                     "type": "float",
                     "description": "Payables turnover",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inventory_turnover",
                     "type": "float",
                     "description": "Inventory turnover",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "roe",
                     "type": "float",
                     "description": "Return on equity",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capex_per_share",
                     "type": "float",
                     "description": "Capital expenditures per share",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -11407,252 +12837,252 @@
                     "name": "price_to_book",
                     "type": "float",
                     "description": "Price to book ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_tangible_book",
                     "type": "float",
                     "description": "Price to tangible book ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_revenue",
                     "type": "float",
                     "description": "Price to revenue ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quick_ratio",
                     "type": "float",
                     "description": "Quick ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_margin",
                     "type": "float",
                     "description": "Gross margin, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebit_margin",
                     "type": "float",
                     "description": "EBIT margin, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "profit_margin",
                     "type": "float",
                     "description": "Profit margin, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps",
                     "type": "float",
                     "description": "Basic earnings per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps_growth",
                     "type": "float",
                     "description": "EPS growth, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue_growth",
                     "type": "float",
                     "description": "Revenue growth, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebitda_growth",
                     "type": "float",
                     "description": "EBITDA growth, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebit_growth",
                     "type": "float",
                     "description": "EBIT growth, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_growth",
                     "type": "float",
                     "description": "Net income growth, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_to_firm_growth",
                     "type": "float",
                     "description": "Free cash flow to firm growth, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "invested_capital_growth",
                     "type": "float",
                     "description": "Invested capital growth, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_assets",
                     "type": "float",
                     "description": "Return on assets, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_equity",
                     "type": "float",
                     "description": "Return on equity, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_invested_capital",
                     "type": "float",
                     "description": "Return on invested capital, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebitda",
                     "type": "int",
                     "description": "Earnings before interest, taxes, depreciation, and amortization.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebit",
                     "type": "int",
                     "description": "Earnings before interest and taxes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_debt",
                     "type": "int",
                     "description": "Long-term debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_debt",
                     "type": "int",
                     "description": "Total debt.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_capital",
                     "type": "int",
                     "description": "The sum of long-term debt and total shareholder equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_value",
                     "type": "int",
                     "description": "Enterprise value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_to_firm",
                     "type": "int",
                     "description": "Free cash flow to firm.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "altman_z_score",
                     "type": "float",
                     "description": "Altman Z-score.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta",
                     "type": "float",
                     "description": "Beta relative to the broad market (rolling three-year).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield",
                     "type": "float",
                     "description": "Dividend yield, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "earnings_yield",
                     "type": "float",
                     "description": "Earnings yield, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_price",
                     "type": "float",
                     "description": "Last price of the stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_high",
                     "type": "float",
                     "description": "52 week high",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_low",
                     "type": "float",
                     "description": "52 week low",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_avg",
                     "type": "int",
                     "description": "Average daily volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_interest",
                     "type": "int",
                     "description": "Number of shares reported as sold short.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_outstanding",
                     "type": "int",
                     "description": "Weighted average shares outstanding (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_to_cover",
                     "type": "float",
                     "description": "Days to cover short interest, based on average daily volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -11661,245 +13091,245 @@
                     "name": "forward_pe",
                     "type": "float",
                     "description": "Forward price-to-earnings ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "peg_ratio",
                     "type": "float",
                     "description": "PEG ratio (5-year expected).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "peg_ratio_ttm",
                     "type": "float",
                     "description": "PEG ratio (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps_ttm",
                     "type": "float",
                     "description": "Earnings per share (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps_forward",
                     "type": "float",
                     "description": "Forward earnings per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_to_ebitda",
                     "type": "float",
                     "description": "Enterprise value to EBITDA ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "earnings_growth",
                     "type": "float",
                     "description": "Earnings growth (Year Over Year), as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "earnings_growth_quarterly",
                     "type": "float",
                     "description": "Quarterly earnings growth (Year Over Year), as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue_per_share",
                     "type": "float",
                     "description": "Revenue per share (TTM).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "revenue_growth",
                     "type": "float",
                     "description": "Revenue growth (Year Over Year), as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_to_revenue",
                     "type": "float",
                     "description": "Enterprise value to revenue ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_per_share",
                     "type": "float",
                     "description": "Cash per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quick_ratio",
                     "type": "float",
                     "description": "Quick ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "current_ratio",
                     "type": "float",
                     "description": "Current ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "debt_to_equity",
                     "type": "float",
                     "description": "Debt-to-equity ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_margin",
                     "type": "float",
                     "description": "Gross margin, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_margin",
                     "type": "float",
                     "description": "Operating margin, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebitda_margin",
                     "type": "float",
                     "description": "EBITDA margin, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "profit_margin",
                     "type": "float",
                     "description": "Profit margin, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_assets",
                     "type": "float",
                     "description": "Return on assets, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_equity",
                     "type": "float",
                     "description": "Return on equity, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield",
                     "type": "float",
                     "description": "Dividend yield, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield_5y_avg",
                     "type": "float",
                     "description": "5-year average dividend yield, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payout_ratio",
                     "type": "float",
                     "description": "Payout ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "book_value",
                     "type": "float",
                     "description": "Book value per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_book",
                     "type": "float",
                     "description": "Price-to-book ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_value",
                     "type": "int",
                     "description": "Enterprise value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "overall_risk",
                     "type": "float",
                     "description": "Overall risk score.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "audit_risk",
                     "type": "float",
                     "description": "Audit risk score.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "board_risk",
                     "type": "float",
                     "description": "Board risk score.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "compensation_risk",
                     "type": "float",
                     "description": "Compensation risk score.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shareholder_rights_risk",
                     "type": "float",
                     "description": "Shareholder rights risk score.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta",
                     "type": "float",
                     "description": "Beta relative to the broad market (5-year monthly).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_return_1y",
                     "type": "float",
                     "description": "One-year price return, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency in which the data is presented.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -11934,7 +13364,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : KeyExecutives\n        Serializable results.\n    provider : Literal['fmp', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[KeyExecutives]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -11956,35 +13412,35 @@
                     "name": "pay",
                     "type": "int",
                     "description": "Pay of the key executive.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_pay",
                     "type": "str",
                     "description": "Currency of the pay.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gender",
                     "type": "str",
                     "description": "Gender of the key executive.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_born",
                     "type": "int",
                     "description": "Birth year of the key executive.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "title_since",
                     "type": "int",
                     "description": "Date the tile was held since.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -11994,14 +13450,14 @@
                     "name": "exercised_value",
                     "type": "int",
                     "description": "Value of shares exercised.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unexercised_value",
                     "type": "int",
                     "description": "Value of shares not exercised.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -12028,14 +13484,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -12049,7 +13505,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : ExecutiveCompensation\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[ExecutiveCompensation]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -12064,7 +13546,7 @@
                     "name": "cik",
                     "type": "str",
                     "description": "Central Index Key (CIK) for the requested entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -12176,7 +13658,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CompanyOverview\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CompanyOverview]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -12191,210 +13699,210 @@
                     "name": "price",
                     "type": "float",
                     "description": "Price of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta",
                     "type": "float",
                     "description": "Beta of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "vol_avg",
                     "type": "int",
                     "description": "Volume average of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mkt_cap",
                     "type": "int",
                     "description": "Market capitalization of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_div",
                     "type": "float",
                     "description": "Last dividend of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "range",
                     "type": "str",
                     "description": "Range of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "changes",
                     "type": "float",
                     "description": "Changes of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "company_name",
                     "type": "str",
                     "description": "Company name of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cik",
                     "type": "str",
                     "description": "Central Index Key (CIK) for the requested entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "isin",
                     "type": "str",
                     "description": "ISIN of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "CUSIP of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "Exchange of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_short_name",
                     "type": "str",
                     "description": "Exchange short name of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry",
                     "type": "str",
                     "description": "Industry of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "website",
                     "type": "str",
                     "description": "Website of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "description",
                     "type": "str",
                     "description": "Description of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ceo",
                     "type": "str",
                     "description": "CEO of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sector",
                     "type": "str",
                     "description": "Sector of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "Country of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "full_time_employees",
                     "type": "str",
                     "description": "Full time employees of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "phone",
                     "type": "str",
                     "description": "Phone of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "address",
                     "type": "str",
                     "description": "Address of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "city",
                     "type": "str",
                     "description": "City of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "state",
                     "type": "str",
                     "description": "State of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "zip",
                     "type": "str",
                     "description": "Zip of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dcf_diff",
                     "type": "float",
                     "description": "Discounted cash flow difference of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dcf",
                     "type": "float",
                     "description": "Discounted cash flow of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "image",
                     "type": "str",
                     "description": "Image of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ipo_date",
                     "type": "date",
                     "description": "IPO date of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -12464,7 +13972,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "12",
+                    "default": 12,
                     "optional": true
                 },
                 {
@@ -12481,13 +13989,39 @@
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The specific fiscal year. Reports do not go beyond 2008.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : FinancialRatios\n        Serializable results.\n    provider : Literal['fmp', 'intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[FinancialRatios]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -12509,7 +14043,7 @@
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "Fiscal year.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -12518,392 +14052,392 @@
                     "name": "current_ratio",
                     "type": "float",
                     "description": "Current ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quick_ratio",
                     "type": "float",
                     "description": "Quick ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_ratio",
                     "type": "float",
                     "description": "Cash ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_of_sales_outstanding",
                     "type": "float",
                     "description": "Days of sales outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_of_inventory_outstanding",
                     "type": "float",
                     "description": "Days of inventory outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_cycle",
                     "type": "float",
                     "description": "Operating cycle.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_of_payables_outstanding",
                     "type": "float",
                     "description": "Days of payables outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_conversion_cycle",
                     "type": "float",
                     "description": "Cash conversion cycle.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "gross_profit_margin",
                     "type": "float",
                     "description": "Gross profit margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_profit_margin",
                     "type": "float",
                     "description": "Operating profit margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pretax_profit_margin",
                     "type": "float",
                     "description": "Pretax profit margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_profit_margin",
                     "type": "float",
                     "description": "Net profit margin.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "effective_tax_rate",
                     "type": "float",
                     "description": "Effective tax rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_assets",
                     "type": "float",
                     "description": "Return on assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_equity",
                     "type": "float",
                     "description": "Return on equity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_on_capital_employed",
                     "type": "float",
                     "description": "Return on capital employed.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_income_per_ebt",
                     "type": "float",
                     "description": "Net income per EBT.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebt_per_ebit",
                     "type": "float",
                     "description": "EBT per EBIT.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ebit_per_revenue",
                     "type": "float",
                     "description": "EBIT per revenue.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "debt_ratio",
                     "type": "float",
                     "description": "Debt ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "debt_equity_ratio",
                     "type": "float",
                     "description": "Debt equity ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_term_debt_to_capitalization",
                     "type": "float",
                     "description": "Long term debt to capitalization.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_debt_to_capitalization",
                     "type": "float",
                     "description": "Total debt to capitalization.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interest_coverage",
                     "type": "float",
                     "description": "Interest coverage.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_flow_to_debt_ratio",
                     "type": "float",
                     "description": "Cash flow to debt ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "company_equity_multiplier",
                     "type": "float",
                     "description": "Company equity multiplier.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "receivables_turnover",
                     "type": "float",
                     "description": "Receivables turnover.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payables_turnover",
                     "type": "float",
                     "description": "Payables turnover.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inventory_turnover",
                     "type": "float",
                     "description": "Inventory turnover.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fixed_asset_turnover",
                     "type": "float",
                     "description": "Fixed asset turnover.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asset_turnover",
                     "type": "float",
                     "description": "Asset turnover.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_cash_flow_per_share",
                     "type": "float",
                     "description": "Operating cash flow per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_per_share",
                     "type": "float",
                     "description": "Free cash flow per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_per_share",
                     "type": "float",
                     "description": "Cash per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payout_ratio",
                     "type": "float",
                     "description": "Payout ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "operating_cash_flow_sales_ratio",
                     "type": "float",
                     "description": "Operating cash flow sales ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_cash_flow_operating_cash_flow_ratio",
                     "type": "float",
                     "description": "Free cash flow operating cash flow ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cash_flow_coverage_ratios",
                     "type": "float",
                     "description": "Cash flow coverage ratios.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_term_coverage_ratios",
                     "type": "float",
                     "description": "Short term coverage ratios.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "capital_expenditure_coverage_ratio",
                     "type": "float",
                     "description": "Capital expenditure coverage ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_paid_and_capex_coverage_ratio",
                     "type": "float",
                     "description": "Dividend paid and capex coverage ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_payout_ratio",
                     "type": "float",
                     "description": "Dividend payout ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_book_value_ratio",
                     "type": "float",
                     "description": "Price book value ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_book_ratio",
                     "type": "float",
                     "description": "Price to book ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_sales_ratio",
                     "type": "float",
                     "description": "Price to sales ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_earnings_ratio",
                     "type": "float",
                     "description": "Price earnings ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_free_cash_flows_ratio",
                     "type": "float",
                     "description": "Price to free cash flows ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_to_operating_cash_flows_ratio",
                     "type": "float",
                     "description": "Price to operating cash flows ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_cash_flow_ratio",
                     "type": "float",
                     "description": "Price cash flow ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_earnings_to_growth_ratio",
                     "type": "float",
                     "description": "Price earnings to growth ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_sales_ratio",
                     "type": "float",
                     "description": "Price sales ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield",
                     "type": "float",
                     "description": "Dividend yield.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield_percentage",
                     "type": "float",
                     "description": "Dividend yield percentage.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_per_share",
                     "type": "float",
                     "description": "Dividend per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "enterprise_value_multiple",
                     "type": "float",
                     "description": "Enterprise value multiple.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_fair_value",
                     "type": "float",
                     "description": "Price fair value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -12952,7 +14486,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : RevenueGeographic\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[RevenueGeographic]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -12967,21 +14527,21 @@
                     "name": "fiscal_period",
                     "type": "str",
                     "description": "The fiscal period of the reporting period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The fiscal year of the reporting period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date",
                     "type": "date",
                     "description": "The filing date of the report.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -13037,7 +14597,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : RevenueBusinessLine\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[RevenueBusinessLine]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -13052,21 +14638,21 @@
                     "name": "fiscal_period",
                     "type": "str",
                     "description": "The fiscal period of the reporting period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fiscal_year",
                     "type": "int",
                     "description": "The fiscal year of the reporting period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date",
                     "type": "date",
                     "description": "The filing date of the report.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -13094,21 +14680,21 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "form_type",
                     "type": "str",
                     "description": "Filter by form type. Check the data provider for available types.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "100",
+                    "default": 100,
                     "optional": true
                 },
                 {
@@ -13125,21 +14711,21 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "thea_enabled",
                     "type": "bool",
                     "description": "Return filings that have been read by Intrinio's Thea NLP.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -13148,27 +14734,53 @@
                     "name": "cik",
                     "type": "Union[int, str]",
                     "description": "Lookup filings by Central Index Key (CIK) instead of by symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "type",
                     "type": "Literal['1', '1-A', '1-A POS', '1-A-W', '1-E', '1-E AD', '1-K', '1-SA', '1-U', '1-Z', '1-Z-W', '10-12B', '10-12G', '10-D', '10-K', '10-KT', '10-Q', '10-QT', '11-K', '11-KT', '13F-HR', '13F-NT', '13FCONP', '144', '15-12B', '15-12G', '15-15D', '15F-12B', '15F-12G', '15F-15D', '18-12B', '18-K', '19B-4E', '2-A', '2-AF', '2-E', '20-F', '20FR12B', '20FR12G', '24F-2NT', '25', '25-NSE', '253G1', '253G2', '253G3', '253G4', '3', '305B2', '34-12H', '4', '40-17F1', '40-17F2', '40-17G', '40-17GCS', '40-202A', '40-203A', '40-206A', '40-24B2', '40-33', '40-6B', '40-8B25', '40-8F-2', '40-APP', '40-F', '40-OIP', '40FR12B', '40FR12G', '424A', '424B1', '424B2', '424B3', '424B4', '424B5', '424B7', '424B8', '424H', '425', '485APOS', '485BPOS', '485BXT', '486APOS', '486BPOS', '486BXT', '487', '497', '497AD', '497H2', '497J', '497K', '497VPI', '497VPU', '5', '6-K', '6B NTC', '6B ORDR', '8-A12B', '8-A12G', '8-K', '8-K12B', '8-K12G3', '8-K15D5', '8-M', '8F-2 NTC', '8F-2 ORDR', '9-M', 'ABS-15G', 'ABS-EE', 'ADN-MTL', 'ADV-E', 'ADV-H-C', 'ADV-H-T', 'ADV-NR', 'ANNLRPT', 'APP NTC', 'APP ORDR', 'APP WD', 'APP WDG', 'ARS', 'ATS-N', 'ATS-N-C', 'ATS-N/UA', 'AW', 'AW WD', 'C', 'C-AR', 'C-AR-W', 'C-TR', 'C-TR-W', 'C-U', 'C-U-W', 'C-W', 'CB', 'CERT', 'CERTARCA', 'CERTBATS', 'CERTCBO', 'CERTNAS', 'CERTNYS', 'CERTPAC', 'CFPORTAL', 'CFPORTAL-W', 'CORRESP', 'CT ORDER', 'D', 'DEF 14A', 'DEF 14C', 'DEFA14A', 'DEFA14C', 'DEFC14A', 'DEFC14C', 'DEFM14A', 'DEFM14C', 'DEFN14A', 'DEFR14A', 'DEFR14C', 'DEL AM', 'DFAN14A', 'DFRN14A', 'DOS', 'DOSLTR', 'DRS', 'DRSLTR', 'DSTRBRPT', 'EFFECT', 'F-1', 'F-10', 'F-10EF', 'F-10POS', 'F-1MEF', 'F-3', 'F-3ASR', 'F-3D', 'F-3DPOS', 'F-3MEF', 'F-4', 'F-4 POS', 'F-4MEF', 'F-6', 'F-6 POS', 'F-6EF', 'F-7', 'F-7 POS', 'F-8', 'F-8 POS', 'F-80', 'F-80POS', 'F-9', 'F-9 POS', 'F-N', 'F-X', 'FOCUSN', 'FWP', 'G-405', 'G-405N', 'G-FIN', 'G-FINW', 'IRANNOTICE', 'MA', 'MA-A', 'MA-I', 'MA-W', 'MSD', 'MSDCO', 'MSDW', 'N-1', 'N-14', 'N-14 8C', 'N-14MEF', 'N-18F1', 'N-1A', 'N-2', 'N-2 POSASR', 'N-23C-2', 'N-23C3A', 'N-23C3B', 'N-23C3C', 'N-2ASR', 'N-2MEF', 'N-30B-2', 'N-30D', 'N-4', 'N-5', 'N-54A', 'N-54C', 'N-6', 'N-6F', 'N-8A', 'N-8B-2', 'N-8F', 'N-8F NTC', 'N-8F ORDR', 'N-CEN', 'N-CR', 'N-CSR', 'N-CSRS', 'N-MFP', 'N-MFP1', 'N-MFP2', 'N-PX', 'N-Q', 'N-VP', 'N-VPFS', 'NO ACT', 'NPORT-EX', 'NPORT-NP', 'NPORT-P', 'NRSRO-CE', 'NRSRO-UPD', 'NSAR-A', 'NSAR-AT', 'NSAR-B', 'NSAR-BT', 'NSAR-U', 'NT 10-D', 'NT 10-K', 'NT 10-Q', 'NT 11-K', 'NT 20-F', 'NT N-CEN', 'NT N-MFP', 'NT N-MFP1', 'NT N-MFP2', 'NT NPORT-EX', 'NT NPORT-P', 'NT-NCEN', 'NT-NCSR', 'NT-NSAR', 'NTFNCEN', 'NTFNCSR', 'NTFNSAR', 'NTN 10D', 'NTN 10K', 'NTN 10Q', 'NTN 20F', 'OIP NTC', 'OIP ORDR', 'POS 8C', 'POS AM', 'POS AMI', 'POS EX', 'POS462B', 'POS462C', 'POSASR', 'PRE 14A', 'PRE 14C', 'PREC14A', 'PREC14C', 'PREM14A', 'PREM14C', 'PREN14A', 'PRER14A', 'PRER14C', 'PRRN14A', 'PX14A6G', 'PX14A6N', 'QRTLYRPT', 'QUALIF', 'REG-NR', 'REVOKED', 'RW', 'RW WD', 'S-1', 'S-11', 'S-11MEF', 'S-1MEF', 'S-20', 'S-3', 'S-3ASR', 'S-3D', 'S-3DPOS', 'S-3MEF', 'S-4', 'S-4 POS', 'S-4EF', 'S-4MEF', 'S-6', 'S-8', 'S-8 POS', 'S-B', 'S-BMEF', 'SBSE', 'SBSE-A', 'SBSE-BD', 'SBSE-C', 'SBSE-W', 'SC 13D', 'SC 13E1', 'SC 13E3', 'SC 13G', 'SC 14D9', 'SC 14F1', 'SC 14N', 'SC TO-C', 'SC TO-I', 'SC TO-T', 'SC13E4F', 'SC14D1F', 'SC14D9C', 'SC14D9F', 'SD', 'SDR', 'SE', 'SEC ACTION', 'SEC STAFF ACTION', 'SEC STAFF LETTER', 'SF-1', 'SF-3', 'SL', 'SP 15D2', 'STOP ORDER', 'SUPPL', 'T-3', 'TA-1', 'TA-2', 'TA-W', 'TACO', 'TH', 'TTW', 'UNDER', 'UPLOAD', 'WDL-REQ', 'X-17A-5']",
                     "description": "Type of the SEC filing form.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "use_cache",
                     "type": "bool",
                     "description": "Whether or not to use cache. If True, cache will store for one day.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CompanyFilings\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CompanyFilings]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -13183,35 +14795,35 @@
                     "name": "accepted_date",
                     "type": "datetime",
                     "description": "Accepted date of the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cik",
                     "type": "str",
                     "description": "Central Index Key (CIK) for the requested entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "report_type",
                     "type": "str",
                     "description": "Type of filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_url",
                     "type": "str",
                     "description": "URL to the filing page.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -13235,7 +14847,7 @@
                     "name": "period_end_date",
                     "type": "date",
                     "description": "Ending date of the fiscal period for the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -13249,7 +14861,7 @@
                     "name": "instance_url",
                     "type": "str",
                     "description": "URL for the XBRL filing for the report.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -13272,91 +14884,91 @@
                     "name": "report_date",
                     "type": "date",
                     "description": "The date of the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "act",
                     "type": "Union[int, str]",
                     "description": "The SEC Act number.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "items",
                     "type": "Union[str, float]",
                     "description": "The SEC Item numbers.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "primary_doc_description",
                     "type": "str",
                     "description": "The description of the primary document.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "primary_doc",
                     "type": "str",
                     "description": "The filename of the primary document.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "accession_number",
                     "type": "Union[int, str]",
                     "description": "The accession number.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "file_number",
                     "type": "Union[int, str]",
                     "description": "The file number.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "film_number",
                     "type": "Union[int, str]",
                     "description": "The film number.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_inline_xbrl",
                     "type": "Union[int, str]",
                     "description": "Whether the filing is an inline XBRL filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_xbrl",
                     "type": "Union[int, str]",
                     "description": "Whether the filing is an XBRL filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "size",
                     "type": "Union[int, str]",
                     "description": "The size of the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "complete_submission_url",
                     "type": "str",
                     "description": "The URL to the complete filing submission.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_detail_url",
                     "type": "str",
                     "description": "The URL to the filing details.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -13390,7 +15002,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : HistoricalSplits\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[HistoricalSplits]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -13461,7 +15099,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EarningsCallTranscript\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EarningsCallTranscript]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -13525,7 +15189,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return. Default is 252, the number of trading days in a year.",
-                    "default": "252",
+                    "default": 252,
                     "optional": true
                 },
                 {
@@ -13539,7 +15203,33 @@
             "tiingo": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : TrailingDividendYield\n        Serializable results.\n    provider : Literal['tiingo']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[TrailingDividendYield]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['tiingo']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -13582,14 +15272,14 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "page",
                     "type": "int",
                     "description": "Page number of the data to fetch.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 },
                 {
@@ -13603,7 +15293,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityOwnership\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityOwnership]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -13914,20 +15630,46 @@
                     "name": "include_current_quarter",
                     "type": "bool",
                     "description": "Include current quarter data.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : InstitutionalOwnership\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[InstitutionalOwnership]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -13942,7 +15684,7 @@
                     "name": "cik",
                     "type": "str",
                     "description": "Central Index Key (CIK) for the requested entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -13979,21 +15721,21 @@
                     "name": "number_of_13f_shares",
                     "type": "int",
                     "description": "Number of 13F shares.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_number_of_13f_shares",
                     "type": "int",
                     "description": "Number of 13F shares in the last quarter.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "number_of_13f_shares_change",
                     "type": "int",
                     "description": "Change in the number of 13F shares.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -14209,7 +15951,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "500",
+                    "default": 500,
                     "optional": true
                 },
                 {
@@ -14225,7 +15967,7 @@
                     "name": "transaction_type",
                     "type": "Literal[None, 'award', 'conversion', 'return', 'expire_short', 'in_kind', 'gift', 'expire_long', 'discretionary', 'other', 'small', 'exempt', 'otm', 'purchase', 'sale', 'tender', 'will', 'itm', 'trust']",
                     "description": "Type of the transaction.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -14248,7 +15990,7 @@
                     "name": "ownership_type",
                     "type": "Literal['D', 'I']",
                     "description": "Type of ownership.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -14261,7 +16003,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : InsiderTrading\n        Serializable results.\n    provider : Literal['fmp', 'intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[InsiderTrading]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -14269,98 +16037,98 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "company_cik",
                     "type": "Union[int, str]",
                     "description": "CIK number of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_date",
                     "type": "Union[date, datetime]",
                     "description": "Filing date of the trade.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "transaction_date",
                     "type": "date",
                     "description": "Date of the transaction.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "owner_cik",
                     "type": "Union[int, str]",
                     "description": "Reporting individual's CIK.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "owner_name",
                     "type": "str",
                     "description": "Name of the reporting individual.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "owner_title",
                     "type": "str",
                     "description": "The title held by the reporting individual.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "transaction_type",
                     "type": "str",
                     "description": "Type of transaction being reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "acquisition_or_disposition",
                     "type": "str",
                     "description": "Acquisition or disposition of the shares.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "security_type",
                     "type": "str",
                     "description": "The type of security transacted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "securities_owned",
                     "type": "float",
                     "description": "Number of securities owned by the reporting individual.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "securities_transacted",
                     "type": "float",
                     "description": "Number of securities transacted by the reporting individual.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "transaction_price",
                     "type": "float",
                     "description": "The price of the transaction.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "filing_url",
                     "type": "str",
                     "description": "Link to the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -14385,91 +16153,91 @@
                     "name": "conversion_exercise_price",
                     "type": "float",
                     "description": "Conversion/Exercise price of the shares.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "deemed_execution_date",
                     "type": "date",
                     "description": "Deemed execution date of the trade.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exercise_date",
                     "type": "date",
                     "description": "Exercise date of the trade.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "expiration_date",
                     "type": "date",
                     "description": "Expiration date of the derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "underlying_security_title",
                     "type": "str",
                     "description": "Name of the underlying non-derivative security related to this derivative transaction.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "underlying_shares",
                     "type": "Union[float, int]",
                     "description": "Number of underlying shares related to this derivative transaction.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "nature_of_ownership",
                     "type": "str",
                     "description": "Nature of ownership of the insider trading.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "director",
                     "type": "bool",
                     "description": "Whether the owner is a director.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "officer",
                     "type": "bool",
                     "description": "Whether the owner is an officer.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ten_percent_owner",
                     "type": "bool",
                     "description": "Whether the owner is a 10% owner.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_relation",
                     "type": "bool",
                     "description": "Whether the owner is having another relation.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "derivative_transaction",
                     "type": "bool",
                     "description": "Whether the owner is having a derivative transaction.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "report_line_number",
                     "type": "int",
                     "description": "Report line number of the insider trading.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -14505,7 +16273,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : ShareStatistics\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[ShareStatistics]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -14520,35 +16314,35 @@
                     "name": "date",
                     "type": "date",
                     "description": "The date of the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "free_float",
                     "type": "float",
                     "description": "Percentage of unrestricted shares of a publicly-traded company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "float_shares",
                     "type": "float",
                     "description": "Number of shares available for trading by the general public.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "outstanding_shares",
                     "type": "float",
                     "description": "Total number of shares of a publicly-traded company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "source",
                     "type": "str",
                     "description": "Source of the received data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -14558,14 +16352,14 @@
                     "name": "adjusted_outstanding_shares",
                     "type": "float",
                     "description": "Total number of shares of a publicly-traded company, adjusted for splits.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "public_float",
                     "type": "float",
                     "description": "Aggregate market value of the shares of a publicly-traded company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -14574,70 +16368,70 @@
                     "name": "implied_shares_outstanding",
                     "type": "int",
                     "description": "Implied Shares Outstanding of common equity, assuming the conversion of all convertible subsidiary equity into common.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_interest",
                     "type": "int",
                     "description": "Number of shares that are reported short.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_percent_of_float",
                     "type": "float",
                     "description": "Percentage of shares that are reported short, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "days_to_cover",
                     "type": "float",
                     "description": "Number of days to repurchase the shares as a ratio of average daily volume",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_interest_prev_month",
                     "type": "int",
                     "description": "Number of shares that were reported short in the previous month.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_interest_prev_date",
                     "type": "date",
                     "description": "Date of the previous month's report.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "insider_ownership",
                     "type": "float",
                     "description": "Percentage of shares held by insiders, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "institution_ownership",
                     "type": "float",
                     "description": "Percentage of shares held by institutions, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "institution_float_ownership",
                     "type": "float",
                     "description": "Percentage of float held by institutions, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "institutions_count",
                     "type": "int",
                     "description": "Number of institutions holding shares.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -14664,14 +16458,14 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for. The date represents the end of the reporting period. All form 13F-HR filings are based on the calendar year and are reported quarterly. If a date is not supplied, the most recent filing is returned. Submissions beginning 2013-06-30 are supported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return. The number of previous filings to return. The date parameter takes priority over this parameter.",
-                    "default": "1",
+                    "default": 1,
                     "optional": true
                 },
                 {
@@ -14685,7 +16479,33 @@
             "sec": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : Form13FHR\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[Form13FHR]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -14721,35 +16541,35 @@
                     "name": "security_type",
                     "type": "Literal['SH', 'PRN']",
                     "description": "The total number of shares of the class of security or the principal amount of such class. 'SH' for shares. 'PRN' for principal amount. Convertible debt securities are reported as 'PRN'.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "option_type",
                     "type": "Literal['call', 'put']",
                     "description": "Defined when the holdings being reported are put or call options. Only long positions are reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "voting_authority_sole",
                     "type": "int",
                     "description": "The number of shares for which the Manager exercises sole voting authority (none).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "voting_authority_shared",
                     "type": "int",
                     "description": "The number of shares for which the Manager exercises a defined shared voting authority (none).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "voting_authority_other",
                     "type": "int",
                     "description": "The number of shares for which the Manager exercises other shared voting authority (none).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -14816,7 +16636,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityQuote\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityQuote]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -14831,224 +16677,224 @@
                     "name": "asset_type",
                     "type": "str",
                     "description": "Type of asset - i.e, stock, ETF, etc.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "name",
                     "type": "str",
                     "description": "Name of the company or asset.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "The name or symbol of the venue where the data is from.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid",
                     "type": "float",
                     "description": "Price of the top bid order.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid_size",
                     "type": "int",
                     "description": "This represents the number of round lot orders at the given price. The normal round lot size is 100 shares. A size of 2 means there are 200 shares available at the given price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid_exchange",
                     "type": "str",
                     "description": "The specific trading venue where the purchase order was placed.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask",
                     "type": "float",
                     "description": "Price of the top ask order.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask_size",
                     "type": "int",
                     "description": "This represents the number of round lot orders at the given price. The normal round lot size is 100 shares. A size of 2 means there are 200 shares available at the given price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask_exchange",
                     "type": "str",
                     "description": "The specific trading venue where the sale order was placed.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quote_conditions",
                     "type": "Union[str, int, List[str], List[int]]",
                     "description": "Conditions or condition codes applicable to the quote.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quote_indicators",
                     "type": "Union[str, int, List[str], List[int]]",
                     "description": "Indicators or indicator codes applicable to the participant quote related to the price bands for the issue, or the affect the quote has on the NBBO.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sales_conditions",
                     "type": "Union[str, int, List[str], List[int]]",
                     "description": "Conditions or condition codes applicable to the sale.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sequence_number",
                     "type": "int",
                     "description": "The sequence number represents the sequence in which message events happened. These are increasing and unique per ticker symbol, but will not always be sequential (e.g., 1, 2, 6, 9, 10, 11).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_center",
                     "type": "str",
                     "description": "The ID of the UTP participant that originated the message.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "participant_timestamp",
                     "type": "datetime",
                     "description": "Timestamp for when the quote was generated by the exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "trf_timestamp",
                     "type": "datetime",
                     "description": "Timestamp for when the TRF (Trade Reporting Facility) received the message.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sip_timestamp",
                     "type": "datetime",
                     "description": "Timestamp for when the SIP (Security Information Processor) received the message from the exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_price",
                     "type": "float",
                     "description": "Price of the last trade.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_tick",
                     "type": "str",
                     "description": "Whether the last sale was an up or down tick.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_size",
                     "type": "int",
                     "description": "Size of the last trade.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_timestamp",
                     "type": "datetime",
                     "description": "Date and Time when the last price was recorded.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "open",
                     "type": "float",
                     "description": "The open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "high",
                     "type": "float",
                     "description": "The high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "low",
                     "type": "float",
                     "description": "The low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close",
                     "type": "float",
                     "description": "The close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "Union[float, int]",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_volume",
                     "type": "Union[float, int]",
                     "description": "Volume of shares exchanged during the trading day on the specific exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_close",
                     "type": "float",
                     "description": "The previous close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in price from previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change in price as a normalized percentage.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_high",
                     "type": "float",
                     "description": "The one year high (52W High).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_low",
                     "type": "float",
                     "description": "The one year low (52W Low).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15057,56 +16903,56 @@
                     "name": "price_avg50",
                     "type": "float",
                     "description": "50 day moving average price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_avg200",
                     "type": "float",
                     "description": "200 day moving average price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "avg_volume",
                     "type": "int",
                     "description": "Average volume over the last 10 trading days.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap",
                     "type": "float",
                     "description": "Market cap of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_outstanding",
                     "type": "int",
                     "description": "Number of shares outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps",
                     "type": "float",
                     "description": "Earnings per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe",
                     "type": "float",
                     "description": "Price earnings ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "earnings_announcement",
                     "type": "Union[datetime, str]",
                     "description": "Upcoming earnings announcement date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15115,14 +16961,14 @@
                     "name": "is_darkpool",
                     "type": "bool",
                     "description": "Whether or not the current trade is from a darkpool.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "source",
                     "type": "str",
                     "description": "Source of the Intrinio data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -15134,9 +16980,9 @@
                 },
                 {
                     "name": "security",
-                    "type": "openbb_intrinio.utils.references.IntrinioSecurity",
+                    "type": "IntrinioSecurity",
                     "description": "Security details related to the quote.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15145,35 +16991,35 @@
                     "name": "ma_50d",
                     "type": "float",
                     "description": "50-day moving average price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ma_200d",
                     "type": "float",
                     "description": "200-day moving average price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_average",
                     "type": "float",
                     "description": "Average daily trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_average_10d",
                     "type": "float",
                     "description": "Average daily trading volume in the last 10 days.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency of the price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -15209,48 +17055,74 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return. Up to ten million records will be returned. Pagination occurs in groups of 50,000. Remaining limit values will always return 50,000 more records unless it is the last page. High volume tickers will require multiple max requests for a single day's NBBO records. Expect stocks, like SPY, to approach 1GB in size, per day, as a raw CSV. Splitting large requests into chunks is recommended for full-day requests of high-volume symbols.",
-                    "default": "50000",
+                    "default": 50000,
                     "optional": true
                 },
                 {
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for. Use bracketed the timestamp parameters to specify exact time ranges.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "timestamp_lt",
                     "type": "Union[datetime, str]",
-                    "description": "Query by datetime, less than. Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,       YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
-                    "default": "None",
+                    "description": "Query by datetime, less than. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "timestamp_gt",
                     "type": "Union[datetime, str]",
-                    "description": "Query by datetime, greater than. Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,       YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
-                    "default": "None",
+                    "description": "Query by datetime, greater than. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "timestamp_lte",
                     "type": "Union[datetime, str]",
-                    "description": "Query by datetime, less than or equal to.       Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,       YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
-                    "default": "None",
+                    "description": "Query by datetime, less than or equal to. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "timestamp_gte",
                     "type": "Union[datetime, str]",
-                    "description": "Query by datetime, greater than or equal to.       Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,       YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
-                    "default": "None",
+                    "description": "Query by datetime, greater than or equal to. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour.",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityNBBO\n        Serializable results.\n    provider : Literal['polygon']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityNBBO]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['polygon']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -15302,49 +17174,49 @@
                     "name": "tape",
                     "type": "str",
                     "description": "The exchange tape.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "conditions",
                     "type": "Union[str, List[int], List[str]]",
                     "description": "A list of condition codes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "indicators",
                     "type": "List[int]",
                     "description": "A list of indicator codes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sequence_num",
                     "type": "int",
-                    "description": "The sequence number represents the sequence in which message events happened.       These are increasing and unique per ticker symbol, but will not always be sequential       (e.g., 1, 2, 6, 9, 10, 11)",
-                    "default": "None",
+                    "description": "The sequence number represents the sequence in which message events happened. These are increasing and unique per ticker symbol, but will not always be sequential (e.g., 1, 2, 6, 9, 10, 11)",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "participant_timestamp",
                     "type": "datetime",
-                    "description": "The nanosecond accuracy Participant/Exchange Unix Timestamp.       This is the timestamp of when the quote was actually generated at the exchange.",
-                    "default": "None",
+                    "description": "The nanosecond accuracy Participant/Exchange Unix Timestamp. This is the timestamp of when the quote was actually generated at the exchange.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sip_timestamp",
                     "type": "datetime",
-                    "description": "The nanosecond accuracy SIP Unix Timestamp.       This is the timestamp of when the SIP received this quote from the exchange which produced it.",
-                    "default": "None",
+                    "description": "The nanosecond accuracy SIP Unix Timestamp. This is the timestamp of when the SIP received this quote from the exchange which produced it.",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "trf_timestamp",
                     "type": "datetime",
-                    "description": "The nanosecond accuracy TRF (Trade Reporting Facility) Unix Timestamp.       This is the timestamp of when the trade reporting facility received this quote.",
-                    "default": "None",
+                    "description": "The nanosecond accuracy TRF (Trade Reporting Facility) Unix Timestamp. This is the timestamp of when the trade reporting facility received this quote.",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -15378,14 +17250,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -15402,14 +17274,14 @@
                     "name": "start_time",
                     "type": "datetime.time",
                     "description": "Return intervals starting at the specified time on the `start_date` formatted as 'HH:MM:SS'.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_time",
                     "type": "datetime.time",
                     "description": "Return intervals stopping at the specified time on the `end_date` formatted as 'HH:MM:SS'.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -15439,7 +17311,7 @@
                     "name": "extended_hours",
                     "type": "bool",
                     "description": "Include Pre and Post market data.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
@@ -15453,7 +17325,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "49999",
+                    "default": 49999,
                     "optional": true
                 }
             ],
@@ -15463,14 +17335,14 @@
                     "name": "extended_hours",
                     "type": "bool",
                     "description": "Include Pre and Post market data.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "include_actions",
                     "type": "bool",
                     "description": "Include dividends and stock splits in results.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -15484,20 +17356,46 @@
                     "name": "adjusted",
                     "type": "bool",
                     "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'adjustment' set as 'splits_and_dividends' instead.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "prepost",
                     "type": "bool",
                     "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'extended_hours' as True instead.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityHistorical\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityHistorical]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -15540,14 +17438,14 @@
                     "name": "volume",
                     "type": "Union[float, int]",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "vwap",
                     "type": "float",
                     "description": "Volume Weighted Average Price over the period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15556,28 +17454,28 @@
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unadjusted_volume",
                     "type": "float",
                     "description": "Unadjusted volume of the symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change in the price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15586,121 +17484,121 @@
                     "name": "average",
                     "type": "float",
                     "description": "Average trade price of an individual equity during the interval.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price of the symbol from the previous day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Percent change in the price of the symbol from the previous day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_open",
                     "type": "float",
                     "description": "The adjusted open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_high",
                     "type": "float",
                     "description": "The adjusted high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_low",
                     "type": "float",
                     "description": "The adjusted low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_volume",
                     "type": "float",
                     "description": "The adjusted volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fifty_two_week_high",
                     "type": "float",
                     "description": "52 week high price for the symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fifty_two_week_low",
                     "type": "float",
                     "description": "52 week low price for the symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "factor",
                     "type": "float",
                     "description": "factor by which to multiply equity prices before this date, in order to calculate historically-adjusted equity prices.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "split_ratio",
                     "type": "float",
                     "description": "Ratio of the equity split, if a split occurred.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend",
                     "type": "float",
                     "description": "Dividend amount, if a dividend was paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_time",
                     "type": "datetime",
                     "description": "The timestamp that represents the end of the interval span.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interval",
                     "type": "str",
                     "description": "The data time frequency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intra_period",
                     "type": "bool",
                     "description": "If true, the equity price represents an unfinished period (be it day, week, quarter, month, or year), meaning that the close price is the latest price available, not the official close price for the period",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "polygon": [
                 {
                     "name": "transactions",
-                    "type": "int, Gt(gt=0)",
+                    "type": "Annotated[int, Gt(gt=0)]",
                     "description": "Number of transactions for the symbol in the time period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15709,49 +17607,49 @@
                     "name": "adj_open",
                     "type": "float",
                     "description": "The adjusted open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_high",
                     "type": "float",
                     "description": "The adjusted high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_low",
                     "type": "float",
                     "description": "The adjusted low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_volume",
                     "type": "float",
                     "description": "The adjusted volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "split_ratio",
                     "type": "float",
                     "description": "Ratio of the equity split, if a split occurred.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend",
                     "type": "float",
                     "description": "Dividend amount, if a dividend was paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15760,14 +17658,14 @@
                     "name": "split_ratio",
                     "type": "float",
                     "description": "Ratio of the equity split, if a split occurred.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend",
                     "type": "float",
                     "description": "Dividend amount (split-adjusted), if a dividend was paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -15801,7 +17699,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : PricePerformance\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[PricePerformance]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -15809,98 +17733,98 @@
                     "name": "one_day",
                     "type": "float",
                     "description": "One-day return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "wtd",
                     "type": "float",
                     "description": "Week to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_week",
                     "type": "float",
                     "description": "One-week return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mtd",
                     "type": "float",
                     "description": "Month to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_month",
                     "type": "float",
                     "description": "One-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "qtd",
                     "type": "float",
                     "description": "Quarter to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "three_month",
                     "type": "float",
                     "description": "Three-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "six_month",
                     "type": "float",
                     "description": "Six-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ytd",
                     "type": "float",
                     "description": "Year to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_year",
                     "type": "float",
                     "description": "One-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "three_year",
                     "type": "float",
                     "description": "Three-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "five_year",
                     "type": "float",
                     "description": "Five-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ten_year",
                     "type": "float",
                     "description": "Ten-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "max",
                     "type": "float",
                     "description": "Return from the beginning of the time series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -15945,20 +17869,46 @@
                     "name": "limit",
                     "type": "int",
                     "description": "Limit the number of reports to parse, from most recent.     Approximately 24 reports per year, going back to 2009.",
-                    "default": "24",
+                    "default": 24,
                     "optional": true
                 },
                 {
                     "name": "skip_reports",
                     "type": "int",
                     "description": "Skip N number of reports from current. A value of 1 will skip the most recent report.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityFTD\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityFTD]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -15966,42 +17916,42 @@
                     "name": "settlement_date",
                     "type": "date",
                     "description": "The settlement date of the fail.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "CUSIP of the Security.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quantity",
                     "type": "int",
                     "description": "The number of fails on that settlement date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price",
                     "type": "float",
                     "description": "The price at the previous closing price from the settlement date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "description",
                     "type": "str",
                     "description": "The description of the Security.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -16029,14 +17979,14 @@
                     "name": "is_symbol",
                     "type": "bool",
                     "description": "Whether to search by ticker symbol.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "use_cache",
                     "type": "bool",
                     "description": "Whether to use the cache or not.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -16052,14 +18002,14 @@
                     "name": "active",
                     "type": "bool",
                     "description": "When true, return companies that are actively traded (having stock prices within the past 14 days). When false, return companies that are not actively traded or never have been traded.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "10000",
+                    "default": 10000,
                     "optional": true
                 }
             ],
@@ -16068,13 +18018,39 @@
                     "name": "is_fund",
                     "type": "bool",
                     "description": "Whether to direct the search to the list of mutual funds and ETFs.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquitySearch\n        Serializable results.\n    provider : Literal['intrinio', 'sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquitySearch]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['intrinio', 'sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -16082,7 +18058,7 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -16150,125 +18126,151 @@
                     "name": "mktcap_min",
                     "type": "int",
                     "description": "Filter by market cap greater than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mktcap_max",
                     "type": "int",
                     "description": "Filter by market cap less than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_min",
                     "type": "float",
                     "description": "Filter by price greater than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price_max",
                     "type": "float",
                     "description": "Filter by price less than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta_min",
                     "type": "float",
                     "description": "Filter by a beta greater than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta_max",
                     "type": "float",
                     "description": "Filter by a beta less than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_min",
                     "type": "int",
                     "description": "Filter by volume greater than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_max",
                     "type": "int",
                     "description": "Filter by volume less than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_min",
                     "type": "float",
                     "description": "Filter by dividend amount greater than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_max",
                     "type": "float",
                     "description": "Filter by dividend amount less than this value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_etf",
                     "type": "bool",
                     "description": "If true, returns only ETFs.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "is_active",
                     "type": "bool",
                     "description": "If false, returns only inactive tickers.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
                     "name": "sector",
                     "type": "Literal['Consumer Cyclical', 'Energy', 'Technology', 'Industrials', 'Financial Services', 'Basic Materials', 'Communication Services', 'Consumer Defensive', 'Healthcare', 'Real Estate', 'Utilities', 'Industrial Goods', 'Financial', 'Services', 'Conglomerates']",
                     "description": "Filter by sector.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry",
                     "type": "str",
                     "description": "Filter by industry.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "Filter by country, as a two-letter country code.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "Literal['amex', 'ams', 'ase', 'asx', 'ath', 'bme', 'bru', 'bud', 'bue', 'cai', 'cnq', 'cph', 'dfm', 'doh', 'etf', 'euronext', 'hel', 'hkse', 'ice', 'iob', 'ist', 'jkt', 'jnb', 'jpx', 'kls', 'koe', 'ksc', 'kuw', 'lse', 'mex', 'mutual_fund', 'nasdaq', 'neo', 'nse', 'nyse', 'nze', 'osl', 'otc', 'pnk', 'pra', 'ris', 'sao', 'sau', 'set', 'sgo', 'shh', 'shz', 'six', 'sto', 'tai', 'tlv', 'tsx', 'two', 'vie', 'wse', 'xetra']",
                     "description": "Filter by exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
                     "description": "Limit the number of results to return.",
-                    "default": "50000",
+                    "default": 50000,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityScreener\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityScreener]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -16292,84 +18294,84 @@
                     "name": "market_cap",
                     "type": "int",
                     "description": "The market cap of ticker.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sector",
                     "type": "str",
                     "description": "The sector the ticker belongs to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry",
                     "type": "str",
                     "description": "The industry ticker belongs to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta",
                     "type": "float",
                     "description": "The beta of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price",
                     "type": "float",
                     "description": "The current price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_annual_dividend",
                     "type": "float",
                     "description": "The last annual amount dividend paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The current trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "The exchange code the asset trades on.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_name",
                     "type": "str",
                     "description": "The full name of the primary exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "The two-letter country abbreviation where the head office is located.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_etf",
                     "type": "Literal[True, False]",
                     "description": "Whether the ticker is an ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "actively_trading",
                     "type": "Literal[True, False]",
                     "description": "Whether the ETF is actively trading.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -16405,7 +18407,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EquityInfo\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EquityInfo]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -16420,259 +18448,259 @@
                     "name": "name",
                     "type": "str",
                     "description": "Common name of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cik",
                     "type": "str",
                     "description": "Central Index Key (CIK) for the requested entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "CUSIP identifier for the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "isin",
                     "type": "str",
                     "description": "International Securities Identification Number.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "lei",
                     "type": "str",
                     "description": "Legal Entity Identifier assigned to the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "legal_name",
                     "type": "str",
                     "description": "Official legal name of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "stock_exchange",
                     "type": "str",
                     "description": "Stock exchange where the company is traded.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sic",
                     "type": "int",
                     "description": "Standard Industrial Classification code for the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "short_description",
                     "type": "str",
                     "description": "Short description of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "long_description",
                     "type": "str",
                     "description": "Long description of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ceo",
                     "type": "str",
                     "description": "Chief Executive Officer of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "company_url",
                     "type": "str",
                     "description": "URL of the company's website.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "business_address",
                     "type": "str",
                     "description": "Address of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mailing_address",
                     "type": "str",
                     "description": "Mailing address of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "business_phone_no",
                     "type": "str",
                     "description": "Phone number of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "hq_address1",
                     "type": "str",
                     "description": "Address of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "hq_address2",
                     "type": "str",
                     "description": "Address of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "hq_address_city",
                     "type": "str",
                     "description": "City of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "hq_address_postal_code",
                     "type": "str",
                     "description": "Zip code of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "hq_state",
                     "type": "str",
                     "description": "State of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "hq_country",
                     "type": "str",
                     "description": "Country of the company's headquarters.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inc_state",
                     "type": "str",
                     "description": "State in which the company is incorporated.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inc_country",
                     "type": "str",
                     "description": "Country in which the company is incorporated.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "employees",
                     "type": "int",
                     "description": "Number of employees working for the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "entity_legal_form",
                     "type": "str",
                     "description": "Legal form of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "entity_status",
                     "type": "str",
                     "description": "Status of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "latest_filing_date",
                     "type": "date",
                     "description": "Date of the company's latest filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "irs_number",
                     "type": "str",
                     "description": "IRS number assigned to the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sector",
                     "type": "str",
                     "description": "Sector in which the company operates.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry_category",
                     "type": "str",
                     "description": "Category of industry in which the company operates.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry_group",
                     "type": "str",
                     "description": "Group of industry in which the company operates.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "template",
                     "type": "str",
                     "description": "Template used to standardize the company's financial statements.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "standardized_active",
                     "type": "bool",
                     "description": "Whether the company is active or not.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "first_fundamental_date",
                     "type": "date",
                     "description": "Date of the company's first fundamental.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_fundamental_date",
                     "type": "date",
                     "description": "Date of the company's last fundamental.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "first_stock_price_date",
                     "type": "date",
                     "description": "Date of the company's first stock price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_stock_price_date",
                     "type": "date",
                     "description": "Date of the company's last stock price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -16709,63 +18737,63 @@
                     "name": "image",
                     "type": "str",
                     "description": "Image of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency in which the stock is traded.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap",
                     "type": "int",
                     "description": "Market capitalization of the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_price",
                     "type": "float",
                     "description": "The last traded price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_high",
                     "type": "float",
                     "description": "The one-year high of the price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_low",
                     "type": "float",
                     "description": "The one-year low of the price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_avg",
                     "type": "int",
                     "description": "Average daily trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "annualized_dividend_amount",
                     "type": "float",
                     "description": "The annualized dividend payment based on the most recent regular dividend payment.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta",
                     "type": "float",
                     "description": "Beta of the stock relative to the market.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -16774,14 +18802,14 @@
                     "name": "id",
                     "type": "str",
                     "description": "Intrinio ID for the company.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "thea_enabled",
                     "type": "bool",
                     "description": "Whether the company has been enabled for Thea.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -16790,70 +18818,70 @@
                     "name": "exchange_timezone",
                     "type": "str",
                     "description": "The timezone of the exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issue_type",
                     "type": "str",
                     "description": "The issuance type of the asset.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "The currency in which the asset is traded.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap",
                     "type": "int",
                     "description": "The market capitalization of the asset.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_outstanding",
                     "type": "int",
                     "description": "The number of listed shares outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_float",
                     "type": "int",
                     "description": "The number of shares in the public float.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_implied_outstanding",
                     "type": "int",
                     "description": "Implied shares outstanding of common equityassuming the conversion of all convertible subsidiary equity into common.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_short",
                     "type": "int",
                     "description": "The reported number of shares short.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield",
                     "type": "float",
                     "description": "The dividend yield of the asset, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta",
                     "type": "float",
                     "description": "The beta of the asset relative to the broad market.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -16889,7 +18917,33 @@
             "polygon": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : MarketSnapshots\n        Serializable results.\n    provider : Literal['fmp', 'polygon']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[MarketSnapshots]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'polygon']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -16904,56 +18958,56 @@
                     "name": "open",
                     "type": "float",
                     "description": "The open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "high",
                     "type": "float",
                     "description": "The high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "low",
                     "type": "float",
                     "description": "The low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close",
                     "type": "float",
                     "description": "The close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_close",
                     "type": "float",
                     "description": "The previous close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "The change in price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "The change in price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -16962,98 +19016,98 @@
                     "name": "last_price",
                     "type": "float",
                     "description": "The last price of the stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_price_timestamp",
                     "type": "Union[date, datetime]",
                     "description": "The timestamp of the last price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ma50",
                     "type": "float",
                     "description": "The 50-day moving average.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ma200",
                     "type": "float",
                     "description": "The 200-day moving average.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_high",
                     "type": "float",
                     "description": "The 52-week high.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_low",
                     "type": "float",
                     "description": "The 52-week low.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_avg",
                     "type": "int",
                     "description": "Average daily trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap",
                     "type": "int",
                     "description": "Market cap of the stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "eps",
                     "type": "float",
                     "description": "Earnings per share.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "pe",
                     "type": "float",
                     "description": "Price to earnings ratio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_outstanding",
                     "type": "int",
                     "description": "Number of shares outstanding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "name",
                     "type": "str",
                     "description": "The company name associated with the symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "The exchange of the stock.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "earnings_date",
                     "type": "Union[date, datetime]",
                     "description": "The upcoming earnings announcement date.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17062,42 +19116,42 @@
                     "name": "vwap",
                     "type": "float",
                     "description": "The volume weighted average price of the stock on the current trading day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_open",
                     "type": "float",
                     "description": "The previous trading session opening price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_high",
                     "type": "float",
                     "description": "The previous trading session high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_low",
                     "type": "float",
                     "description": "The previous trading session low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_volume",
                     "type": "float",
                     "description": "The previous trading session volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_vwap",
                     "type": "float",
                     "description": "The previous trading session VWAP.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -17111,70 +19165,70 @@
                     "name": "bid",
                     "type": "float",
                     "description": "The current bid price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid_size",
                     "type": "int",
                     "description": "The current bid size.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask_size",
                     "type": "int",
                     "description": "The current ask size.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask",
                     "type": "float",
                     "description": "The current ask price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quote_timestamp",
                     "type": "datetime",
                     "description": "The timestamp of the last quote.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_trade_price",
                     "type": "float",
                     "description": "The last trade price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_trade_size",
                     "type": "int",
                     "description": "The last trade size.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_trade_conditions",
                     "type": "List[int]",
                     "description": "The last trade condition codes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_trade_exchange",
                     "type": "int",
                     "description": "The last trade exchange ID code.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_trade_timestamp",
                     "type": "datetime",
                     "description": "The last trade timestamp.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -17210,14 +19264,14 @@
                     "name": "exchange",
                     "type": "Literal['AMEX', 'NYSE', 'NASDAQ', 'ETF', 'TSX', 'EURONEXT']",
                     "description": "The exchange code the ETF trades on.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_active",
                     "type": "Literal[True, False]",
                     "description": "Whether the ETF is actively trading.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17226,13 +19280,39 @@
                     "name": "exchange",
                     "type": "Literal['xnas', 'arcx', 'bats', 'xnys', 'bvmf', 'xshg', 'xshe', 'xhkg', 'xbom', 'xnse', 'xidx', 'tase', 'xkrx', 'xkls', 'xmex', 'xses', 'roco', 'xtai', 'xbkk', 'xist']",
                     "description": "Target a specific exchange by providing the MIC code.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfSearch\n        Serializable results.\n    provider : Literal['fmp', 'intrinio']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfSearch]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -17247,7 +19327,7 @@
                     "name": "name",
                     "type": "str",
                     "description": "Name of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17256,77 +19336,77 @@
                     "name": "market_cap",
                     "type": "float",
                     "description": "The market cap of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sector",
                     "type": "str",
                     "description": "The sector of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry",
                     "type": "str",
                     "description": "The industry of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta",
                     "type": "float",
                     "description": "The beta of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "price",
                     "type": "float",
                     "description": "The current price of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "last_annual_dividend",
                     "type": "float",
                     "description": "The last annual dividend paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "float",
                     "description": "The current trading volume of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "The exchange code the ETF trades on.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_name",
                     "type": "str",
                     "description": "The full name of the exchange the ETF trades on.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "The country the ETF is registered in.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "actively_trading",
                     "type": "Literal[True, False]",
                     "description": "Whether the ETF is actively trading.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17335,42 +19415,42 @@
                     "name": "exchange",
                     "type": "str",
                     "description": "The exchange MIC code.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "figi_ticker",
                     "type": "str",
                     "description": "The OpenFIGI ticker.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ric",
                     "type": "str",
                     "description": "The Reuters Instrument Code.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "isin",
                     "type": "str",
                     "description": "The International Securities Identification Number.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sedol",
                     "type": "str",
                     "description": "The Stock Exchange Daily Official List.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intrinio_id",
                     "type": "str",
                     "description": "The unique Intrinio ID for the security.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -17404,14 +19484,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -17428,14 +19508,14 @@
                     "name": "start_time",
                     "type": "datetime.time",
                     "description": "Return intervals starting at the specified time on the `start_date` formatted as 'HH:MM:SS'.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_time",
                     "type": "datetime.time",
                     "description": "Return intervals stopping at the specified time on the `end_date` formatted as 'HH:MM:SS'.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -17465,7 +19545,7 @@
                     "name": "extended_hours",
                     "type": "bool",
                     "description": "Include Pre and Post market data.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
@@ -17479,7 +19559,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "49999",
+                    "default": 49999,
                     "optional": true
                 }
             ],
@@ -17489,14 +19569,14 @@
                     "name": "extended_hours",
                     "type": "bool",
                     "description": "Include Pre and Post market data.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "include_actions",
                     "type": "bool",
                     "description": "Include dividends and stock splits in results.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -17510,20 +19590,46 @@
                     "name": "adjusted",
                     "type": "bool",
                     "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'adjustment' set as 'splits_and_dividends' instead.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
                     "name": "prepost",
                     "type": "bool",
                     "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'extended_hours' as True instead.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfHistorical\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfHistorical]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -17566,14 +19672,14 @@
                     "name": "volume",
                     "type": "Union[float, int]",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "vwap",
                     "type": "float",
                     "description": "Volume Weighted Average Price over the period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17582,28 +19688,28 @@
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unadjusted_volume",
                     "type": "float",
                     "description": "Unadjusted volume of the symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change in the price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17612,121 +19718,121 @@
                     "name": "average",
                     "type": "float",
                     "description": "Average trade price of an individual equity during the interval.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price of the symbol from the previous day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Percent change in the price of the symbol from the previous day.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_open",
                     "type": "float",
                     "description": "The adjusted open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_high",
                     "type": "float",
                     "description": "The adjusted high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_low",
                     "type": "float",
                     "description": "The adjusted low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_volume",
                     "type": "float",
                     "description": "The adjusted volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fifty_two_week_high",
                     "type": "float",
                     "description": "52 week high price for the symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fifty_two_week_low",
                     "type": "float",
                     "description": "52 week low price for the symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "factor",
                     "type": "float",
                     "description": "factor by which to multiply equity prices before this date, in order to calculate historically-adjusted equity prices.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "split_ratio",
                     "type": "float",
                     "description": "Ratio of the equity split, if a split occurred.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend",
                     "type": "float",
                     "description": "Dividend amount, if a dividend was paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_time",
                     "type": "datetime",
                     "description": "The timestamp that represents the end of the interval span.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "interval",
                     "type": "str",
                     "description": "The data time frequency.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intra_period",
                     "type": "bool",
                     "description": "If true, the equity price represents an unfinished period (be it day, week, quarter, month, or year), meaning that the close price is the latest price available, not the official close price for the period",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "polygon": [
                 {
                     "name": "transactions",
-                    "type": "int, Gt(gt=0)",
+                    "type": "Annotated[int, Gt(gt=0)]",
                     "description": "Number of transactions for the symbol in the time period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17735,49 +19841,49 @@
                     "name": "adj_open",
                     "type": "float",
                     "description": "The adjusted open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_high",
                     "type": "float",
                     "description": "The adjusted high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_low",
                     "type": "float",
                     "description": "The adjusted low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_close",
                     "type": "float",
                     "description": "The adjusted close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "adj_volume",
                     "type": "float",
                     "description": "The adjusted volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "split_ratio",
                     "type": "float",
                     "description": "Ratio of the equity split, if a split occurred.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend",
                     "type": "float",
                     "description": "Dividend amount, if a dividend was paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17786,14 +19892,14 @@
                     "name": "split_ratio",
                     "type": "float",
                     "description": "Ratio of the equity split, if a split occurred.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend",
                     "type": "float",
                     "description": "Dividend amount (split-adjusted), if a dividend was paid.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -17829,7 +19935,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfInfo\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfInfo]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -17851,7 +19983,7 @@
                     "name": "description",
                     "type": "str",
                     "description": "Description of the fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -17867,84 +19999,84 @@
                     "name": "issuer",
                     "type": "str",
                     "description": "Company of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "CUSIP of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "isin",
                     "type": "str",
                     "description": "ISIN of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "domicile",
                     "type": "str",
                     "description": "Domicile of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asset_class",
                     "type": "str",
                     "description": "Asset class of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "aum",
                     "type": "float",
                     "description": "Assets under management.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "nav",
                     "type": "float",
                     "description": "Net asset value of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "nav_currency",
                     "type": "str",
                     "description": "Currency of the ETF's net asset value.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "expense_ratio",
                     "type": "float",
                     "description": "The expense ratio, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "holdings_count",
                     "type": "int",
                     "description": "Number of holdings.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "avg_volume",
                     "type": "float",
                     "description": "Average daily trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "website",
                     "type": "str",
                     "description": "Website of the issuer.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -17953,798 +20085,798 @@
                     "name": "fund_listing_date",
                     "type": "date",
                     "description": "The date on which the Exchange Traded Product (ETP) or share class of the ETP is listed on a specific exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "data_change_date",
                     "type": "date",
                     "description": "The last date on which there was a change in a classifications data field for this ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "etn_maturity_date",
                     "type": "date",
                     "description": "If the product is an ETN, this field identifies the maturity date for the ETN.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_listed",
                     "type": "bool",
                     "description": "If true, the ETF is still listed on an exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close_date",
                     "type": "date",
                     "description": "The date on which the ETF was de-listed if it is no longer listed.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "The exchange Market Identifier Code (MIC).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "isin",
                     "type": "str",
                     "description": "International Securities Identification Number (ISIN).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ric",
                     "type": "str",
                     "description": "Reuters Instrument Code (RIC).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sedol",
                     "type": "str",
                     "description": "Stock Exchange Daily Official List (SEDOL).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "figi_symbol",
                     "type": "str",
                     "description": "Financial Instrument Global Identifier (FIGI) symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "share_class_figi",
                     "type": "str",
                     "description": "Financial Instrument Global Identifier (FIGI).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "firstbridge_id",
                     "type": "str",
                     "description": "The FirstBridge unique identifier for the Exchange Traded Fund (ETF).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "firstbridge_parent_id",
                     "type": "str",
                     "description": "The FirstBridge unique identifier for the parent Exchange Traded Fund (ETF), if applicable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intrinio_id",
                     "type": "str",
                     "description": "Intrinio unique identifier for the security.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "intraday_nav_symbol",
                     "type": "str",
                     "description": "Intraday Net Asset Value (NAV) symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "primary_symbol",
                     "type": "str",
                     "description": "The primary ticker field is used for Exchange Traded Products (ETPs) that have multiple listings and share classes. If an ETP has multiple listings or share classes, the same primary ticker is assigned to all the listings and share classes.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "etp_structure_type",
                     "type": "str",
                     "description": "Classifies Exchange Traded Products (ETPs) into very broad categories based on its legal structure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "legal_structure",
                     "type": "str",
                     "description": "Legal structure of the fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuer",
                     "type": "str",
                     "description": "Issuer of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "etn_issuing_bank",
                     "type": "str",
                     "description": "If the product is an Exchange Traded Note (ETN), this field identifies the issuing bank.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fund_family",
                     "type": "str",
                     "description": "This field identifies the fund family to which the ETF belongs, as categorized by the ETF Sponsor.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "investment_style",
                     "type": "str",
                     "description": "Investment style of the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "derivatives_based",
                     "type": "str",
                     "description": "This field is populated if the ETF holds either listed or over-the-counter derivatives in its portfolio.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "income_category",
                     "type": "str",
                     "description": "Identifies if an Exchange Traded Fund (ETF) falls into a category that is specifically designed to provide a high yield or income",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asset_class",
                     "type": "str",
                     "description": "Captures the underlying nature of the securities in the Exchanged Traded Product (ETP).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_asset_types",
                     "type": "str",
                     "description": "If 'asset_class' field is classified as 'Other Asset Types' this field captures the specific category of the underlying assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "single_category_designation",
                     "type": "str",
                     "description": "This categorization is created for those users who want every ETF to be 'forced' into a single bucket, so that the assets for all categories will always sum to the total market.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta_type",
                     "type": "str",
                     "description": "This field identifies whether an ETF provides 'Traditional' beta exposure or 'Smart' beta exposure. ETFs that are active (i.e. non-indexed), leveraged / inverse or have a proprietary quant model (i.e. that don't provide indexed exposure to a targeted factor) are classified separately.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta_details",
                     "type": "str",
                     "description": "This field provides further detail within the traditional and smart beta categories.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap_range",
                     "type": "str",
                     "description": "Equity ETFs are classified as falling into categories based on the description of their investment strategy in the prospectus. Examples ('Mega Cap', 'Large Cap', 'Mid Cap', etc.)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_cap_weighting_type",
                     "type": "str",
                     "description": "For ETFs that take the value 'Market Cap Weighted' in the 'index_weighting_scheme' field, this field provides detail on the market cap weighting type.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "index_weighting_scheme",
                     "type": "str",
                     "description": "For ETFs that track an underlying index, this field provides detail on the index weighting type.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "index_linked",
                     "type": "str",
                     "description": "This field identifies whether an ETF is index linked or active.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "index_name",
                     "type": "str",
                     "description": "This field identifies the name of the underlying index tracked by the ETF, if applicable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "index_symbol",
                     "type": "str",
                     "description": "This field identifies the OpenFIGI ticker for the Index underlying the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "parent_index",
                     "type": "str",
                     "description": "This field identifies the name of the parent index, which represents the broader universe from which the index underlying the ETF is created, if applicable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "index_family",
                     "type": "str",
                     "description": "This field identifies the index family to which the index underlying the ETF belongs. The index family is represented as categorized by the index provider.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "broader_index_family",
                     "type": "str",
                     "description": "This field identifies the broader index family to which the index underlying the ETF belongs. The broader index family is represented as categorized by the index provider.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "index_provider",
                     "type": "str",
                     "description": "This field identifies the Index provider for the index underlying the ETF, if applicable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "index_provider_code",
                     "type": "str",
                     "description": "This field provides the First Bridge code for each Index provider, corresponding to the index underlying the ETF if applicable.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "replication_structure",
                     "type": "str",
                     "description": "The replication structure of the Exchange Traded Product (ETP).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "growth_value_tilt",
                     "type": "str",
                     "description": "Classifies equity ETFs as either 'Growth' or Value' based on the stated style tilt in the ETF prospectus. Equity ETFs that do not have a stated style tilt are classified as 'Core / Blend'.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "growth_type",
                     "type": "str",
                     "description": "For ETFs that are classified as 'Growth' in 'growth_value_tilt', this field further identifies those where the stocks in the ETF are both selected and weighted based on their growth (style factor) scores.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value_type",
                     "type": "str",
                     "description": "For ETFs that are classified as 'Value' in 'growth_value_tilt', this field further identifies those where the stocks in the ETF are both selected and weighted based on their value (style factor) scores.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "sector",
                     "type": "str",
                     "description": "For equity ETFs that aim to provide targeted exposure to a sector or industry, this field identifies the Sector that it provides the exposure to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry",
                     "type": "str",
                     "description": "For equity ETFs that aim to provide targeted exposure to an industry, this field identifies the Industry that it provides the exposure to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "industry_group",
                     "type": "str",
                     "description": "For equity ETFs that aim to provide targeted exposure to a sub-industry, this field identifies the sub-Industry that it provides the exposure to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cross_sector_theme",
                     "type": "str",
                     "description": "For equity ETFs that aim to provide targeted exposure to a specific investment theme that cuts across GICS sectors, this field identifies the specific cross-sector theme. Examples ('Agri-business', 'Natural Resources', 'Green Investing', etc.)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "natural_resources_type",
                     "type": "str",
                     "description": "For ETFs that are classified as 'Natural Resources' in the 'cross_sector_theme' field, this field provides further detail on the type of Natural Resources exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "us_or_excludes_us",
                     "type": "str",
                     "description": "Takes the value of 'Domestic' for US exposure, 'International' for non-US exposure and 'Global' for exposure that includes all regions including the US.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "developed_emerging",
                     "type": "str",
                     "description": "This field identifies the stage of development of the markets that the ETF provides exposure to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "specialized_region",
                     "type": "str",
                     "description": "This field is populated if the ETF provides targeted exposure to a specific type of geography-based grouping that does not fall into a specific country or continent grouping. Examples ('BRIC', 'Chindia', etc.)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "continent",
                     "type": "str",
                     "description": "This field is populated if the ETF provides targeted exposure to a specific continent or country within that Continent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "latin_america_sub_group",
                     "type": "str",
                     "description": "For ETFs that are classified as 'Latin America' in the 'continent' field, this field provides further detail on the type of regional exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "europe_sub_group",
                     "type": "str",
                     "description": "For ETFs that are classified as 'Europe' in the 'continent' field, this field provides further detail on the type of regional exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asia_sub_group",
                     "type": "str",
                     "description": "For ETFs that are classified as 'Asia' in the 'continent' field, this field provides further detail on the type of regional exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "specific_country",
                     "type": "str",
                     "description": "This field is populated if the ETF provides targeted exposure to a specific country.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "china_listing_location",
                     "type": "str",
                     "description": "For ETFs that are classified as 'China' in the 'country' field, this field provides further detail on the type of exposure in the underlying securities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "us_state",
                     "type": "str",
                     "description": "Takes the value of a US state if the ETF provides targeted exposure to the municipal bonds or equities of companies.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "real_estate",
                     "type": "str",
                     "description": "For ETFs that provide targeted real estate exposure, this field is populated if the ETF provides targeted exposure to a specific segment of the real estate market.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fundamental_weighting_type",
                     "type": "str",
                     "description": "For ETFs that take the value 'Fundamental Weighted' in the 'index_weighting_scheme' field, this field provides detail on the fundamental weighting methodology.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_weighting_type",
                     "type": "str",
                     "description": "For ETFs that take the value 'Dividend Weighted' in the 'index_weighting_scheme' field, this field provides detail on the dividend weighting methodology.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bond_type",
                     "type": "str",
                     "description": "For ETFs where 'asset_class_type' is 'Bonds', this field provides detail on the type of bonds held in the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "government_bond_types",
                     "type": "str",
                     "description": "For bond ETFs that take the value 'Treasury & Government' in 'bond_type', this field provides detail on the exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "municipal_bond_region",
                     "type": "str",
                     "description": "For bond ETFs that take the value 'Municipal' in 'bond_type', this field provides additional detail on the geographic exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "municipal_vrdo",
                     "type": "bool",
                     "description": "For bond ETFs that take the value 'Municipal' in 'bond_type', this field identifies those ETFs that specifically provide exposure to Variable Rate Demand Obligations.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mortgage_bond_types",
                     "type": "str",
                     "description": "For bond ETFs that take the value 'Mortgage' in 'bond_type', this field provides additional detail on the type of underlying securities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bond_tax_status",
                     "type": "str",
                     "description": "For all US bond ETFs, this field provides additional detail on the tax treatment of the underlying securities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "credit_quality",
                     "type": "str",
                     "description": "For all bond ETFs, this field helps to identify if the ETF provides targeted exposure to securities of a specific credit quality range.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "average_maturity",
                     "type": "str",
                     "description": "For all bond ETFs, this field helps to identify if the ETF provides targeted exposure to securities of a specific maturity range.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "specific_maturity_year",
                     "type": "int",
                     "description": "For all bond ETFs that take the value 'Specific Maturity Year' in the 'average_maturity' field, this field specifies the calendar year.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "commodity_types",
                     "type": "str",
                     "description": "For ETFs where 'asset_class_type' is 'Commodities', this field provides detail on the type of commodities held in the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "energy_type",
                     "type": "str",
                     "description": "For ETFs where 'commodity_type' is 'Energy', this field provides detail on the type of energy exposure provided by the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "agricultural_type",
                     "type": "str",
                     "description": "For ETFs where 'commodity_type' is 'Agricultural', this field provides detail on the type of agricultural exposure provided by the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "livestock_type",
                     "type": "str",
                     "description": "For ETFs where 'commodity_type' is 'Livestock', this field provides detail on the type of livestock exposure provided by the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "metal_type",
                     "type": "str",
                     "description": "For ETFs where 'commodity_type' is 'Gold & Metals', this field provides detail on the type of exposure provided by the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inverse_leveraged",
                     "type": "str",
                     "description": "This field is populated if the ETF provides inverse or leveraged exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "target_date_multi_asset_type",
                     "type": "str",
                     "description": "For ETFs where 'asset_class_type' is 'Target Date / MultiAsset', this field provides detail on the type of commodities held in the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_pair",
                     "type": "str",
                     "description": "This field is populated if the ETF's strategy involves providing exposure to the movements of a currency or involves hedging currency exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "social_environmental_type",
                     "type": "str",
                     "description": "This field is populated if the ETF's strategy involves providing exposure to a specific social or environmental theme.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "clean_energy_type",
                     "type": "str",
                     "description": "This field is populated if the ETF has a value of 'Clean Energy' in the 'social_environmental_type' field.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_type",
                     "type": "str",
                     "description": "This field is populated if the ETF has an intended investment objective of holding dividend-oriented stocks as stated in the prospectus.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "regular_dividend_payor_type",
                     "type": "str",
                     "description": "This field is populated if the ETF has a value of'Dividend - Regular Payors' in the 'dividend_type' field.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "quant_strategies_type",
                     "type": "str",
                     "description": "This field is populated if the ETF has either an index-linked or active strategy that is based on a proprietary quantitative strategy.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_quant_models",
                     "type": "str",
                     "description": "For ETFs where 'quant_strategies_type' is 'Other Quant Model', this field provides the name of the specific proprietary quant model used as the underlying strategy for the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "hedge_fund_type",
                     "type": "str",
                     "description": "For ETFs where 'other_asset_types' is 'Hedge Fund Replication', this field provides detail on the type of hedge fund replication strategy.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "excludes_financials",
                     "type": "bool",
                     "description": "For equity ETFs, identifies those ETFs where the underlying fund holdings will not hold financials stocks, based on the funds intended objective.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "excludes_technology",
                     "type": "bool",
                     "description": "For equity ETFs, identifies those ETFs where the underlying fund holdings will not hold technology stocks, based on the funds intended objective.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "holds_only_nyse_stocks",
                     "type": "bool",
                     "description": "If true, the ETF is an equity ETF and holds only stocks listed on NYSE.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "holds_only_nasdaq_stocks",
                     "type": "bool",
                     "description": "If true, the ETF is an equity ETF and holds only stocks listed on Nasdaq.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "holds_mlp",
                     "type": "bool",
                     "description": "If true, the ETF's investment objective explicitly specifies that it holds MLPs as an intended part of its investment strategy.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "holds_preferred_stock",
                     "type": "bool",
                     "description": "If true, the ETF's investment objective explicitly specifies that it holds preferred stock as an intended part of its investment strategy.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "holds_closed_end_funds",
                     "type": "bool",
                     "description": "If true, the ETF's investment objective explicitly specifies that it holds closed end funds as an intended part of its investment strategy.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "holds_adr",
                     "type": "bool",
                     "description": "If true, he ETF's investment objective explicitly specifies that it holds American Depositary Receipts (ADRs) as an intended part of its investment strategy.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "laddered",
                     "type": "bool",
                     "description": "For bond ETFs, this field identifies those ETFs that specifically hold bonds in a laddered structure, where the bonds are scheduled to mature in an annual, sequential structure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "zero_coupon",
                     "type": "bool",
                     "description": "For bond ETFs, this field identifies those ETFs that specifically hold zero coupon Treasury Bills.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "floating_rate",
                     "type": "bool",
                     "description": "For bond ETFs, this field identifies those ETFs that specifically hold floating rate bonds.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "build_america_bonds",
                     "type": "bool",
                     "description": "For municipal bond ETFs, this field identifies those ETFs that specifically hold Build America Bonds.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dynamic_futures_roll",
                     "type": "bool",
                     "description": "If the product holds futures contracts, this field identifies those products where the roll strategy is dynamic (rather than entirely rules based), so as to minimize roll costs.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_hedged",
                     "type": "bool",
                     "description": "This field is populated if the ETF's strategy involves hedging currency exposure.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "includes_short_exposure",
                     "type": "bool",
                     "description": "This field is populated if the ETF has short exposure in any of its holdings e.g. in a long/short or inverse ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ucits",
                     "type": "bool",
                     "description": "If true, the Exchange Traded Product (ETP) is Undertakings for the Collective Investment in Transferable Securities (UCITS) compliant",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "registered_countries",
                     "type": "str",
                     "description": "The list of countries where the ETF is legally registered for sale. This may differ from where the ETF is domiciled or traded, particularly in Europe.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuer_country",
                     "type": "str",
                     "description": "2 letter ISO country code for the country where the issuer is located.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "domicile",
                     "type": "str",
                     "description": "2 letter ISO country code for the country where the ETP is domiciled.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "listing_country",
                     "type": "str",
                     "description": "2 letter ISO country code for the country of the primary listing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "listing_region",
                     "type": "str",
                     "description": "Geographic region in the country of the primary listing falls.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bond_currency_denomination",
                     "type": "str",
                     "description": "For all bond ETFs, this field provides additional detail on the currency denomination of the underlying securities.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "base_currency",
                     "type": "str",
                     "description": "Base currency in which NAV is reported.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "listing_currency",
                     "type": "str",
                     "description": "Listing currency of the Exchange Traded Product (ETP) in which it is traded. Reported using the 3-digit ISO currency code.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "number_of_holdings",
                     "type": "int",
                     "description": "The number of holdings in the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "month_end_assets",
                     "type": "float",
                     "description": "Net assets in millions of dollars as of the most recent month end.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "net_expense_ratio",
                     "type": "float",
                     "description": "Gross expense net of Fee Waivers, as a percentage of net assets as published by the ETF issuer.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "etf_portfolio_turnover",
                     "type": "float",
                     "description": "The percentage of positions turned over in the last 12 months.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -18753,217 +20885,217 @@
                     "name": "fund_type",
                     "type": "str",
                     "description": "The legal type of fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fund_family",
                     "type": "str",
                     "description": "The fund family.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "category",
                     "type": "str",
                     "description": "The fund category.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange",
                     "type": "str",
                     "description": "The exchange the fund is listed on.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_timezone",
                     "type": "str",
                     "description": "The timezone of the exchange.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "The currency in which the fund is listed.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "nav_price",
                     "type": "float",
                     "description": "The net asset value per unit of the fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "total_assets",
                     "type": "int",
                     "description": "The total value of assets held by the fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "trailing_pe",
                     "type": "float",
                     "description": "The trailing twelve month P/E ratio of the fund's assets.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield",
                     "type": "float",
                     "description": "The dividend yield of the fund, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_rate_ttm",
                     "type": "float",
                     "description": "The trailing twelve month annual dividend rate of the fund, in currency units.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "dividend_yield_ttm",
                     "type": "float",
                     "description": "The trailing twelve month annual dividend yield of the fund, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_high",
                     "type": "float",
                     "description": "The fifty-two week high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_low",
                     "type": "float",
                     "description": "The fifty-two week low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ma_50d",
                     "type": "float",
                     "description": "50-day moving average price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ma_200d",
                     "type": "float",
                     "description": "200-day moving average price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_ytd",
                     "type": "float",
                     "description": "The year-to-date return of the fund, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_3y_avg",
                     "type": "float",
                     "description": "The three year average return of the fund, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "return_5y_avg",
                     "type": "float",
                     "description": "The five year average return of the fund, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "beta_3y_avg",
                     "type": "float",
                     "description": "The three year average beta of the fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_avg",
                     "type": "float",
                     "description": "The average daily trading volume of the fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume_avg_10d",
                     "type": "float",
                     "description": "The average daily trading volume of the fund over the past ten days.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid",
                     "type": "float",
                     "description": "The current bid price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "bid_size",
                     "type": "float",
                     "description": "The current bid size.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask",
                     "type": "float",
                     "description": "The current ask price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ask_size",
                     "type": "float",
                     "description": "The current ask size.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "open",
                     "type": "float",
                     "description": "The open price of the most recent trading session.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "high",
                     "type": "float",
                     "description": "The highest price of the most recent trading session.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "low",
                     "type": "float",
                     "description": "The lowest price of the most recent trading session.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The trading volume of the most recent trading session.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "prev_close",
                     "type": "float",
                     "description": "The previous closing price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -18997,7 +21129,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfSectors\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfSectors]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -19047,7 +21205,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfCountries\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfCountries]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -19090,7 +21274,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : PricePerformance\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[PricePerformance]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -19098,98 +21308,98 @@
                     "name": "one_day",
                     "type": "float",
                     "description": "One-day return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "wtd",
                     "type": "float",
                     "description": "Week to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_week",
                     "type": "float",
                     "description": "One-week return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mtd",
                     "type": "float",
                     "description": "Month to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_month",
                     "type": "float",
                     "description": "One-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "qtd",
                     "type": "float",
                     "description": "Quarter to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "three_month",
                     "type": "float",
                     "description": "Three-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "six_month",
                     "type": "float",
                     "description": "Six-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ytd",
                     "type": "float",
                     "description": "Year to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_year",
                     "type": "float",
                     "description": "One-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "three_year",
                     "type": "float",
                     "description": "Three-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "five_year",
                     "type": "float",
                     "description": "Five-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ten_year",
                     "type": "float",
                     "description": "Ten-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "max",
                     "type": "float",
                     "description": "Return from the beginning of the time series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -19234,14 +21444,14 @@
                     "name": "date",
                     "type": "Union[Union[str, date], str]",
                     "description": "A specific date to get data for. Entering a date will attempt to return the NPORT-P filing for the entered date. This needs to be _exactly_ the date of the filing. Use the holdings_date command/endpoint to find available filing dates for the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cik",
                     "type": "str",
                     "description": "The CIK of the filing entity. Overrides symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -19250,20 +21460,46 @@
                     "name": "date",
                     "type": "Union[Union[str, date], str]",
                     "description": "A specific date to get data for. The date represents the period ending. The date entered will return the closest filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "use_cache",
                     "type": "bool",
                     "description": "Whether or not to use cache for the request.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfHoldings\n        Serializable results.\n    provider : Literal['fmp', 'sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfHoldings]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -19271,14 +21507,14 @@
                     "name": "symbol",
                     "type": "str",
                     "description": "Symbol representing the entity requested in the data. (ETF)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "name",
                     "type": "str",
                     "description": "Name of the ETF holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -19287,147 +21523,147 @@
                     "name": "lei",
                     "type": "str",
                     "description": "The LEI of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "title",
                     "type": "str",
                     "description": "The title of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "The CUSIP of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "isin",
                     "type": "str",
                     "description": "The ISIN of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "balance",
                     "type": "int",
                     "description": "The balance of the holding, in shares or units.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "units",
                     "type": "Union[str, float]",
                     "description": "The type of units.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "The currency of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "The value of the holding, in dollars.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weight",
                     "type": "float",
                     "description": "The weight of the holding, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payoff_profile",
                     "type": "str",
                     "description": "The payoff profile of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asset_category",
                     "type": "str",
                     "description": "The asset category of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuer_category",
                     "type": "str",
                     "description": "The issuer category of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "The country of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_restricted",
                     "type": "str",
                     "description": "Whether the holding is restricted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fair_value_level",
                     "type": "int",
                     "description": "The fair value level of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_cash_collateral",
                     "type": "str",
                     "description": "Whether the holding is cash collateral.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_non_cash_collateral",
                     "type": "str",
                     "description": "Whether the holding is non-cash collateral.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_loan_by_fund",
                     "type": "str",
                     "description": "Whether the holding is loan by fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cik",
                     "type": "str",
                     "description": "The CIK of the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "acceptance_datetime",
                     "type": "str",
                     "description": "The acceptance datetime of the filing.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "updated",
                     "type": "Union[date, datetime]",
                     "description": "The date the data was updated.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -19436,511 +21672,511 @@
                     "name": "lei",
                     "type": "str",
                     "description": "The LEI of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "The CUSIP of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "isin",
                     "type": "str",
                     "description": "The ISIN of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "other_id",
                     "type": "str",
                     "description": "Internal identifier for the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "balance",
                     "type": "float",
                     "description": "The balance of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weight",
                     "type": "float",
                     "description": "The weight of the holding in ETF in %.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "value",
                     "type": "float",
                     "description": "The value of the holding in USD.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payoff_profile",
                     "type": "str",
                     "description": "The payoff profile of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "units",
                     "type": "Union[str, float]",
                     "description": "The units of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "The currency of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asset_category",
                     "type": "str",
                     "description": "The asset category of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuer_category",
                     "type": "str",
                     "description": "The issuer category of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "country",
                     "type": "str",
                     "description": "The country of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_restricted",
                     "type": "str",
                     "description": "Whether the holding is restricted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "fair_value_level",
                     "type": "int",
                     "description": "The fair value level of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_cash_collateral",
                     "type": "str",
                     "description": "Whether the holding is cash collateral.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_non_cash_collateral",
                     "type": "str",
                     "description": "Whether the holding is non-cash collateral.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_loan_by_fund",
                     "type": "str",
                     "description": "Whether the holding is loan by fund.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "loan_value",
                     "type": "float",
                     "description": "The loan value of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "issuer_conditional",
                     "type": "str",
                     "description": "The issuer conditions of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "asset_conditional",
                     "type": "str",
                     "description": "The asset conditions of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "maturity_date",
                     "type": "date",
                     "description": "The maturity date of the debt security.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "coupon_kind",
                     "type": "str",
                     "description": "The type of coupon for the debt security.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rate_type",
                     "type": "str",
                     "description": "The type of rate for the debt security, floating or fixed.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "annualized_return",
                     "type": "float",
                     "description": "The annualized return on the debt security.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_default",
                     "type": "str",
                     "description": "If the debt security is defaulted.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "in_arrears",
                     "type": "str",
                     "description": "If the debt security is in arrears.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_paid_kind",
                     "type": "str",
                     "description": "If the debt security payments are paid in kind.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "derivative_category",
                     "type": "str",
                     "description": "The derivative category of the holding.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "counterparty",
                     "type": "str",
                     "description": "The counterparty of the derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "underlying_name",
                     "type": "str",
                     "description": "The name of the underlying asset associated with the derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "option_type",
                     "type": "str",
                     "description": "The type of option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "derivative_payoff",
                     "type": "str",
                     "description": "The payoff profile of the derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "expiry_date",
                     "type": "date",
                     "description": "The expiry or termination date of the derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exercise_price",
                     "type": "float",
                     "description": "The exercise price of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exercise_currency",
                     "type": "str",
                     "description": "The currency of the option exercise price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "shares_per_contract",
                     "type": "float",
                     "description": "The number of shares per contract.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "delta",
                     "type": "Union[str, float]",
                     "description": "The delta of the option.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rate_type_rec",
                     "type": "str",
                     "description": "The type of rate for reveivable portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "receive_currency",
                     "type": "str",
                     "description": "The receive currency of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "upfront_receive",
                     "type": "float",
                     "description": "The upfront amount received of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "floating_rate_index_rec",
                     "type": "str",
                     "description": "The floating rate index for reveivable portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "floating_rate_spread_rec",
                     "type": "float",
                     "description": "The floating rate spread for reveivable portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rate_tenor_rec",
                     "type": "str",
                     "description": "The rate tenor for reveivable portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rate_tenor_unit_rec",
                     "type": "Union[int, str]",
                     "description": "The rate tenor unit for reveivable portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reset_date_rec",
                     "type": "str",
                     "description": "The reset date for reveivable portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reset_date_unit_rec",
                     "type": "Union[int, str]",
                     "description": "The reset date unit for reveivable portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rate_type_pmnt",
                     "type": "str",
                     "description": "The type of rate for payment portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "payment_currency",
                     "type": "str",
                     "description": "The payment currency of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "upfront_payment",
                     "type": "float",
                     "description": "The upfront amount received of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "floating_rate_index_pmnt",
                     "type": "str",
                     "description": "The floating rate index for payment portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "floating_rate_spread_pmnt",
                     "type": "float",
                     "description": "The floating rate spread for payment portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rate_tenor_pmnt",
                     "type": "str",
                     "description": "The rate tenor for payment portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "rate_tenor_unit_pmnt",
                     "type": "Union[int, str]",
                     "description": "The rate tenor unit for payment portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reset_date_pmnt",
                     "type": "str",
                     "description": "The reset date for payment portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "reset_date_unit_pmnt",
                     "type": "Union[int, str]",
                     "description": "The reset date unit for payment portion of the swap.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "repo_type",
                     "type": "str",
                     "description": "The type of repo.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_cleared",
                     "type": "str",
                     "description": "If the repo is cleared.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "is_tri_party",
                     "type": "str",
                     "description": "If the repo is tri party.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "principal_amount",
                     "type": "float",
                     "description": "The principal amount of the repo.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "principal_currency",
                     "type": "str",
                     "description": "The currency of the principal amount.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "collateral_type",
                     "type": "str",
                     "description": "The collateral type of the repo.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "collateral_amount",
                     "type": "float",
                     "description": "The collateral amount of the repo.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "collateral_currency",
                     "type": "str",
                     "description": "The currency of the collateral amount.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_currency",
                     "type": "str",
                     "description": "The currency of the exchange rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "exchange_rate",
                     "type": "float",
                     "description": "The exchange rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_sold",
                     "type": "str",
                     "description": "The currency sold in a Forward Derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_amount_sold",
                     "type": "float",
                     "description": "The amount of currency sold in a Forward Derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_bought",
                     "type": "str",
                     "description": "The currency bought in a Forward Derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency_amount_bought",
                     "type": "float",
                     "description": "The amount of currency bought in a Forward Derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "notional_amount",
                     "type": "float",
                     "description": "The notional amount of the derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "notional_currency",
                     "type": "str",
                     "description": "The currency of the derivative's notional amount.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "unrealized_gain",
                     "type": "float",
                     "description": "The unrealized gain or loss on the derivative.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -19976,13 +22212,39 @@
                     "name": "cik",
                     "type": "str",
                     "description": "The CIK of the filing entity. Overrides symbol.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfHoldingsDate\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfHoldingsDate]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20025,7 +22287,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfHoldingsPerformance\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfHoldingsPerformance]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20033,98 +22321,98 @@
                     "name": "one_day",
                     "type": "float",
                     "description": "One-day return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "wtd",
                     "type": "float",
                     "description": "Week to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_week",
                     "type": "float",
                     "description": "One-week return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "mtd",
                     "type": "float",
                     "description": "Month to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_month",
                     "type": "float",
                     "description": "One-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "qtd",
                     "type": "float",
                     "description": "Quarter to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "three_month",
                     "type": "float",
                     "description": "Three-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "six_month",
                     "type": "float",
                     "description": "Six-month return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ytd",
                     "type": "float",
                     "description": "Year to date return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "one_year",
                     "type": "float",
                     "description": "One-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "three_year",
                     "type": "float",
                     "description": "Three-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "five_year",
                     "type": "float",
                     "description": "Five-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "ten_year",
                     "type": "float",
                     "description": "Ten-year return.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "max",
                     "type": "float",
                     "description": "Return from the beginning of the time series.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -20167,7 +22455,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EtfEquityExposure\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EtfEquityExposure]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20189,21 +22503,21 @@
                     "name": "shares",
                     "type": "int",
                     "description": "The number of shares held in the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "weight",
                     "type": "float",
                     "description": "The weight of the equity in the ETF, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "market_value",
                     "type": "Union[float, int]",
                     "description": "The market value of the equity position in the ETF.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -20224,14 +22538,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20253,7 +22567,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : AMERIBOR\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[AMERIBOR]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20289,14 +22629,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20318,7 +22658,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SONIA\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SONIA]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20354,14 +22720,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20375,7 +22741,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : IORB\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[IORB]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20411,14 +22803,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20441,7 +22833,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : FEDFUNDS\n        Serializable results.\n    provider : Literal['federal_reserve', 'fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[FEDFUNDS]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['federal_reserve', 'fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20487,13 +22905,39 @@
                     "name": "long_run",
                     "type": "bool",
                     "description": "Flag to show long run projections",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : PROJECTIONS\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[PROJECTIONS]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20571,14 +23015,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20600,7 +23044,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : ESTR\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[ESTR]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20636,14 +23106,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20664,7 +23134,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : EuropeanCentralBankInterestRates\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[EuropeanCentralBankInterestRates]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20700,14 +23196,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20729,7 +23225,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : DiscountWindowPrimaryCreditRate\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[DiscountWindowPrimaryCreditRate]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20765,14 +23287,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20793,7 +23315,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : TreasuryConstantMaturity\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[TreasuryConstantMaturity]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20829,14 +23377,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20857,7 +23405,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SelectedTreasuryConstantMaturity\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SelectedTreasuryConstantMaturity]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20893,14 +23467,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -20921,7 +23495,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SelectedTreasuryBill\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SelectedTreasuryBill]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -20957,14 +23557,14 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for. Defaults to the most recent FRED entry.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "inflation_adjusted",
                     "type": "bool",
                     "description": "Get inflation adjusted rates.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 },
                 {
@@ -20978,7 +23578,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : USYieldCurve\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[USYieldCurve]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21014,14 +23640,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21036,7 +23662,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : TreasuryRates\n        Serializable results.\n    provider : Literal['federal_reserve', 'fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[TreasuryRates]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['federal_reserve', 'fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21051,91 +23703,91 @@
                     "name": "week_4",
                     "type": "float",
                     "description": "4 week Treasury bills rate (secondary market).",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "month_1",
                     "type": "float",
                     "description": "1 month Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "month_2",
                     "type": "float",
                     "description": "2 month Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "month_3",
                     "type": "float",
                     "description": "3 month Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "month_6",
                     "type": "float",
                     "description": "6 month Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_1",
                     "type": "float",
                     "description": "1 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_2",
                     "type": "float",
                     "description": "2 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_3",
                     "type": "float",
                     "description": "3 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_5",
                     "type": "float",
                     "description": "5 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_7",
                     "type": "float",
                     "description": "7 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_10",
                     "type": "float",
                     "description": "10 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_20",
                     "type": "float",
                     "description": "20 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "year_30",
                     "type": "float",
                     "description": "30 year Treasury rate.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21157,14 +23809,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21208,13 +23860,39 @@
                     "name": "options",
                     "type": "bool",
                     "description": "Whether to include options in the results.",
-                    "default": "False",
+                    "default": false,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : ICEBofA\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[ICEBofA]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21250,14 +23928,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21280,13 +23958,39 @@
                     "name": "spread",
                     "type": "Literal['treasury', 'fed_funds']",
                     "description": "The type of spread.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : MoodyCorporateBondIndex\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[MoodyCorporateBondIndex]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21322,7 +24026,7 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21343,7 +24047,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : HighQualityMarketCorporateBond\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[HighQualityMarketCorporateBond]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21401,21 +24131,21 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "maturity",
                     "type": "Union[Union[float, str], List[Union[float, str]]]",
                     "description": "Maturities in years. Multiple items allowed for provider(s): fred.",
-                    "default": "10.0",
+                    "default": 10.0,
                     "optional": true
                 },
                 {
@@ -21436,7 +24166,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SpotRate\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SpotRate]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21472,14 +24228,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21514,7 +24270,33 @@
             "fred": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CommercialPaper\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CommercialPaper]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21550,14 +24332,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21579,7 +24361,33 @@
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SOFR\n        Serializable results.\n    provider : Literal['fred']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SOFR]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fred']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21622,14 +24430,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21653,7 +24461,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "10000",
+                    "default": 10000,
                     "optional": true
                 }
             ],
@@ -21669,14 +24477,40 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "49999",
+                    "default": 49999,
                     "optional": true
                 }
             ],
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : IndexHistorical\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[IndexHistorical]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21689,37 +24523,37 @@
                 },
                 {
                     "name": "open",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "high",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "low",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21728,21 +24562,21 @@
                     "name": "vwap",
                     "type": "float",
                     "description": "Volume Weighted Average Price over the period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change in the price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21750,9 +24584,9 @@
             "polygon": [
                 {
                     "name": "transactions",
-                    "type": "int, Gt(gt=0)",
+                    "type": "Annotated[int, Gt(gt=0)]",
                     "description": "Number of transactions for the symbol in the time period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21780,14 +24614,14 @@
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -21811,7 +24645,7 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "10000",
+                    "default": 10000,
                     "optional": true
                 }
             ],
@@ -21827,14 +24661,40 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return.",
-                    "default": "49999",
+                    "default": 49999,
                     "optional": true
                 }
             ],
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : MarketIndices\n        Serializable results.\n    provider : Literal['fmp', 'intrinio', 'polygon', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[MarketIndices]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'intrinio', 'polygon', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21847,37 +24707,37 @@
                 },
                 {
                     "name": "open",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The open price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "high",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The high price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "low",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The low price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "close",
-                    "type": "float, Strict(strict=True)",
+                    "type": "Annotated[float, Strict(strict=True)]",
                     "description": "The close price.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "volume",
                     "type": "int",
                     "description": "The trading volume.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21886,21 +24746,21 @@
                     "name": "vwap",
                     "type": "float",
                     "description": "Volume Weighted Average Price over the period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change",
                     "type": "float",
                     "description": "Change in the price from the previous close.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "change_percent",
                     "type": "float",
                     "description": "Change in the price from the previous close, as a normalized percent.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21908,9 +24768,9 @@
             "polygon": [
                 {
                     "name": "transactions",
-                    "type": "int, Gt(gt=0)",
+                    "type": "Annotated[int, Gt(gt=0)]",
                     "description": "Number of transactions for the symbol in the time period.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21945,7 +24805,33 @@
             "fmp": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : IndexConstituents\n        Serializable results.\n    provider : Literal['fmp']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[IndexConstituents]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -21960,7 +24846,7 @@
                     "name": "name",
                     "type": "str",
                     "description": "Name of the constituent company in the index.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -21976,35 +24862,35 @@
                     "name": "sub_sector",
                     "type": "str",
                     "description": "Sub-sector the constituent company in the index belongs to.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "headquarter",
                     "type": "str",
                     "description": "Location of the headquarter of the constituent company in the index.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "date_first_added",
                     "type": "Union[str, date]",
                     "description": "Date the constituent company was added to the index.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cik",
                     "type": "int",
                     "description": "Central Index Key (CIK) for the requested entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "founded",
                     "type": "Union[str, date]",
                     "description": "Founding year of the constituent company in the index.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -22032,7 +24918,33 @@
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : AvailableIndices\n        Serializable results.\n    provider : Literal['fmp', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[AvailableIndices]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['fmp', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -22040,14 +24952,14 @@
                     "name": "name",
                     "type": "str",
                     "description": "Name of the index.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "currency",
                     "type": "str",
                     "description": "Currency the index is traded in.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22099,21 +25011,21 @@
                     "name": "limit",
                     "type": "int",
                     "description": "The number of data entries to return. The number of articles to return.",
-                    "default": "2500",
+                    "default": 2500,
                     "optional": true
                 },
                 {
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22129,7 +25041,7 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22143,14 +25055,14 @@
                     "name": "updated_since",
                     "type": "int",
                     "description": "Number of seconds since the news was updated.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "published_since",
                     "type": "int",
                     "description": "Number of seconds since the news was published.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22171,42 +25083,42 @@
                     "name": "isin",
                     "type": "str",
                     "description": "The ISIN of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "The CUSIP of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "channels",
                     "type": "str",
                     "description": "Channels of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "topics",
                     "type": "str",
                     "description": "Topics of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "authors",
                     "type": "str",
                     "description": "Authors of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "content_types",
                     "type": "str",
                     "description": "Content types of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22217,20 +25129,46 @@
                     "name": "offset",
                     "type": "int",
                     "description": "Page offset, used in conjunction with limit.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 },
                 {
                     "name": "source",
                     "type": "str",
                     "description": "A comma-separated list of the domains requested.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : WorldNews\n        Serializable results.\n    provider : Literal['benzinga', 'fmp', 'intrinio', 'tiingo']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[WorldNews]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['benzinga', 'fmp', 'intrinio', 'tiingo']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -22252,21 +25190,21 @@
                     "name": "images",
                     "type": "List[Dict[str, str]]",
                     "description": "Images associated with the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "text",
                     "type": "str",
                     "description": "Text/body of the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "url",
                     "type": "str",
                     "description": "URL to the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22282,42 +25220,42 @@
                     "name": "author",
                     "type": "str",
                     "description": "Author of the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "teaser",
                     "type": "str",
                     "description": "Teaser of the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "channels",
                     "type": "str",
                     "description": "Channels associated with the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "stocks",
                     "type": "str",
                     "description": "Stocks associated with the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tags",
                     "type": "str",
                     "description": "Tags associated with the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "updated",
                     "type": "datetime",
                     "description": "Updated date of the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22351,7 +25289,7 @@
                     "name": "symbols",
                     "type": "str",
                     "description": "Ticker tagged in the fetched news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22372,7 +25310,7 @@
                     "name": "tags",
                     "type": "str",
                     "description": "Tags associated with the news article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22399,28 +25337,28 @@
                     "name": "symbol",
                     "type": "Union[str, List[str]]",
                     "description": "Symbol to get data for. This endpoint will accept multiple symbols separated by commas. Multiple items allowed for provider(s): benzinga, fmp, intrinio, polygon, tiingo, yfinance.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "start_date",
                     "type": "Union[date, str]",
                     "description": "Start date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "end_date",
                     "type": "Union[date, str]",
                     "description": "End date of the data, in YYYY-MM-DD format.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "limit",
-                    "type": "int, Ge(ge=0)",
+                    "type": "Annotated[int, Ge(ge=0)]",
                     "description": "The number of data entries to return.",
-                    "default": "2500",
+                    "default": 2500,
                     "optional": true
                 },
                 {
@@ -22436,7 +25374,7 @@
                     "name": "date",
                     "type": "Union[date, str]",
                     "description": "A specific date to get data for.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22450,14 +25388,14 @@
                     "name": "updated_since",
                     "type": "int",
                     "description": "Number of seconds since the news was updated.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "published_since",
                     "type": "int",
                     "description": "Number of seconds since the news was published.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22478,42 +25416,42 @@
                     "name": "isin",
                     "type": "str",
                     "description": "The company's ISIN.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cusip",
                     "type": "str",
                     "description": "The company's CUSIP.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "channels",
                     "type": "str",
                     "description": "Channels of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "topics",
                     "type": "str",
                     "description": "Topics of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "authors",
                     "type": "str",
                     "description": "Authors of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "content_types",
                     "type": "str",
                     "description": "Content types of the news to retrieve.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22522,7 +25460,7 @@
                     "name": "page",
                     "type": "int",
                     "description": "Page number of the results. Use in combination with limit.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 }
             ],
@@ -22541,21 +25479,47 @@
                     "name": "offset",
                     "type": "int",
                     "description": "Page offset, used in conjunction with limit.",
-                    "default": "0",
+                    "default": 0,
                     "optional": true
                 },
                 {
                     "name": "source",
                     "type": "str",
                     "description": "A comma-separated list of the domains requested.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
             "yfinance": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CompanyNews\n        Serializable results.\n    provider : Literal['benzinga', 'fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CompanyNews]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['benzinga', 'fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -22577,14 +25541,14 @@
                     "name": "text",
                     "type": "str",
                     "description": "Text/body of the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "images",
                     "type": "List[Dict[str, str]]",
                     "description": "Images associated with the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22598,7 +25562,7 @@
                     "name": "symbols",
                     "type": "str",
                     "description": "Symbols associated with the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22614,42 +25578,42 @@
                     "name": "author",
                     "type": "str",
                     "description": "Author of the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "teaser",
                     "type": "str",
                     "description": "Teaser of the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "channels",
                     "type": "str",
                     "description": "Channels associated with the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "stocks",
                     "type": "str",
                     "description": "Stocks associated with the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tags",
                     "type": "str",
                     "description": "Tags associated with the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "updated",
                     "type": "datetime",
                     "description": "Updated date of the news.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22676,14 +25640,14 @@
                     "name": "source",
                     "type": "str",
                     "description": "Source of the article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "tags",
                     "type": "str",
                     "description": "Keywords/tags in the article",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22697,12 +25661,12 @@
                     "name": "amp_url",
                     "type": "str",
                     "description": "AMP URL.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "publisher",
-                    "type": "openbb_polygon.models.company_news.PolygonPublisher",
+                    "type": "PolygonPublisher",
                     "description": "Publisher of the article.",
                     "default": "",
                     "optional": false
@@ -22713,7 +25677,7 @@
                     "name": "tags",
                     "type": "str",
                     "description": "Tags associated with the news article.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
@@ -22777,7 +25741,33 @@
             "sec": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : CikMap\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[CikMap]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [
@@ -22785,7 +25775,7 @@
                     "name": "cik",
                     "type": "Union[int, str]",
                     "description": "Central Index Key (CIK) for the requested entity.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ],
@@ -22813,7 +25803,7 @@
                     "name": "use_cache",
                     "type": "bool",
                     "description": "Whether or not to use cache. If True, cache will store for seven days.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -22827,7 +25817,33 @@
             "sec": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : InstitutionsSearch\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[InstitutionsSearch]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [],
@@ -22836,14 +25852,14 @@
                     "name": "name",
                     "type": "str",
                     "description": "The name of the institution.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 },
                 {
                     "name": "cik",
                     "type": "Union[int, str]",
                     "description": "Central Index Key (CIK)",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
@@ -22870,7 +25886,7 @@
                     "name": "use_cache",
                     "type": "bool",
                     "description": "Whether or not to use cache. If True, cache will store for seven days.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -22886,13 +25902,39 @@
                     "name": "url",
                     "type": "str",
                     "description": "Enter an optional URL path to fetch the next level.",
-                    "default": "None",
+                    "default": null,
                     "optional": true
                 }
             ]
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SchemaFiles\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SchemaFiles]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [],
@@ -22928,7 +25970,7 @@
                     "name": "use_cache",
                     "type": "bool",
                     "description": "Whether or not to use cache. If True, cache will store for seven days.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -22942,7 +25984,33 @@
             "sec": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SymbolMap\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SymbolMap]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [],
@@ -22978,7 +26046,33 @@
             "sec": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : RssLitigation\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[RssLitigation]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [],
@@ -23042,7 +26136,7 @@
                     "name": "use_cache",
                     "type": "bool",
                     "description": "Whether or not to use cache. If True, cache will store for seven days.",
-                    "default": "True",
+                    "default": true,
                     "optional": true
                 },
                 {
@@ -23056,7 +26150,33 @@
             "sec": []
         },
         "returns": {
-            "OBBject": "OBBject\n    results : SicSearch\n        Serializable results.\n    provider : Literal['sec']\n        Provider name.\n    warnings : Optional[List[Warning_]]\n        List of warnings.\n    chart : Optional[Chart]\n        Chart object.\n    extra : Dict[str, Any]\n        Extra info.\n"
+            "OBBject": [
+                {
+                    "name": "results",
+                    "type": "List[SicSearch]",
+                    "description": "Serializable results."
+                },
+                {
+                    "name": "provider",
+                    "type": "Optional[Literal['sec']]",
+                    "description": "Provider name."
+                },
+                {
+                    "name": "warnings",
+                    "type": "Optional[List[Warning_]]",
+                    "description": "List of warnings."
+                },
+                {
+                    "name": "chart",
+                    "type": "Optional[Chart]",
+                    "description": "Chart object."
+                },
+                {
+                    "name": "extra",
+                    "type": "Dict[str, Any]",
+                    "description": "Extra info."
+                }
+            ]
         },
         "data": {
             "standard": [],

--- a/openbb_platform/openbb/package/equity_calendar.py
+++ b/openbb_platform/openbb/package/equity_calendar.py
@@ -295,53 +295,27 @@ class ROUTER_equity_calendar(Container):
         ipo_date : Optional[date]
             The date of the IPO, when the stock first trades on a major exchange.
         status : Optional[Literal['upcoming', 'priced', 'withdrawn']]
-
-                    The status of the IPO. Upcoming IPOs have not taken place yet but are expected to.
-                    Priced IPOs have taken place.
-                    Withdrawn IPOs were expected to take place, but were subsequently withdrawn and did not take place
-                 (provider: intrinio)
+            The status of the IPO. Upcoming IPOs have not taken place yet but are expected to. Priced IPOs have taken place. Withdrawn IPOs were expected to take place, but were subsequently withdrawn. (provider: intrinio)
         exchange : Optional[str]
-
-                    The acronym of the stock exchange that the company is going to trade publicly on.
-                    Typically NYSE or NASDAQ.
-                 (provider: intrinio)
+            The acronym of the stock exchange that the company is going to trade publicly on. Typically NYSE or NASDAQ. (provider: intrinio)
         offer_amount : Optional[float]
             The total dollar amount of shares offered in the IPO. Typically this is share price * share count (provider: intrinio)
         share_price : Optional[float]
             The price per share at which the IPO was offered. (provider: intrinio)
         share_price_lowest : Optional[float]
-
-                    The expected lowest price per share at which the IPO will be offered.
-                    Before an IPO is priced, companies typically provide a range of prices per share at which
-                    they expect to offer the IPO (typically available for upcoming IPOs).
-                 (provider: intrinio)
+            The expected lowest price per share at which the IPO will be offered. Before an IPO is priced, companies typically provide a range of prices per share at which they expect to offer the IPO (typically available for upcoming IPOs). (provider: intrinio)
         share_price_highest : Optional[float]
-
-                    The expected highest price per share at which the IPO will be offered.
-                    Before an IPO is priced, companies typically provide a range of prices per share at which
-                    they expect to offer the IPO (typically available for upcoming IPOs).
-                 (provider: intrinio)
+            The expected highest price per share at which the IPO will be offered. Before an IPO is priced, companies typically provide a range of prices per share at which they expect to offer the IPO (typically available for upcoming IPOs). (provider: intrinio)
         share_count : Optional[int]
             The number of shares offered in the IPO. (provider: intrinio)
         share_count_lowest : Optional[int]
-
-                    The expected lowest number of shares that will be offered in the IPO. Before an IPO is priced,
-                    companies typically provide a range of shares that they expect to offer in the IPO
-                    (typically available for upcoming IPOs).
-                 (provider: intrinio)
+            The expected lowest number of shares that will be offered in the IPO. Before an IPO is priced, companies typically provide a range of shares that they expect to offer in the IPO (typically available for upcoming IPOs). (provider: intrinio)
         share_count_highest : Optional[int]
-
-                    The expected highest number of shares that will be offered in the IPO. Before an IPO is priced,
-                    companies typically provide a range of shares that they expect to offer in the IPO
-                    (typically available for upcoming IPOs).
-                 (provider: intrinio)
+            The expected highest number of shares that will be offered in the IPO. Before an IPO is priced, companies typically provide a range of shares that they expect to offer in the IPO (typically available for upcoming IPOs). (provider: intrinio)
         announcement_url : Optional[str]
             The URL to the company's announcement of the IPO (provider: intrinio)
         sec_report_url : Optional[str]
-
-                    The URL to the company's S-1, S-1/A, F-1, or F-1/A SEC filing,
-                    which is required to be filed before an IPO takes place.
-                 (provider: intrinio)
+            The URL to the company's S-1, S-1/A, F-1, or F-1/A SEC filing, which is required to be filed before an IPO takes place. (provider: intrinio)
         open_price : Optional[float]
             The opening price at the beginning of the first trading day (only available for priced IPOs). (provider: intrinio)
         close_price : Optional[float]
@@ -349,25 +323,16 @@ class ROUTER_equity_calendar(Container):
         volume : Optional[int]
             The volume at the end of the first trading day (only available for priced IPOs). (provider: intrinio)
         day_change : Optional[float]
-
-                    The percentage change between the open price and the close price on the first trading day
-                    (only available for priced IPOs).
-                 (provider: intrinio)
+            The percentage change between the open price and the close price on the first trading day (only available for priced IPOs). (provider: intrinio)
         week_change : Optional[float]
-
-                    The percentage change between the open price on the first trading day and the close price approximately
-                    a week after the first trading day (only available for priced IPOs).
-                 (provider: intrinio)
+            The percentage change between the open price on the first trading day and the close price approximately a week after the first trading day (only available for priced IPOs). (provider: intrinio)
         month_change : Optional[float]
-
-                    The percentage change between the open price on the first trading day and the close price approximately
-                    a month after the first trading day (only available for priced IPOs).
-                 (provider: intrinio)
+            The percentage change between the open price on the first trading day and the close price approximately a month after the first trading day (only available for priced IPOs). (provider: intrinio)
         id : Optional[str]
             The Intrinio ID of the IPO. (provider: intrinio)
-        company : Optional[openbb_intrinio.utils.references.IntrinioCompany]
+        company : Optional[IntrinioCompany]
             The company that is going public via the IPO. (provider: intrinio)
-        security : Optional[openbb_intrinio.utils.references.IntrinioSecurity]
+        security : Optional[IntrinioSecurity]
             The primary Security for the Company that is going public via the IPO (provider: intrinio)
 
         Examples

--- a/openbb_platform/openbb/package/equity_price.py
+++ b/openbb_platform/openbb/package/equity_price.py
@@ -231,27 +231,13 @@ class ROUTER_equity_price(Container):
         date : Optional[datetime.date]
             A specific date to get data for. Use bracketed the timestamp parameters to specify exact time ranges. (provider: polygon)
         timestamp_lt : Optional[Union[datetime.datetime, str]]
-
-                    Query by datetime, less than. Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-                    YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-                 (provider: polygon)
+            Query by datetime, less than. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour. (provider: polygon)
         timestamp_gt : Optional[Union[datetime.datetime, str]]
-
-                    Query by datetime, greater than. Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-                    YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-                 (provider: polygon)
+            Query by datetime, greater than. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour. (provider: polygon)
         timestamp_lte : Optional[Union[datetime.datetime, str]]
-
-                    Query by datetime, less than or equal to.
-                    Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-                    YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-                 (provider: polygon)
+            Query by datetime, less than or equal to. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour. (provider: polygon)
         timestamp_gte : Optional[Union[datetime.datetime, str]]
-
-                    Query by datetime, greater than or equal to.
-                    Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-                    YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-                 (provider: polygon)
+            Query by datetime, greater than or equal to. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour. (provider: polygon)
 
         Returns
         -------
@@ -292,26 +278,13 @@ class ROUTER_equity_price(Container):
         indicators : Optional[List[int]]
             A list of indicator codes. (provider: polygon)
         sequence_num : Optional[int]
-
-                    The sequence number represents the sequence in which message events happened.
-                    These are increasing and unique per ticker symbol, but will not always be sequential
-                    (e.g., 1, 2, 6, 9, 10, 11)
-                 (provider: polygon)
+            The sequence number represents the sequence in which message events happened. These are increasing and unique per ticker symbol, but will not always be sequential (e.g., 1, 2, 6, 9, 10, 11) (provider: polygon)
         participant_timestamp : Optional[datetime]
-
-                    The nanosecond accuracy Participant/Exchange Unix Timestamp.
-                    This is the timestamp of when the quote was actually generated at the exchange.
-                 (provider: polygon)
+            The nanosecond accuracy Participant/Exchange Unix Timestamp. This is the timestamp of when the quote was actually generated at the exchange. (provider: polygon)
         sip_timestamp : Optional[datetime]
-
-                    The nanosecond accuracy SIP Unix Timestamp.
-                    This is the timestamp of when the SIP received this quote from the exchange which produced it.
-                 (provider: polygon)
+            The nanosecond accuracy SIP Unix Timestamp. This is the timestamp of when the SIP received this quote from the exchange which produced it. (provider: polygon)
         trf_timestamp : Optional[datetime]
-
-                    The nanosecond accuracy TRF (Trade Reporting Facility) Unix Timestamp.
-                    This is the timestamp of when the trade reporting facility received this quote.
-                 (provider: polygon)
+            The nanosecond accuracy TRF (Trade Reporting Facility) Unix Timestamp. This is the timestamp of when the trade reporting facility received this quote. (provider: polygon)
 
         Examples
         --------
@@ -571,7 +544,7 @@ class ROUTER_equity_price(Container):
             Source of the Intrinio data. (provider: intrinio)
         updated_on : Optional[datetime]
             Date and Time when the data was last updated. (provider: intrinio)
-        security : Optional[openbb_intrinio.utils.references.IntrinioSecurity]
+        security : Optional[IntrinioSecurity]
             Security details related to the quote. (provider: intrinio)
         ma_50d : Optional[float]
             50-day moving average price. (provider: yfinance)

--- a/openbb_platform/openbb/package/news.py
+++ b/openbb_platform/openbb/package/news.py
@@ -154,7 +154,7 @@ class ROUTER_news(Container):
             Source of the news article (provider: yfinance)
         amp_url : Optional[str]
             AMP URL. (provider: polygon)
-        publisher : Optional[openbb_polygon.models.company_news.PolygonPublisher]
+        publisher : Optional[PolygonPublisher]
             Publisher of the article. (provider: polygon)
         article_id : Optional[int]
             Unique ID of the news article. (provider: tiingo)

--- a/openbb_platform/providers/benzinga/openbb_benzinga/models/price_target.py
+++ b/openbb_platform/providers/benzinga/openbb_benzinga/models/price_target.py
@@ -83,8 +83,7 @@ class BenzingaPriceTargetQueryParams(PriceTargetQueryParams):
         + " Uses Greater Than or Equal To the importance indicated",
         alias="parameters[importance]",
     )
-    action: Union[
-        None,
+    action: Optional[
         Literal[
             "downgrades",
             "maintains",
@@ -97,7 +96,7 @@ class BenzingaPriceTargetQueryParams(PriceTargetQueryParams):
             "removes",
             "suspends",
             "firm_dissolved",
-        ],
+        ]
     ] = Field(
         default=None,
         description="Filter by a specific action_company.",
@@ -166,8 +165,7 @@ class BenzingaPriceTargetData(PriceTargetData):
         "url_analyst": "url",
     }
 
-    action: Union[
-        None,
+    action: Optional[
         Literal[
             "Downgrades",
             "Maintains",
@@ -180,22 +178,21 @@ class BenzingaPriceTargetData(PriceTargetData):
             "Removes",
             "Suspends",
             "Firm Dissolved",
-        ],
+        ]
     ] = Field(
         default=None,
         description="Description of the change in rating from firm's last rating."
         "Note that all of these terms are precisely defined.",
         alias="action_company",
     )
-    action_change: Union[
-        None,
-        Literal["Announces", "Maintains", "Lowers", "Raises", "Removes", "Adjusts"],
+    action_change: Optional[
+        Literal["Announces", "Maintains", "Lowers", "Raises", "Removes", "Adjusts"]
     ] = Field(
         default=None,
         description="Description of the change in price target from firm's last price target.",
         alias="action_pt",
     )
-    importance: Union[None, Literal[0, 1, 2, 3, 4, 5]] = Field(
+    importance: Optional[Literal[0, 1, 2, 3, 4, 5]] = Field(
         default=None,
         description="Subjective Basis of How Important Event is to Market. 5 = High",
     )

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/calendar_ipo.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/calendar_ipo.py
@@ -45,18 +45,17 @@ class IntrinioCalendarIpoData(CalendarIpoData):
     __alias_dict__ = {"symbol": "ticker", "ipo_date": "date"}
 
     status: Optional[Literal["upcoming", "priced", "withdrawn"]] = Field(
-        description="""
-            The status of the IPO. Upcoming IPOs have not taken place yet but are expected to.
-            Priced IPOs have taken place.
-            Withdrawn IPOs were expected to take place, but were subsequently withdrawn and did not take place
-        """,
+        description=(
+            "The status of the IPO. Upcoming IPOs have not taken place yet but are expected to. "
+            "Priced IPOs have taken place. Withdrawn IPOs were expected to take place, but were subsequently withdrawn."
+        ),
         default=None,
     )
     exchange: Optional[str] = Field(
-        description="""
-            The acronym of the stock exchange that the company is going to trade publicly on.
-            Typically NYSE or NASDAQ.
-        """,
+        description=(
+            "The acronym of the stock exchange that the company is going to trade publicly on. "
+            "Typically NYSE or NASDAQ."
+        ),
         default=None,
     )
     offer_amount: Optional[float] = Field(
@@ -67,48 +66,48 @@ class IntrinioCalendarIpoData(CalendarIpoData):
         description="The price per share at which the IPO was offered.", default=None
     )
     share_price_lowest: Optional[float] = Field(
-        description="""
-            The expected lowest price per share at which the IPO will be offered.
-            Before an IPO is priced, companies typically provide a range of prices per share at which
-            they expect to offer the IPO (typically available for upcoming IPOs).
-        """,
+        description=(
+            "The expected lowest price per share at which the IPO will be offered. "
+            "Before an IPO is priced, companies typically provide a range of prices per share at which "
+            "they expect to offer the IPO (typically available for upcoming IPOs)."
+        ),
         default=None,
     )
     share_price_highest: Optional[float] = Field(
-        description="""
-            The expected highest price per share at which the IPO will be offered.
-            Before an IPO is priced, companies typically provide a range of prices per share at which
-            they expect to offer the IPO (typically available for upcoming IPOs).
-        """,
+        description=(
+            "The expected highest price per share at which the IPO will be offered. "
+            "Before an IPO is priced, companies typically provide a range of prices per share at which "
+            "they expect to offer the IPO (typically available for upcoming IPOs)."
+        ),
         default=None,
     )
     share_count: Optional[int] = Field(
         description="The number of shares offered in the IPO.", default=None
     )
     share_count_lowest: Optional[int] = Field(
-        description="""
-            The expected lowest number of shares that will be offered in the IPO. Before an IPO is priced,
-            companies typically provide a range of shares that they expect to offer in the IPO
-            (typically available for upcoming IPOs).
-        """,
+        description=(
+            "The expected lowest number of shares that will be offered in the IPO. Before an IPO is priced, "
+            "companies typically provide a range of shares that they expect to offer in the IPO "
+            "(typically available for upcoming IPOs)."
+        ),
         default=None,
     )
     share_count_highest: Optional[int] = Field(
-        description="""
-            The expected highest number of shares that will be offered in the IPO. Before an IPO is priced,
-            companies typically provide a range of shares that they expect to offer in the IPO
-            (typically available for upcoming IPOs).
-        """,
+        description=(
+            "The expected highest number of shares that will be offered in the IPO. Before an IPO is priced, "
+            "companies typically provide a range of shares that they expect to offer in the IPO "
+            "(typically available for upcoming IPOs)."
+        ),
         default=None,
     )
     announcement_url: Optional[str] = Field(
         description="The URL to the company's announcement of the IPO", default=None
     )
     sec_report_url: Optional[str] = Field(
-        description="""
-            The URL to the company's S-1, S-1/A, F-1, or F-1/A SEC filing,
-            which is required to be filed before an IPO takes place.
-        """,
+        description=(
+            "The URL to the company's S-1, S-1/A, F-1, or F-1/A SEC filing, which is required to be filed "
+            "before an IPO takes place."
+        ),
         default=None,
     )
     open_price: Optional[float] = Field(
@@ -124,24 +123,24 @@ class IntrinioCalendarIpoData(CalendarIpoData):
         default=None,
     )
     day_change: Optional[float] = Field(
-        description="""
-            The percentage change between the open price and the close price on the first trading day
-            (only available for priced IPOs).
-        """,
+        description=(
+            "The percentage change between the open price and the close price on the first trading day "
+            "(only available for priced IPOs)."
+        ),
         default=None,
     )
     week_change: Optional[float] = Field(
-        description="""
-            The percentage change between the open price on the first trading day and the close price approximately
-            a week after the first trading day (only available for priced IPOs).
-        """,
+        description=(
+            "The percentage change between the open price on the first trading day and the close price approximately "
+            "a week after the first trading day (only available for priced IPOs)."
+        ),
         default=None,
     )
     month_change: Optional[float] = Field(
-        description="""
-            The percentage change between the open price on the first trading day and the close price approximately
-            a month after the first trading day (only available for priced IPOs).
-        """,
+        description=(
+            "The percentage change between the open price on the first trading day and the close price approximately "
+            "a month after the first trading day (only available for priced IPOs)."
+        ),
         default=None,
     )
     id: Optional[str] = Field(description="The Intrinio ID of the IPO.", default=None)

--- a/openbb_platform/providers/polygon/openbb_polygon/models/equity_nbbo.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/equity_nbbo.py
@@ -45,33 +45,33 @@ class PolygonEquityNBBOQueryParams(EquityNBBOQueryParams):
     )
     timestamp_lt: Optional[Union[datetime, str]] = Field(
         default=None,
-        description="""
-            Query by datetime, less than. Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-            YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-        """,
+        description=(
+            "Query by datetime, less than. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, "
+            "'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour."
+        ),
     )
     timestamp_gt: Optional[Union[datetime, str]] = Field(
         default=None,
-        description="""
-            Query by datetime, greater than. Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-            YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-        """,
+        description=(
+            "Query by datetime, greater than. Either a date with the format 'YYYY-MM-DD' or a TZ-aware timestamp string, "
+            "'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the day and hour."
+        ),
     )
     timestamp_lte: Optional[Union[datetime, str]] = Field(
         default=None,
-        description="""
-            Query by datetime, less than or equal to.
-            Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-            YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-        """,
+        description=(
+            "Query by datetime, less than or equal to. Either a date with the format 'YYYY-MM-DD' or a TZ-aware "
+            "timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the "
+            "day and hour."
+        ),
     )
     timestamp_gte: Optional[Union[datetime, str]] = Field(
         default=None,
-        description="""
-            Query by datetime, greater than or equal to.
-            Either a date with the format YYYY-MM-DD or a TZ-aware timestamp string,
-            YYYY-MM-DDTH:M:S.000000000-04:00". Include all nanoseconds and the 'T' between the day and hour.
-        """,
+        description=(
+            "Query by datetime, greater than or equal to. Either a date with the format 'YYYY-MM-DD' or a TZ-aware "
+            "timestamp string, 'YYYY-MM-DDTH:M:S.000000000-04:00'. Include all nanoseconds and the 'T' between the "
+            "day and hour."
+        ),
     )
 
     @field_validator("limit", mode="before", check_fields=False)
@@ -97,33 +97,33 @@ class PolygonEquityNBBOData(EquityNBBOData):
     )
     sequence_num: Optional[int] = Field(
         default=None,
-        description="""
-            The sequence number represents the sequence in which message events happened.
-            These are increasing and unique per ticker symbol, but will not always be sequential
-            (e.g., 1, 2, 6, 9, 10, 11)
-        """,
+        description=(
+            "The sequence number represents the sequence in which message events happened. "
+            "These are increasing and unique per ticker symbol, but will not always be sequential "
+            "(e.g., 1, 2, 6, 9, 10, 11)"
+        ),
         alias="sequence_number",
     )
     participant_timestamp: Optional[datetime] = Field(
         default=None,
-        description="""
-            The nanosecond accuracy Participant/Exchange Unix Timestamp.
-            This is the timestamp of when the quote was actually generated at the exchange.
-        """,
+        description=(
+            "The nanosecond accuracy Participant/Exchange Unix Timestamp. "
+            "This is the timestamp of when the quote was actually generated at the exchange."
+        ),
     )
     sip_timestamp: Optional[datetime] = Field(
         default=None,
-        description="""
-            The nanosecond accuracy SIP Unix Timestamp.
-            This is the timestamp of when the SIP received this quote from the exchange which produced it.
-        """,
+        description=(
+            "The nanosecond accuracy SIP Unix Timestamp. "
+            "This is the timestamp of when the SIP received this quote from the exchange which produced it."
+        ),
     )
     trf_timestamp: Optional[datetime] = Field(
         default=None,
-        description="""
-            The nanosecond accuracy TRF (Trade Reporting Facility) Unix Timestamp.
-            This is the timestamp of when the trade reporting facility received this quote.
-        """,
+        description=(
+            "The nanosecond accuracy TRF (Trade Reporting Facility) Unix Timestamp. "
+            "This is the timestamp of when the trade reporting facility received this quote."
+        ),
     )
 
     @field_validator(

--- a/website/generate_platform_v4_markdown.py
+++ b/website/generate_platform_v4_markdown.py
@@ -336,21 +336,34 @@ def create_reference_markdown_tabular_section(
     return markdown
 
 
-def create_reference_markdown_returns_section(returns_content: str) -> str:
+def create_reference_markdown_returns_section(returns: List[Dict[str, str]]) -> str:
     """Create the returns section for the markdown file.
 
-    Parameters
-    ----------
-        returns_content (str):
-            Returns section formatted as a string
-
+    Args
+    ----
+        returns (List[Dict[str, str]]):
+            List of dictionaries containing the name, type and description of the returns
     Returns
     -------
         str:
             Returns section for the markdown file
     """
 
-    return f"---\n\n## Returns\n\n```python wordwrap\n{returns_content}\n```\n\n"
+    returns_str = ""
+
+    for params in returns:
+        returns_str += f"{TAB_WIDTH*' '}{params['name']} : {params['type']}\n"
+        returns_str += f"{TAB_WIDTH*' '}{TAB_WIDTH*' '}{params['description']}\n\n"
+
+    # Remove the last two newline characters to render Returns section properly
+    returns_str = returns_str.rstrip("\n\n")
+
+    # For easy debugging of the created strings
+    markdown = (
+        f"---\n\n## Returns\n\n```python wordwrap\nOBBject\n{returns_str}\n```\n\n"
+    )
+
+    return markdown
 
 
 def create_data_model_markdown(title: str, description: str, model: str) -> str:


### PR DESCRIPTION
# [Enhancement] Sync `reference.json` and Platform function docstring

1. **Why**? 

    Consistent information between `reference.json` and package docstring

2. **What**?

    - `"None"` is now saved as `None` type in `QueryParams` and `Data` fields to be leverage on the Platform CLI
    - Field types with Pydantic models are processed to show only the model name resulting in cleaner type
    - `OBBject` return data fields are now stored as a list of dictionaries in the `reference.json` for consistency with the `data` and `parameters` fields in the `reference.json`. Updated logic is used to create the markdown content in the `create_reference_markdown_returns_section` function.
    - Fixed provider models to reflect correct field type and description
    - Updated static to reflect the new changes

3. **Impact** 

    - Minor impact on docs, major impact in CX/DX
    - `reference.json` is not backwards compatible with the previous versions

4. **Testing Done**

    - Static generated and tested locally 
    - Website docs generated and tested locally
