### PR TITLE
[BugFix] yFinance ETF Info: Try Different Field When Missing fundInceptionDate

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
@@ -190,7 +190,9 @@ class YFinanceEtfInfoData(EtfInfoData):
     @classmethod
     def validate_date(cls, v):
         """Validate first stock price date."""
-        return datetime.utcfromtimestamp(v).date().strftime("%Y-%m-%d") if v else None
+        if isinstance(v, datetime):
+            return v.date().strftime("%Y-%m-%d")
+        return datetime.fromtimestamp(v).date().strftime("%Y-%m-%d") if v else None
 
 
 class YFinanceEtfInfoFetcher(
@@ -249,6 +251,7 @@ class YFinanceEtfInfoFetcher(
             "fiveYearAverageReturn",
             "beta3Year",
             "longBusinessSummary",
+            "firstTradeDateEpochUtc",
         ]
 
         async def get_one(symbol):
@@ -263,8 +266,17 @@ class YFinanceEtfInfoFetcher(
                 quote_type = ticker.pop("quoteType", "")
                 if quote_type == "ETF":
                     for field in fields:
-                        if field in ticker:
+                        if field in ticker and ticker.get(field) is not None:
                             result[field] = ticker.get(field, None)
+                    if "firstTradeDateEpochUtc" in result:
+                        _first_trade = result.pop("firstTradeDateEpochUtc")
+                        if (
+                            "fundInceptionDate" not in result
+                            and _first_trade is not None
+                        ):
+                            result["fundInceptionDate"] = datetime.fromtimestamp(
+                                _first_trade
+                            )
                 if quote_type != "ETF":
                     _warn(f"{symbol} is not an ETF.")
                 if result:

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
@@ -265,18 +265,22 @@ class YFinanceEtfInfoFetcher(
             if ticker:
                 quote_type = ticker.pop("quoteType", "")
                 if quote_type == "ETF":
-                    for field in fields:
-                        if field in ticker and ticker.get(field) is not None:
-                            result[field] = ticker.get(field, None)
-                    if "firstTradeDateEpochUtc" in result:
-                        _first_trade = result.pop("firstTradeDateEpochUtc")
-                        if (
-                            "fundInceptionDate" not in result
-                            and _first_trade is not None
-                        ):
-                            result["fundInceptionDate"] = datetime.fromtimestamp(
-                                _first_trade
-                            )
+                    try:
+                        for field in fields:
+                            if field in ticker and ticker.get(field) is not None:
+                                result[field] = ticker.get(field, None)
+                        if "firstTradeDateEpochUtc" in result:
+                            _first_trade = result.pop("firstTradeDateEpochUtc")
+                            if (
+                                "fundInceptionDate" not in result
+                                and _first_trade is not None
+                            ):
+                                result["fundInceptionDate"] = datetime.fromtimestamp(
+                                    _first_trade
+                                )
+                    except Exception as e:
+                        _warn(f"Error processing data for {symbol}: {e}")
+                        result = None
                 if quote_type != "ETF":
                     _warn(f"{symbol} is not an ETF.")
                 if result:

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
@@ -280,7 +280,7 @@ class YFinanceEtfInfoFetcher(
                                 )
                     except Exception as e:
                         _warn(f"Error processing data for {symbol}: {e}")
-                        result = None
+                        result = {}
                 if quote_type != "ETF":
                     _warn(f"{symbol} is not an ETF.")
                 if result:


### PR DESCRIPTION

1. **Why**?:

    - In some instances, ETF info data does not contain the `fundInceptionDate` field and this caused a validation error because it was missing.

2. **What**? (1-3 sentences or a bullet point list):

    - If that field is not present, use `firstTradeDateEpochUtc` instead.

3. **Impact**:

    - Improves exception handling for edge case symbols.

4. **Testing Done**:

    - Before/After: `obb.etf.info("JJEB", provider="yfinance")`
