### PR TITLE
[BugFix] Fix metadata creation

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/metadata.py
+++ b/openbb_platform/core/openbb_core/app/model/metadata.py
@@ -44,7 +44,7 @@ class Metadata(BaseModel):
         arguments: Dict[str, Any] = {}
         for item in ["provider_choices", "standard_params", "extra_params"]:
             arguments[item] = {}
-            for arg, arg_val in v.items():
+            for arg, arg_val in v[item].items():
                 new_arg_val: Optional[Union[str, dict[str, Sequence[Any]]]] = None
 
                 # Data
@@ -132,4 +132,4 @@ class Metadata(BaseModel):
 
                 arguments[item][arg] = new_arg_val or arg_val
 
-        return v
+        return arguments

--- a/openbb_platform/core/openbb_core/app/model/metadata.py
+++ b/openbb_platform/core/openbb_core/app/model/metadata.py
@@ -41,90 +41,95 @@ class Metadata(BaseModel):
         containing the type and the columns. If the type is not one of the previous, the
         value is kept or trimmed to 80 characters.
         """
-        for arg, arg_val in v.items():
-            new_arg_val: Optional[Union[str, dict[str, Sequence[Any]]]] = None
+        arguments: Dict[str, Any] = {}
+        for item in ["provider_choices", "standard_params", "extra_params"]:
+            arguments[item] = {}
+            for arg, arg_val in v.items():
+                new_arg_val: Optional[Union[str, dict[str, Sequence[Any]]]] = None
 
-            # Data
-            if isclass(type(arg_val)) and issubclass(type(arg_val), Data):
-                new_arg_val = {
-                    "type": f"{type(arg_val).__name__}",
-                    "columns": list(arg_val.model_dump().keys()),
-                }
+                # Data
+                if isclass(type(arg_val)) and issubclass(type(arg_val), Data):
+                    new_arg_val = {
+                        "type": f"{type(arg_val).__name__}",
+                        "columns": list(arg_val.model_dump().keys()),
+                    }
 
-            # List[Data]
-            if isinstance(arg_val, list) and issubclass(type(arg_val[0]), Data):
-                _columns = [list(d.model_dump().keys()) for d in arg_val]
-                ld_columns = (
-                    item for sublist in _columns for item in sublist
-                )  # flatten
-                new_arg_val = {
-                    "type": f"List[{type(arg_val[0]).__name__}]",
-                    "columns": list(set(ld_columns)),
-                }
+                # List[Data]
+                if isinstance(arg_val, list) and issubclass(type(arg_val[0]), Data):
+                    _columns = [list(d.model_dump().keys()) for d in arg_val]
+                    ld_columns = (
+                        item for sublist in _columns for item in sublist
+                    )  # flatten
+                    new_arg_val = {
+                        "type": f"List[{type(arg_val[0]).__name__}]",
+                        "columns": list(set(ld_columns)),
+                    }
 
-            # DataFrame
-            elif isinstance(arg_val, pd.DataFrame):
-                df_columns = (
-                    list(arg_val.index.names) + arg_val.columns.tolist()
-                    if any(index is not None for index in list(arg_val.index.names))
-                    else arg_val.columns.tolist()
-                )
-                new_arg_val = {
-                    "type": f"{type(arg_val).__name__}",
-                    "columns": df_columns,
-                }
-
-            # List[DataFrame]
-            elif isinstance(arg_val, list) and issubclass(
-                type(arg_val[0]), pd.DataFrame
-            ):
-                ldf_columns = [
-                    (
-                        list(df.index.names) + df.columns.tolist()
-                        if any(index is not None for index in list(df.index.names))
-                        else df.columns.tolist()
+                # DataFrame
+                elif isinstance(arg_val, pd.DataFrame):
+                    df_columns = (
+                        list(arg_val.index.names) + arg_val.columns.tolist()
+                        if any(index is not None for index in list(arg_val.index.names))
+                        else arg_val.columns.tolist()
                     )
-                    for df in arg_val
-                ]
-                new_arg_val = {
-                    "type": f"List[{type(arg_val[0]).__name__}]",
-                    "columns": ldf_columns,
-                }
+                    new_arg_val = {
+                        "type": f"{type(arg_val).__name__}",
+                        "columns": df_columns,
+                    }
 
-            # Series
-            elif isinstance(arg_val, pd.Series):
-                new_arg_val = {
-                    "type": f"{type(arg_val).__name__}",
-                    "columns": list(arg_val.index.names) + [arg_val.name],
-                }
+                # List[DataFrame]
+                elif isinstance(arg_val, list) and issubclass(
+                    type(arg_val[0]), pd.DataFrame
+                ):
+                    ldf_columns = [
+                        (
+                            list(df.index.names) + df.columns.tolist()
+                            if any(index is not None for index in list(df.index.names))
+                            else df.columns.tolist()
+                        )
+                        for df in arg_val
+                    ]
+                    new_arg_val = {
+                        "type": f"List[{type(arg_val[0]).__name__}]",
+                        "columns": ldf_columns,
+                    }
 
-            # List[Series]
-            elif isinstance(arg_val, list) and isinstance(arg_val[0], pd.Series):
-                ls_columns = [
-                    (
-                        list(series.index.names) + [series.name]
-                        if any(index is not None for index in list(series.index.names))
-                        else series.name
-                    )
-                    for series in arg_val
-                ]
-                new_arg_val = {
-                    "type": f"List[{type(arg_val[0]).__name__}]",
-                    "columns": ls_columns,
-                }
+                # Series
+                elif isinstance(arg_val, pd.Series):
+                    new_arg_val = {
+                        "type": f"{type(arg_val).__name__}",
+                        "columns": list(arg_val.index.names) + [arg_val.name],
+                    }
 
-            # ndarray
-            elif isinstance(arg_val, np.ndarray):
-                new_arg_val = {
-                    "type": f"{type(arg_val).__name__}",
-                    "columns": list(arg_val.dtype.names or []),
-                }
+                # List[Series]
+                elif isinstance(arg_val, list) and isinstance(arg_val[0], pd.Series):
+                    ls_columns = [
+                        (
+                            list(series.index.names) + [series.name]
+                            if any(
+                                index is not None for index in list(series.index.names)
+                            )
+                            else series.name
+                        )
+                        for series in arg_val
+                    ]
+                    new_arg_val = {
+                        "type": f"List[{type(arg_val[0]).__name__}]",
+                        "columns": ls_columns,
+                    }
 
-            else:
-                str_repr_arg_val = str(arg_val)
-                if len(str_repr_arg_val) > 80:
-                    new_arg_val = str_repr_arg_val[:80]
+                # ndarray
+                elif isinstance(arg_val, np.ndarray):
+                    new_arg_val = {
+                        "type": f"{type(arg_val).__name__}",
+                        "columns": list(arg_val.dtype.names or []),
+                    }
 
-            v[arg] = new_arg_val or arg_val
+                else:
+                    str_repr_arg_val = str(arg_val)
+                    if len(str_repr_arg_val) > 80:
+                        new_arg_val = str_repr_arg_val[:80]
+
+                arguments[item][arg] = new_arg_val or arg_val
 
         return v

--- a/openbb_platform/core/tests/app/model/test_metadata.py
+++ b/openbb_platform/core/tests/app/model/test_metadata.py
@@ -12,7 +12,11 @@ from openbb_core.provider.abstract.data import Data
 def test_Metadata():
     """Run Smoke test."""
     m = Metadata(
-        arguments={"test": "test"},
+        arguments={
+            "provider_choices": {},
+            "standard_params": {},
+            "extra_params": {},
+        },
         route="test",
         timestamp=datetime.now(),
         duration=0,
@@ -44,7 +48,7 @@ def test_fields():
             {
                 "data_list": {
                     "type": "List[Data]",
-                    "columns": ["open", "close", "volume"],
+                    "columns": ["close", "volume", "open"],
                 }
             },
         ),
@@ -53,7 +57,7 @@ def test_fields():
             {
                 "data_list": {
                     "type": "List[Data]",
-                    "columns": ["open", "close", "volume"],
+                    "columns": ["close", "volume", "open"],
                 }
             },
         ),
@@ -101,8 +105,13 @@ def test_fields():
 )
 def test_scale_arguments(input_data, expected_output):
     """Test the scale_arguments method."""
+    kwargs = {
+        "provider_choices": {},
+        "standard_params": {},
+        "extra_params": input_data,
+    }
     m = Metadata(
-        arguments=input_data,
+        arguments=kwargs,
         route="test",
         timestamp=datetime.now(),
         duration=0,
@@ -112,9 +121,9 @@ def test_scale_arguments(input_data, expected_output):
     for arg in arguments:  # pylint: disable=E1133
         if "columns" in arguments[arg]:
             # compare the column names disregarding the order with the expected output
-            assert sorted(arguments[arg]["columns"]) == sorted(
+            assert sorted(arguments["extra_params"][arg]["columns"]) == sorted(
                 expected_output[arg]["columns"]
             )
             assert arguments[arg]["type"] == expected_output[arg]["type"]
         else:
-            assert m.arguments == expected_output
+            assert m.arguments["extra_params"] == expected_output

--- a/openbb_platform/core/tests/app/model/test_metadata.py
+++ b/openbb_platform/core/tests/app/model/test_metadata.py
@@ -48,7 +48,7 @@ def test_fields():
             {
                 "data_list": {
                     "type": "List[Data]",
-                    "columns": ["close", "volume", "open"],
+                    "columns": ["open", "volume", "close"],
                 }
             },
         ),
@@ -57,7 +57,7 @@ def test_fields():
             {
                 "data_list": {
                     "type": "List[Data]",
-                    "columns": ["close", "volume", "open"],
+                    "columns": ["open", "close", "volume"],
                 }
             },
         ),
@@ -126,4 +126,19 @@ def test_scale_arguments(input_data, expected_output):
             )
             assert arguments[arg]["type"] == expected_output[arg]["type"]
         else:
-            assert m.arguments["extra_params"] == expected_output
+            # assert m.arguments["extra_params"] == expected_output
+            keys = list(arguments["extra_params"].keys())
+            expected_keys = list(expected_output.keys())
+            assert sorted(keys) == sorted(expected_keys)
+
+            for key in keys:
+                if "type" in arguments["extra_params"][key]:
+                    assert (
+                        arguments["extra_params"][key]["type"]
+                        == expected_output[key]["type"]
+                    )
+                    assert sorted(arguments["extra_params"][key]["columns"]) == sorted(
+                        expected_output[key]["columns"]
+                    )
+                else:
+                    assert arguments["extra_params"][key] == expected_output[key]

--- a/openbb_platform/core/tests/app/test_command_runner.py
+++ b/openbb_platform/core/tests/app/test_command_runner.py
@@ -352,6 +352,7 @@ async def test_static_command_runner_run(
             """Initialize the mock object."""
             self.results = results
             self.extra = {}
+            self.extra["metadata"] = {"test": "test"}
 
     mock_get_command.return_value = other_mock_func
     mock_execute_func.return_value = MockOBBject(results=[1, 2, 3, 4])


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Metadata in a wrong format (namely json string) causes a poor UX.

2. **What**? (1-3 sentences or a bullet point list):

    - Fixed iteration on the arguments so that the length of each argument is properly accessed.

3. **Impact** (1-2 sentences or a bullet point list):

    - No impact (metadata is optional).

4. **Testing Done**:

    - Running any endpoint with several arguments (before and after):
```python
from openbb import obb
res = obb.equity.price.historical("AAPL,MSFT", provider="fmp", start_date="2022-01-01")
res.extra["metadata"]
```

5. **Reviewer Notes** (optional):

    - NA

6. **Any other information** (optional)

Before:
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/48914296/8b1df87e-1b9c-4a60-9b64-d1f17e5dd307)

After:
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/48914296/0fcf2d58-9912-4933-bf22-150d65ff8204)
