### PR TITLE
[BugFix] - Fix nested router descriptions

### DIFF
--- a/openbb_platform/core/openbb_core/app/router.py
+++ b/openbb_platform/core/openbb_core/app/router.py
@@ -209,7 +209,7 @@ class Router:
         return self._api_router.prefix
 
     @property
-    def description(self) -> str:
+    def description(self) -> Optional[str]:
         """Description."""
         return self._description
 
@@ -221,7 +221,7 @@ class Router:
     def __init__(
         self,
         prefix: str = "",
-        description: str = "",
+        description: Optional[str] = None,
     ) -> None:
         """Initialize Router."""
         self._api_router = APIRouter(

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1684,8 +1684,15 @@ class ReferenceGenerator:
         main_router = RouterLoader.from_extensions()
         routers = {}
         for path in route_map:
-            # Strip the command name from the path
-            _path = "/".join(path.split("/")[:-1])
-            if description := main_router.get_attr(_path, "description"):
-                routers[_path] = {"description": description}
+            path_parts = path.split("/")
+            # We start at 2: ["/", "some_router"] "/some_router"
+            i = 2
+            _path = "/".join(path_parts[:i])
+            while _path not in routers and _path != path:
+                description = main_router.get_attr(_path, "description")
+                if description is not None:
+                    routers[_path] = description
+                # We go down the path to include sub-routers
+                i += 1
+                _path = "/".join(path_parts[:i])
         return routers

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1687,18 +1687,18 @@ class ReferenceGenerator:
             path_parts = path.split("/")
             # We start at 2: ["/", "some_router"] "/some_router"
             i = 2
-            _path = "/".join(path_parts[:i])
-            while _path != path:
-                if _path in routers:
+            p = "/".join(path_parts[:i])
+            while p != path:
+                if p in routers:
                     i += 1
-                    _path = "/".join(path_parts[:i])
+                    p = "/".join(path_parts[:i])
                     # No need to add the same router again
                     continue
-                _path = "/".join(path_parts[:i])
-                description = main_router.get_attr(_path, "description")
+                p = "/".join(path_parts[:i])
+                description = main_router.get_attr(p, "description")
                 if description is not None:
-                    routers[_path] = {"description": description}
+                    routers[p] = {"description": description}
                 # We go down the path to include sub-routers
                 i += 1
-                _path = "/".join(path_parts[:i])
+                p = "/".join(path_parts[:i])
         return routers

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1688,7 +1688,13 @@ class ReferenceGenerator:
             # We start at 2: ["/", "some_router"] "/some_router"
             i = 2
             _path = "/".join(path_parts[:i])
-            while _path not in routers and _path != path:
+            while _path != path:
+                if _path in routers:
+                    i += 1
+                    _path = "/".join(path_parts[:i])
+                    # No need to add the same router again
+                    continue
+                _path = "/".join(path_parts[:i])
                 description = main_router.get_attr(_path, "description")
                 if description is not None:
                     routers[_path] = {"description": description}

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1691,7 +1691,7 @@ class ReferenceGenerator:
             while _path not in routers and _path != path:
                 description = main_router.get_attr(_path, "description")
                 if description is not None:
-                    routers[_path] = description
+                    routers[_path] = {"description": description}
                 # We go down the path to include sub-routers
                 i += 1
                 _path = "/".join(path_parts[:i])

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1689,15 +1689,11 @@ class ReferenceGenerator:
             i = 2
             p = "/".join(path_parts[:i])
             while p != path:
-                if p in routers:
-                    i += 1
+                if p not in routers:
                     p = "/".join(path_parts[:i])
-                    # No need to add the same router again
-                    continue
-                p = "/".join(path_parts[:i])
-                description = main_router.get_attr(p, "description")
-                if description is not None:
-                    routers[p] = {"description": description}
+                    description = main_router.get_attr(p, "description")
+                    if description is not None:
+                        routers[p] = {"description": description}
                 # We go down the path to include sub-routers
                 i += 1
                 p = "/".join(path_parts[:i])

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1690,7 +1690,6 @@ class ReferenceGenerator:
             p = "/".join(path_parts[:i])
             while p != path:
                 if p not in routers:
-                    p = "/".join(path_parts[:i])
                     description = main_router.get_attr(p, "description")
                     if description is not None:
                         routers[p] = {"description": description}

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -27167,15 +27167,35 @@
         }
     },
     "routers": {
-        "/crypto": "Cryptocurrency market data.",
-        "/currency": "Foreign exchange (FX) market data.",
-        "/derivatives": "Derivatives market data.",
-        "/economy": "Economic data.",
-        "/equity": "Equity market data.",
-        "/etf": "Exchange Traded Funds market data.",
-        "/fixedincome": "Fixed Income market data.",
-        "/index": "Indices data.",
-        "/news": "Financial market news data.",
-        "/regulators": "Financial market regulators data."
+        "/crypto": {
+            "description": "Cryptocurrency market data."
+        },
+        "/currency": {
+            "description": "Foreign exchange (FX) market data."
+        },
+        "/derivatives": {
+            "description": "Derivatives market data."
+        },
+        "/economy": {
+            "description": "Economic data."
+        },
+        "/equity": {
+            "description": "Equity market data."
+        },
+        "/etf": {
+            "description": "Exchange Traded Funds market data."
+        },
+        "/fixedincome": {
+            "description": "Fixed Income market data."
+        },
+        "/index": {
+            "description": "Indices data."
+        },
+        "/news": {
+            "description": "Financial market news data."
+        },
+        "/regulators": {
+            "description": "Financial market regulators data."
+        }
     }
 }

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -27167,29 +27167,15 @@
         }
     },
     "routers": {
-        "/crypto": {
-            "description": "Cryptocurrency market data."
-        },
-        "/currency": {
-            "description": "Foreign exchange (FX) market data."
-        },
-        "/economy": {
-            "description": "Economic data."
-        },
-        "/equity": {
-            "description": "Equity market data."
-        },
-        "/etf": {
-            "description": "Exchange Traded Funds market data."
-        },
-        "/fixedincome": {
-            "description": "Fixed Income market data."
-        },
-        "/index": {
-            "description": "Indices data."
-        },
-        "/news": {
-            "description": "Financial market news data."
-        }
+        "/crypto": "Cryptocurrency market data.",
+        "/currency": "Foreign exchange (FX) market data.",
+        "/derivatives": "Derivatives market data.",
+        "/economy": "Economic data.",
+        "/equity": "Equity market data.",
+        "/etf": "Exchange Traded Funds market data.",
+        "/fixedincome": "Fixed Income market data.",
+        "/index": "Indices data.",
+        "/news": "Financial market news data.",
+        "/regulators": "Financial market regulators data."
     }
 }


### PR DESCRIPTION
1. **Why**?

    - Package builder was not dumping router descriptions if no command is at main router level, like `/derivatives` or `/regulators`. E.g.

```python
/derivatives
      /options
      /futures
```

2. **What**?

    - Loop through the full route path looking for descriptions
    - Avoid adding same router twice

3. **Impact**
    NA

5. **Testing Done**:

    - Add descriptions to sub-routers, rebuild and check they are dumped into reference.json