### PR TITLE
[BugFix] - Allow kwargs on POST endpoints

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -343,7 +343,7 @@ class ImportDefinition:
         code += "\nfrom pydantic import BaseModel"
         code += "\nfrom inspect import Parameter"
         code += "\nimport typing"
-        code += "\nfrom typing import List, Dict, Union, Optional, Literal"
+        code += "\nfrom typing import List, Dict, Union, Optional, Literal, Any"
         code += "\nfrom annotated_types import Ge, Le, Gt, Lt"
         code += "\nfrom warnings import warn, simplefilter"
         if sys.version_info < (3, 9):
@@ -567,6 +567,10 @@ class MethodDefinition:
         for name, param in parameter_map.items():
             if name == "extra_params":
                 formatted[name] = Parameter(name="kwargs", kind=Parameter.VAR_KEYWORD)
+            elif name == "kwargs":
+                formatted["**" + name] = Parameter(
+                    name="kwargs", kind=Parameter.VAR_KEYWORD, annotation=Any
+                )
             elif name == "provider_choices":
                 fields = param.annotation.__args__[0].__dataclass_fields__
                 field = fields["provider"]


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Passing kwargs was broken for POST endpoints which hindered the development and user experience.

2. **What**? (1-3 sentences or a bullet point list):

    - Handles the kwargs parameter and type hint on the package builder. Now kwargs can be passed and used.
    
3. **Impact** (1-2 sentences or a bullet point list):

    - No noticeable impact. Allows for kwargs being passed when defined on the router.

4. **Testing Done**:

    - Tested that the kwargs work and are being passed.