### PR TITLE
[BugFix] - Serialise response before FastAPI

### DIFF
--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -117,7 +117,7 @@ def build_new_signature(path: str, func: Callable) -> Signature:
     )
 
 
-def validate_output(c_out: OBBject) -> OBBject:
+def validate_output(c_out: OBBject) -> Dict:
     """
     Validate OBBject object.
 
@@ -132,8 +132,8 @@ def validate_output(c_out: OBBject) -> OBBject:
 
     Returns
     -------
-    OBBject
-        Validated OBBject object.
+    Dict
+        Serialized OBBject.
     """
 
     def is_model(type_):
@@ -170,7 +170,7 @@ def validate_output(c_out: OBBject) -> OBBject:
     for k, v in c_out.model_copy():
         exclude_fields_from_api(k, v)
 
-    return c_out
+    return c_out.model_dump()
 
 
 def build_api_wrapper(
@@ -188,7 +188,7 @@ def build_api_wrapper(
     func.__annotations__ = new_annotations_map
 
     @wraps(wrapped=func)
-    async def wrapper(*args: Tuple[Any], **kwargs: Dict[str, Any]):
+    async def wrapper(*args: Tuple[Any], **kwargs: Dict[str, Any]) -> Dict:
         user_settings: UserSettings = UserSettings.model_validate(
             kwargs.pop(
                 "__authenticated_user_settings",
@@ -198,8 +198,7 @@ def build_api_wrapper(
         execute = partial(command_runner.run, path, user_settings)
         output: OBBject = await execute(*args, **kwargs)
 
-        output = validate_output(output)
-        return output
+        return validate_output(output)
 
     return wrapper
 

--- a/openbb_platform/core/openbb_core/provider/registry_map.py
+++ b/openbb_platform/core/openbb_core/provider/registry_map.py
@@ -110,7 +110,7 @@ class RegistryMap:
         fetcher: Fetcher,
         model_map: dict,
     ):
-        """Merge json schema extra for different providers"""
+        """Merge json schema extra for different providers."""
         model: BaseModel = RegistryMap._get_model(fetcher, "query_params")
         std_fields = model_map["openbb"]["QueryParams"]["fields"]
         extra_fields = model_map[provider]["QueryParams"]["fields"]
@@ -157,7 +157,6 @@ class RegistryMap:
             Field(
                 default=provider_str,
                 description="The data provider for the data.",
-                exclude=True,
             ),
         )
 


### PR DESCRIPTION
1. **Why**?

    - API responses are excluding the symbol response field when multiple symbols are passed into `symbol` query parameter

2. **What**?

    - Serialising the response before FastAPI prevents Pydantic from dropping extra fields, thus dropping `symbol` from API response
    - This was present before https://github.com/OpenBB-finance/OpenBBTerminal/pull/6024, but discriminated unions require us to pass the provider field in the model

3. **Impact**

    - Behaviour is consistent in both interfaces
    - It also returns the provider where the data comes from, removing this in both interfaces introduces unnecessary complexity since the information can be ignored by frontend

4. **Testing Done**:

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/79287829/f09c3162-c816-4cb4-86b8-62cd0683ca82)

<img width="1227" alt="Screenshot 2024-04-02 at 16 13 45" src="https://github.com/OpenBB-finance/OpenBBTerminal/assets/79287829/dc296809-ca5e-4c4e-9177-594169b44fbc">
