### PR TITLE
[BugFix] Make **kwargs Get Inserted Last On Build

### DIFF
--- a/openbb_platform/core/openbb_core/app/command_runner.py
+++ b/openbb_platform/core/openbb_core/app/command_runner.py
@@ -332,6 +332,7 @@ class StaticCommandRunner:
         user_settings = execution_context.user_settings
         system_settings = execution_context.system_settings
 
+        # TODO: Use execution_context > CommandMap to get the method (GET, POST)
         # If "data" and "kwargs" are both keys in kwargs, it is a POST command.
         # We want to unpack the "kwargs" into the kwargs dict.
         if "data" in kwargs and "kwargs" in kwargs:

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -561,14 +561,14 @@ class MethodDefinition:
                 ],
                 default=False,
             )
-
+        kwargs = None
         formatted: Dict[str, Parameter] = {}
 
         for name, param in parameter_map.items():
             if name == "extra_params":
                 formatted[name] = Parameter(name="kwargs", kind=Parameter.VAR_KEYWORD)
             elif name == "kwargs":
-                formatted["**" + name] = Parameter(
+                kwargs = Parameter(
                     name="kwargs", kind=Parameter.VAR_KEYWORD, annotation=Any
                 )
             elif name == "provider_choices":
@@ -628,7 +628,8 @@ class MethodDefinition:
                     annotation=updated_type,
                     default=param.default,
                 )
-
+        if kwargs:
+            formatted["**kwargs"] = kwargs
         return MethodDefinition.reorder_params(params=formatted)
 
     @staticmethod

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -531,7 +531,7 @@ class MethodDefinition:
     def reorder_params(params: Dict[str, Parameter]) -> "OrderedDict[str, Parameter]":
         """Reorder the params."""
         formatted_keys = list(params.keys())
-        for k in ["provider", "extra_params"]:
+        for k in ["provider", "extra_params", "**kwargs"]:
             if k in formatted_keys:
                 formatted_keys.remove(k)
                 formatted_keys.append(k)
@@ -561,14 +561,14 @@ class MethodDefinition:
                 ],
                 default=False,
             )
-        kwargs = None
+
         formatted: Dict[str, Parameter] = {}
 
         for name, param in parameter_map.items():
             if name == "extra_params":
                 formatted[name] = Parameter(name="kwargs", kind=Parameter.VAR_KEYWORD)
             elif name == "kwargs":
-                kwargs = Parameter(
+                formatted["**" + name] = Parameter(
                     name="kwargs", kind=Parameter.VAR_KEYWORD, annotation=Any
                 )
             elif name == "provider_choices":
@@ -628,8 +628,7 @@ class MethodDefinition:
                     annotation=updated_type,
                     default=param.default,
                 )
-        if kwargs:
-            formatted["**kwargs"] = kwargs
+
         return MethodDefinition.reorder_params(params=formatted)
 
     @staticmethod


### PR DESCRIPTION
1. **Why**?:

    - Fixes an order of insertion error where **kwargs was not placed last argument in the function signature.
    - This raised a SyntaxError.

2. **What**? (1-3 sentences or a bullet point list):

    - Add kwargs to the end of the params ordered dict.
    - In `def validate_kwargs`, don't validate the "kwargs" field.
    - In `def _execute_func`, unpack the "kwargs" dictionary when it is a key in "kwargs".

3. **Impact** (1-2 sentences or a bullet point list):

    - **kwargs + chart can now exist together.

4. **Testing Done**:

Before:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/a0ac7924-df06-4321-b040-66f4f37df4e3)

After:

![Screenshot 2024-03-21 at 1 30 23 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/cb0e7e1a-8227-4cfb-b764-a102a4b782c2)
