### PR TITLE
[BugFix] - @validate with args breaks autocompletion

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/utils/decorators.py
+++ b/openbb_platform/core/openbb_core/app/static/utils/decorators.py
@@ -18,7 +18,7 @@ def validate(func: Callable[P, R]) -> Callable[P, R]:
 
 
 @overload
-def validate(**dec_kwargs) -> Callable[P, R]:
+def validate(**dec_kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]:
     pass
 
 


### PR DESCRIPTION
1. **Why**?

    - Autocompletion broken in Jupyter for functions with kwargs passed to `@validate(...)` decorator, such as `@validate(config=dict(arbitrary_types_allowed=True))`


2. **What**?

    - Proper typing fixes the issue

3. **Impact**

    - Minimal

4. **Testing Done**:

    - Typing a command and stopping at `...()`

Before

<img width="403" alt="Screenshot 2024-03-19 at 15 33 26" src="https://github.com/OpenBB-finance/OpenBBTerminal/assets/79287829/f6675d54-f378-4caa-8bf2-585c4e305545">

After
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/79287829/18fb7d6a-4454-492e-9d39-0031f0097cb2)