### PR TITLE
[BugFix] Drop 'provider' in `to_df()`

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/obbject.py
+++ b/openbb_platform/core/openbb_core/app/model/obbject.py
@@ -226,6 +226,9 @@ class OBBject(Tagged, Generic[T]):
         except Exception as ex:
             raise OpenBBError(f"An unexpected error occurred: {ex}") from ex
 
+        if "provider" in df.columns:
+            df.drop(columns=["provider"], inplace=True)
+
         return df
 
     def to_polars(self) -> "PolarsDataFrame":

--- a/openbb_platform/core/openbb_core/app/utils.py
+++ b/openbb_platform/core/openbb_core/app/utils.py
@@ -46,6 +46,9 @@ def basemodel_to_df(
         else:
             df = df.set_index(index) if index and index in df.columns else df
 
+    if "provider" in df.columns:
+        df.drop(columns=["provider"], inplace=True)
+
     return df
 
 


### PR DESCRIPTION
1. **Why**?:

    - Takes care of an impact detailed in #6279, ignoring the 'provider' column introduced, for the Python Interface.

2. **What**? (1-3 sentences or a bullet point list):

    - Drops that column in `to_df()` and `basemodel_to_df()`

3. **Impact** (1-2 sentences or a bullet point list):

    - Maintains a cleaner output and presentation.

4. **Testing Done**:

![Screenshot 2024-04-02 at 10 57 10 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/f0c6ee83-910b-44ee-aad2-41adfd408d91)


