### PR TITLE
[Bugfix] Removes Charting Integration Test For Chart That Doesn't Exist

### DIFF
--- a/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
+++ b/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
@@ -59,26 +59,6 @@ def test_charting_equity_price_historical(params, obb):
     assert result.chart.content
     assert isinstance(result.chart.fig, OpenBBFigure)
 
-
-@parametrize(
-    "params",
-    [
-        ({"symbol": "AAPL", "limit": 100, "chart": "True"}),
-    ],
-)
-@pytest.mark.integration
-def test_charting_equity_fundamental_multiples(params, obb):
-    """Test chart equity multiples."""
-    params = {p: v for p, v in params.items() if v}
-
-    result = obb.equity.fundamental.multiples(**params)
-    assert result
-    assert isinstance(result, OBBject)
-    assert len(result.results) > 0
-    assert result.chart.content
-    assert isinstance(result.chart.fig, OpenBBFigure)
-
-
 @parametrize(
     "params",
     [

--- a/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
+++ b/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
@@ -59,6 +59,7 @@ def test_charting_equity_price_historical(params, obb):
     assert result.chart.content
     assert isinstance(result.chart.fig, OpenBBFigure)
 
+
 @parametrize(
     "params",
     [


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - equity.fundamental.multiples chart does not exist, test was removed from API integration tests, but not Python.

2. **What**? (1-3 sentences or a bullet point list):

    - Yeeted

3. **Impact** (1-2 sentences or a bullet point list):

    - N/A

4. **Testing Done**:

    - Run tests.
