### PR TITLE
[BugFix] Undocumented Benzinga Fields In API Response

### DIFF
--- a/openbb_platform/providers/benzinga/openbb_benzinga/models/analyst_search.py
+++ b/openbb_platform/providers/benzinga/openbb_benzinga/models/analyst_search.py
@@ -145,6 +145,17 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
         alias="1m_stdev",
     )
+    smart_score_1m: Optional[float] = Field(
+        default=None,
+        description="A weighted average smart score over the last month.",
+        alias="1m_smart_score",
+    )
+    success_rate_1m: Optional[float] = Field(
+        default=None,
+        description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last month",
+        json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
+        alias="1m_success_rate",
+    )
     gain_count_3m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 3 months",
@@ -168,6 +179,17 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         + " analyst's ratings over the last 3 months",
         json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
         alias="3m_stdev",
+    )
+    smart_score_3m: Optional[float] = Field(
+        default=None,
+        description="A weighted average smart score over the last 3 months.",
+        alias="3m_smart_score",
+    )
+    success_rate_3m: Optional[float] = Field(
+        default=None,
+        description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 months",
+        json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
+        alias="3m_success_rate",
     )
     gain_count_6m: Optional[int] = Field(
         default=None,
@@ -217,6 +239,17 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
         alias="9m_stdev",
     )
+    smart_score_9m: Optional[float] = Field(
+        default=None,
+        description="A weighted average smart score over the last 9 months.",
+        alias="9m_smart_score",
+    )
+    success_rate_9m: Optional[float] = Field(
+        default=None,
+        description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 9 months",
+        json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
+        alias="9m_success_rate",
+    )
     gain_count_1y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 1 year",
@@ -240,6 +273,17 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         + " analyst's ratings over the last 1 year",
         json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
         alias="1y_stdev",
+    )
+    smart_score_1y: Optional[float] = Field(
+        default=None,
+        description="A weighted average smart score over the last 1 year.",
+        alias="1y_smart_score",
+    )
+    success_rate_1y: Optional[float] = Field(
+        default=None,
+        description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 1 year",
+        json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
+        alias="1y_success_rate",
     )
     gain_count_2y: Optional[int] = Field(
         default=None,
@@ -265,6 +309,17 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
         alias="2y_stdev",
     )
+    smart_score_2y: Optional[float] = Field(
+        default=None,
+        description="A weighted average smart score over the last 3 years.",
+        alias="2y_smart_score",
+    )
+    success_rate_2y: Optional[float] = Field(
+        default=None,
+        description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 2 years",
+        json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
+        alias="2y_success_rate",
+    )
     gain_count_3y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 3 years",
@@ -288,6 +343,17 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         + " analyst's ratings over the last 3 years",
         json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
         alias="3y_stdev",
+    )
+    smart_score_3y: Optional[float] = Field(
+        default=None,
+        description="A weighted average smart score over the last 3 years.",
+        alias="3y_smart_score",
+    )
+    success_rate_3y: Optional[float] = Field(
+        default=None,
+        description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 years",
+        json_schema_extra={"unit_measurement": "percent", "frontend_multiply": 100},
+        alias="3y_success_rate",
     )
 
     @field_validator("last_updated", mode="before", check_fields=False)


### PR DESCRIPTION
1. **Why**?:

    - Fields are being returned from Benzinga that are undocumented - 'smart_score' and 'success_rate' over different intervals.
        - Reference: https://docs.benzinga.io/benzinga-apis/calendar/get-analysts

2. **What**? (1-3 sentences or a bullet point list):

    - Added fields to the data model. FYI, @andrewkenreich

3. **Impact** (1-2 sentences or a bullet point list):

    - Mystery fields will now have be defined in `open_api.json`
    - Doesn't change anything, just adds model definitions.

4. **Testing Done**:

Before:

![Screenshot 2024-04-10 at 6 08 58 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/47d5faab-e4ac-489e-8e9e-ed8dafe7887a)

After:

![Screenshot 2024-04-10 at 6 06 19 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/3436d2e5-1766-48af-8901-37a77d59a6ee)
