### PR TITLE
[BugFix] Docs: Build Static Assets Before Generating Markdown Files

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -56,6 +56,7 @@ jobs:
           source .venv/bin/activate
           pip install -U poetry
           poetry run python openbb_platform/dev_install.py -e all
+          poetry run python -c "import openbb; openbb.build()"
           pip uninstall nbmake -y
           poetry run python website/generate_platform_v4_markdown.py
 


### PR DESCRIPTION
1. **Why**?:

    - When the docs pages were deployed, the static assets were built before generating the reference markdown files.

2. **What**?:

    - Adds: `poetry run python -c "import openbb; openbb.build()"` after `dev_install.py -e`.

3. **Impact**:

    - Documentation site should now show all routers and models.

4. **Testing Done**:

    - Tested the sequence of actions locally.

    - Example: "Validated with historical market data and simulated scenarios."
