### PR TITLE
[BugFix] Fix yFinance end_date filter when not intraday.

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -172,7 +172,7 @@ def yf_download(
                 data["date"]
                 <= (
                     pd.to_datetime(end_date)
-                    + relativedelta(days=1 if intraday is True else 0)
+                    + relativedelta(minutes=719 if intraday is True else 0)
                 )
             ]
         if intraday is True:

--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -100,19 +100,22 @@ def yf_download(
     """Get yFinance OHLC data for any ticker and interval available."""
     symbol = symbol.upper()
     _start_date = start_date
-
+    intraday = False
     if interval in ["60m", "1h"]:
         period = "2y" if period in ["5y", "10y", "max"] else period
         _start_date = None
+        intraday = True
 
     if interval in ["2m", "5m", "15m", "30m", "90m"]:
         _start_date = (datetime.now().date() - relativedelta(days=58)).strftime(
             "%Y-%m-%d"
         )
+        intraday = True
 
     if interval == "1m":
         period = "5d"
         _start_date = None
+        intraday = True
 
     if adjusted is False:
         kwargs = dict(auto_adjust=False, back_adjust=False)
@@ -158,7 +161,6 @@ def yf_download(
         data = data.rename(columns={"Date": "date", "Datetime": "date"})
         data["date"] = data["date"].apply(pd.to_datetime)
         data = data[data["Open"] > 0]
-
         if start_date is not None:
             data = data[data["date"] >= pd.to_datetime(start_date)]
         if (
@@ -167,31 +169,19 @@ def yf_download(
             and pd.to_datetime(end_date) > pd.to_datetime(start_date)
         ):
             data = data[
-                data["date"] <= (pd.to_datetime(end_date) + relativedelta(days=1))
+                data["date"]
+                <= (
+                    pd.to_datetime(end_date)
+                    + relativedelta(days=1 if intraday is True else 0)
+                )
             ]
-
-        if period not in [
-            "max",
-            "1d",
-            "5d",
-            "1wk",
-            "1mo",
-            "3mo",
-            "6mo",
-            "1y",
-            "2y",
-            "5y",
-            "10y",
-        ]:
+        if intraday is True:
             data["date"] = data["date"].dt.strftime("%Y-%m-%d %H:%M:%S")
-        if interval not in ["1m", "2m", "5m", "15m", "30m", "90m", "60m", "1h"]:
+        else:
             data["date"] = data["date"].dt.strftime("%Y-%m-%d")
-
         if adjusted is False:
             data = data.drop(columns=["Adj Close"])
-
         data.columns = data.columns.str.lower().str.replace(" ", "_").to_list()
-
     return data
 
 


### PR DESCRIPTION
1. **Why**?:

    - When an end date is requested, handling for intraday was also adjusting the target date for non-intraday, resulting in an extra day being added.

2. **What**? (1-3 sentences or a bullet point list):

    - Set flag so that if `intraday`, then add 719 minutes to capture all intraday values inclusive of the `end_date`.

3. **Impact** (1-2 sentences or a bullet point list):

    - No more unexpected extra date.

4. **Testing Done**:

    March 31, 2024 is a good test case because it is a Sunday, and we should not be getting April 1 when the data is daily/weekly/monthly.

    - obb.equity.price.historical("BTC-USD", start_date="2024-03-01", end_date="2024-03-31", provider="yfinance", interval="15m"
    - obb.equity.price.historical("QQQ", start_date="2024-01-01", end_date="2024-03-31", provider="yfinance")
