### PR TITLE
[Feature] Limit number of countries in TE request

### DIFF
--- a/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/models/economic_calendar.py
+++ b/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/models/economic_calendar.py
@@ -57,6 +57,13 @@ class TEEconomicCalendarQueryParams(EconomicCalendarQueryParams):
         for v in values:
             check_item(v.lower(), COUNTRIES)
             result.append(v.lower())
+
+            if len(result) > 32:
+                raise ValueError(
+                    "Too many countries. "
+                    "Trading Economics API allows a maximum of 32 countries."
+                )
+
         return ",".join(result)
 
     @field_validator("importance")

--- a/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/models/economic_calendar.py
+++ b/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/models/economic_calendar.py
@@ -31,6 +31,7 @@ GROUPS = Literal[
     "trade",
     "business",
 ]
+TE_COUNTRY_LIMIT = 32
 
 
 class TEEconomicCalendarQueryParams(EconomicCalendarQueryParams):
@@ -58,7 +59,7 @@ class TEEconomicCalendarQueryParams(EconomicCalendarQueryParams):
             check_item(v.lower(), COUNTRIES)
             result.append(v.lower())
 
-            if len(result) > 32:
+            if len(result) > TE_COUNTRY_LIMIT:
                 raise ValueError(
                     "Too many countries. "
                     "Trading Economics API allows a maximum of 32 countries."

--- a/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/models/economic_calendar.py
+++ b/openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/models/economic_calendar.py
@@ -143,6 +143,7 @@ class TEEconomicCalendarFetcher(
 
         return await amake_request(url, response_callback=callback, **kwargs)
 
+    # pylint: disable=unused-argument
     @staticmethod
     def transform_data(
         query: TEEconomicCalendarQueryParams, data: List[Dict], **kwargs: Any


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Allowing more than N countries in a TE request would break with a http code of 400 - this PR enhances the UX.

2. **What**? (1-3 sentences or a bullet point list):

    - Added a validation for the number of countries in the fetcher.

3. **Impact** (1-2 sentences or a bullet point list):

    - Low - small improvement on UX.

4. **Testing Done**:

    - Experiment with any amount of countries from `openbb_platform/providers/tradingeconomics/openbb_tradingeconomics/utils/countries.py`:
```python
from openbb import obb
countries = [...]
obb.economy.calendar(provider="tradingeconomics", country=countries).to_df()
```

5. **Reviewer Notes** (optional):

    - It looks like it depends on the countries we're sending. Sometimes it fails for 28, other times 31/32. I wasn't able to get more than 32 with any combination of countries. Also, couldn't find any information related with this limit on TE API docs. cc @andrewkenreich 