### PR TITLE
[BugFix] Handling negative timestamps on Windows

### DIFF
--- a/openbb_platform/core/openbb_core/provider/utils/helpers.py
+++ b/openbb_platform/core/openbb_core/provider/utils/helpers.py
@@ -1,8 +1,9 @@
 """Provider helpers."""
 
 import asyncio
+import os
 import re
-from datetime import date, datetime
+from datetime import date, datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from functools import partial
 from inspect import iscoroutinefunction
@@ -313,3 +314,10 @@ def filter_by_dates(
         return False
 
     return list(filter(_filter, data))
+
+
+def safe_fromtimestamp(timestamp: float, tz: Optional[timezone] = None) -> datetime:
+    """datetime.fromtimestamp alternative which supports negative timestamps on Windows platform."""
+    if os.name == "nt" and timestamp < 0:
+        return datetime(1970, 1, 1, tzinfo=tz) + timedelta(seconds=timestamp)
+    return datetime.fromtimestamp(timestamp, tz)

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
@@ -3,7 +3,10 @@
 # pylint: disable=unused-argument
 import asyncio
 import warnings
-from datetime import datetime
+from datetime import (
+    date as dateType,
+    timezone,
+)
 from typing import Any, Dict, List, Optional
 
 from openbb_core.provider.abstract.fetcher import Fetcher
@@ -11,6 +14,7 @@ from openbb_core.provider.standard_models.equity_info import (
     EquityInfoData,
     EquityInfoQueryParams,
 )
+from openbb_core.provider.utils.helpers import safe_fromtimestamp
 from pydantic import Field, field_validator
 from yfinance import Ticker
 
@@ -97,9 +101,9 @@ class YFinanceEquityProfileData(EquityInfoData):
 
     @field_validator("first_stock_price_date", mode="before", check_fields=False)
     @classmethod
-    def validate_first_trade_date(cls, v):
+    def validate_first_trade_date(cls, v: float) -> Optional[dateType]:
         """Validate first stock price date."""
-        return datetime.utcfromtimestamp(v).date() if v else None
+        return safe_fromtimestamp(v, tz=timezone.utc).date() if v else None
 
 
 class YFinanceEquityProfileFetcher(


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Having a negative timestamp would break the model validation, thus corrupting the command response.

2. **What**? (1-3 sentences or a bullet point list):

    - Used `datetime.timedelta` for a safe timestamp converstion when on Windows platform.

3. **Impact** (1-2 sentences or a bullet point list):

    - NA - done at the provider level, allowing users to use the affected endpoint.

4. **Testing Done**:

    - Running the identified command that was running into issues for all the available providers: `obb.equity.profile("IBM", provider="yfinance").to_df()`.

5. **Reviewer Notes** (optional):

    - If the reviewer can't test on Windows:
    - Before:
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/48914296/542fb519-72fb-4892-ace1-08a790fa8ee6)

    - After:
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/48914296/55e7e756-788c-4c0b-98a3-5f700821032e)

