### PR TITLE
[BugFix] No event loop when exporting images

### DIFF
--- a/openbb_platform/obbject_extensions/charting/openbb_charting/core/backend.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/core/backend.py
@@ -152,7 +152,6 @@ class Backend(PyWry):
         theme: Optional[str] = None,
     ) -> dict:
         """Get the json update for the backend."""
-
         posthog: Dict[str, Any] = dict(collect_logs=self.charting_settings.log_collect)
         if (
             self.charting_settings.log_collect
@@ -222,6 +221,11 @@ class Backend(PyWry):
         self.send_outgoing(outgoing)
 
         if export_image and isinstance(export_image, Path):
+            if self.loop.is_closed():
+                # Create a new event loop
+                self.loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self.loop)
+
             self.loop.run_until_complete(self.process_image(export_image))
 
     async def process_image(self, export_image: Path):
@@ -507,6 +511,7 @@ if not PLOTLYJS_PATH.exists() and not JUPYTER_NOTEBOOK:
 
 
 def create_backend(charting_settings: Optional["ChartingSettings"] = None):
+    """Create the backend."""
     # # pylint: disable=import-outside-toplevel
     from openbb_core.app.model.charts.charting_settings import ChartingSettings
 
@@ -517,6 +522,7 @@ def create_backend(charting_settings: Optional["ChartingSettings"] = None):
 
 
 def get_backend() -> Backend:
+    """Get the backend instance."""
     if BACKEND is None:
         raise ValueError("Backend not created")
     return BACKEND

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
@@ -923,11 +923,7 @@ class OpenBBFigure(go.Figure):
                 # If the backend fails, we just show the figure normally
                 # This is a very rare case, but it's better to have a fallback
 
-                if getattr(self._charting_settings, "debug_mode", False):
-                    warn(f"Failed to show figure with backend: {e}")
-                warn(
-                    f"Failed to show figure with backend: {e}"
-                )  # remove this line when the above lines are figured out
+                warn(f"Failed to show figure with backend. {e}")
 
                 # We check if any figures were initialized before the backend failed
                 # If so, we show them with the default plotly backend


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - When exporting an image, if the `loop` was already closed the `process_image()` method couldn't complete causing it do doesn't export at all.

2. **What**? (1-3 sentences or a bullet point list):

    - Check if we need to initialize a new `loop` and if yes, do it.

3. **Impact** (1-2 sentences or a bullet point list):

    - None: all stays the same.

4. **Testing Done**:

    - Exporting the image: `res.chart.fig.show(export_image="test.png")`

5. **Reviewer Notes** (optional):

    Warning/Failure I was getting:

```bash
/OpenBBTerminal/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py:928: UserWarning:

Failed to show figure with backend: Event loop is closed
```
