### PR TITLE
[BugFix] Fix the multiple items check

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/utils/filters.py
+++ b/openbb_platform/core/openbb_core/app/static/utils/filters.py
@@ -42,5 +42,16 @@ def filter_inputs(
 
                         kwargs[p][field] = new
                         break
+    else:
+        provider = kwargs.get("provider_choices", {}).get("provider")
+        for param_category in ("standard_params", "extra_params"):
+            if param_category in kwargs:
+                for field, value in kwargs[param_category].items():
+                    if isinstance(value, list):
+                        kwargs[param_category][field] = ",".join(map(str, value))
+                    check_single_item(
+                        kwargs[param_category][field],
+                        f"{field} -> multiple items not allowed for '{provider}'",
+                    )
 
     return kwargs

--- a/openbb_platform/core/openbb_core/app/utils.py
+++ b/openbb_platform/core/openbb_core/app/utils.py
@@ -166,6 +166,6 @@ def check_single_item(
     value: Optional[str], message: Optional[str] = None
 ) -> Optional[str]:
     """Check that string contains a single item."""
-    if value and ("," in value or ";" in value):
+    if value and isinstance(value, str) and ("," in value or ";" in value):
         raise OpenBBError(message if message else "multiple items not allowed")
     return value


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Multiple symbol check not working for many endpoints.
    - Root cause was that if no `info` i.e., if there is no provider declaring `__json_schema_extra__` for the endpoint, no info will be there - this doesn't mean that we don't need to perform the check for multiple items.

2. **What**? (1-3 sentences or a bullet point list):

    - Added an `else` statement when no `info` is available that will evaluate the `kwargs` and verify that there aren't any multiple items.

3. **Impact** (1-2 sentences or a bullet point list):

    - This presents a moderate impact as all the endpoints go through `filter_inputs()` function.

4. **Testing Done**:

    - Running multiples endpoints:
```python
from openbb import obb
obb.equity.estimates.historical(["AAPL","MSFT"], provider="fmp").to_df()                                  # good
obb.equity.fundamental.historical_splits(symbol="AAPL,MSFT",provider="fmp").to_df()        # good
obb.equity.fundamental.historical_splits(symbol="AAPL,MSFT",provider="fmp").to_df()        # bad
obb.equity.fundamental.historical_splits(symbol=["AAPL","MSFT"],provider="fmp").to_df()   # bad
obb.equity.price.historical("AAPL,MSFT", provider="intrinio").to_df()                                           # bad
obb.equity.fundamental.cash("MSFT,AAPL", provider="polygon")                                                # bad
obb.equity.fundamental.cash("MSFT", provider="polygon")                                                          # good
```

5. **Reviewer Notes** (optional):

    - NA

6. **Any other information** (optional)

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/48914296/7c4ae068-1ee7-421f-a909-6066c64981be)
