### PR TITLE
[BugFix] Chunk FMP Price Performance URL For Large Lists

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_holdings.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_holdings.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -16,6 +16,12 @@ class EtfHoldingsQueryParams(QueryParams):
     """ETF Holdings Query."""
 
     symbol: str = Field(description=QUERY_DESCRIPTIONS.get("symbol", "") + " (ETF)")
+
+    @field_validator("symbol")
+    @classmethod
+    def to_upper(cls, v: str) -> str:
+        """Convert field to uppercase."""
+        return v.upper()
 
 
 class EtfHoldingsData(Data):

--- a/openbb_platform/extensions/etf/openbb_etf/etf_router.py
+++ b/openbb_platform/extensions/etf/openbb_etf/etf_router.py
@@ -1,5 +1,6 @@
 """ETF Router."""
 
+from openbb_core.app.deprecation import OpenBBDeprecationWarning
 from openbb_core.app.model.command_context import CommandContext
 from openbb_core.app.model.example import APIEx
 from openbb_core.app.model.obbject import OBBject
@@ -172,6 +173,13 @@ async def holdings_date(
 
 @router.command(
     model="EtfHoldingsPerformance",
+    deprecated=True,
+    deprecation=OpenBBDeprecationWarning(
+        message="This endpoint is deprecated; pass a list of holdings symbols directly to"
+        + " `/equity/price/performance` instead.",
+        since=(4, 1, 6),
+        expected_removal=(4, 2),
+    ),
     examples=[APIEx(parameters={"symbol": "XLK", "provider": "fmp"})],
 )
 async def holdings_performance(

--- a/openbb_platform/extensions/etf/openbb_etf/etf_router.py
+++ b/openbb_platform/extensions/etf/openbb_etf/etf_router.py
@@ -177,7 +177,7 @@ async def holdings_date(
     deprecation=OpenBBDeprecationWarning(
         message="This endpoint is deprecated; pass a list of holdings symbols directly to"
         + " `/equity/price/performance` instead.",
-        since=(4, 1, 6),
+        since=(4, 1),
         expected_removal=(4, 2),
     ),
     examples=[APIEx(parameters={"symbol": "XLK", "provider": "fmp"})],

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -5351,6 +5351,20 @@
                         "optional": true
                     },
                     {
+                        "name": "smart_score_1m",
+                        "type": "float",
+                        "description": "A weighted average smart score over the last month.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "success_rate_1m",
+                        "type": "float",
+                        "description": "The percentage (normalized) of gain/loss ratings that resulted in a gain over the last month",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
                         "name": "gain_count_3m",
                         "type": "int",
                         "description": "The number of ratings that have gained value over the last 3 months",
@@ -5375,6 +5389,20 @@
                         "name": "std_dev_3m",
                         "type": "float",
                         "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 3 months",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "smart_score_3m",
+                        "type": "float",
+                        "description": "A weighted average smart score over the last 3 months.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "success_rate_3m",
+                        "type": "float",
+                        "description": "The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 months",
                         "default": null,
                         "optional": true
                     },
@@ -5435,6 +5463,20 @@
                         "optional": true
                     },
                     {
+                        "name": "smart_score_9m",
+                        "type": "float",
+                        "description": "A weighted average smart score over the last 9 months.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "success_rate_9m",
+                        "type": "float",
+                        "description": "The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 9 months",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
                         "name": "gain_count_1y",
                         "type": "int",
                         "description": "The number of ratings that have gained value over the last 1 year",
@@ -5459,6 +5501,20 @@
                         "name": "std_dev_1y",
                         "type": "float",
                         "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 1 year",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "smart_score_1y",
+                        "type": "float",
+                        "description": "A weighted average smart score over the last 1 year.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "success_rate_1y",
+                        "type": "float",
+                        "description": "The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 1 year",
                         "default": null,
                         "optional": true
                     },
@@ -5491,6 +5547,20 @@
                         "optional": true
                     },
                     {
+                        "name": "smart_score_2y",
+                        "type": "float",
+                        "description": "A weighted average smart score over the last 3 years.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "success_rate_2y",
+                        "type": "float",
+                        "description": "The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 2 years",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
                         "name": "gain_count_3y",
                         "type": "int",
                         "description": "The number of ratings that have gained value over the last 3 years",
@@ -5515,6 +5585,20 @@
                         "name": "std_dev_3y",
                         "type": "float",
                         "description": "The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 3 years",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "smart_score_3y",
+                        "type": "float",
+                        "description": "A weighted average smart score over the last 3 years.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "success_rate_3y",
+                        "type": "float",
+                        "description": "The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 years",
                         "default": null,
                         "optional": true
                     }
@@ -23216,8 +23300,8 @@
         },
         "/etf/holdings_performance": {
             "deprecated": {
-                "flag": null,
-                "message": null
+                "flag": true,
+                "message": "This endpoint is deprecated; pass a list of holdings symbols directly to `/equity/price/performance` instead. Deprecated in OpenBB Platform V4.1 to be removed in V4.2."
             },
             "description": "Get the recent price performance of each ticker held in the ETF.",
             "examples": "\nExamples\n--------\n\n```python\nfrom openbb import obb\nobb.etf.holdings_performance(symbol='XLK', provider='fmp')\n```\n\n",

--- a/openbb_platform/openbb/package/equity_estimates.py
+++ b/openbb_platform/openbb/package/equity_estimates.py
@@ -126,6 +126,10 @@ class ROUTER_equity_estimates(Container):
             The average percent (normalized) price difference per rating over the last month (provider: benzinga)
         std_dev_1m : Optional[float]
             The standard deviation in percent (normalized) price difference in the analyst's ratings over the last month (provider: benzinga)
+        smart_score_1m : Optional[float]
+            A weighted average smart score over the last month. (provider: benzinga)
+        success_rate_1m : Optional[float]
+            The percentage (normalized) of gain/loss ratings that resulted in a gain over the last month (provider: benzinga)
         gain_count_3m : Optional[int]
             The number of ratings that have gained value over the last 3 months (provider: benzinga)
         loss_count_3m : Optional[int]
@@ -134,6 +138,10 @@ class ROUTER_equity_estimates(Container):
             The average percent (normalized) price difference per rating over the last 3 months (provider: benzinga)
         std_dev_3m : Optional[float]
             The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 3 months (provider: benzinga)
+        smart_score_3m : Optional[float]
+            A weighted average smart score over the last 3 months. (provider: benzinga)
+        success_rate_3m : Optional[float]
+            The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 months (provider: benzinga)
         gain_count_6m : Optional[int]
             The number of ratings that have gained value over the last 6 months (provider: benzinga)
         loss_count_6m : Optional[int]
@@ -150,6 +158,10 @@ class ROUTER_equity_estimates(Container):
             The average percent (normalized) price difference per rating over the last 9 months (provider: benzinga)
         std_dev_9m : Optional[float]
             The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 9 months (provider: benzinga)
+        smart_score_9m : Optional[float]
+            A weighted average smart score over the last 9 months. (provider: benzinga)
+        success_rate_9m : Optional[float]
+            The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 9 months (provider: benzinga)
         gain_count_1y : Optional[int]
             The number of ratings that have gained value over the last 1 year (provider: benzinga)
         loss_count_1y : Optional[int]
@@ -158,6 +170,10 @@ class ROUTER_equity_estimates(Container):
             The average percent (normalized) price difference per rating over the last 1 year (provider: benzinga)
         std_dev_1y : Optional[float]
             The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 1 year (provider: benzinga)
+        smart_score_1y : Optional[float]
+            A weighted average smart score over the last 1 year. (provider: benzinga)
+        success_rate_1y : Optional[float]
+            The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 1 year (provider: benzinga)
         gain_count_2y : Optional[int]
             The number of ratings that have gained value over the last 2 years (provider: benzinga)
         loss_count_2y : Optional[int]
@@ -166,6 +182,10 @@ class ROUTER_equity_estimates(Container):
             The average percent (normalized) price difference per rating over the last 2 years (provider: benzinga)
         std_dev_2y : Optional[float]
             The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 2 years (provider: benzinga)
+        smart_score_2y : Optional[float]
+            A weighted average smart score over the last 3 years. (provider: benzinga)
+        success_rate_2y : Optional[float]
+            The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 2 years (provider: benzinga)
         gain_count_3y : Optional[int]
             The number of ratings that have gained value over the last 3 years (provider: benzinga)
         loss_count_3y : Optional[int]
@@ -174,6 +194,10 @@ class ROUTER_equity_estimates(Container):
             The average percent (normalized) price difference per rating over the last 3 years (provider: benzinga)
         std_dev_3y : Optional[float]
             The standard deviation in percent (normalized) price difference in the analyst's ratings over the last 3 years (provider: benzinga)
+        smart_score_3y : Optional[float]
+            A weighted average smart score over the last 3 years. (provider: benzinga)
+        success_rate_3y : Optional[float]
+            The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 years (provider: benzinga)
 
         Examples
         --------

--- a/openbb_platform/openbb/package/etf.py
+++ b/openbb_platform/openbb/package/etf.py
@@ -2,13 +2,15 @@
 
 import datetime
 from typing import List, Literal, Optional, Union
+from warnings import simplefilter, warn
 
+from openbb_core.app.deprecation import OpenBBDeprecationWarning
 from openbb_core.app.model.custom_parameter import OpenBBCustomParameter
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.static.container import Container
 from openbb_core.app.static.utils.decorators import exception_handler, validate
 from openbb_core.app.static.utils.filters import filter_inputs
-from typing_extensions import Annotated
+from typing_extensions import Annotated, deprecated
 
 
 class ROUTER_etf(Container):
@@ -698,6 +700,10 @@ class ROUTER_etf(Container):
 
     @exception_handler
     @validate
+    @deprecated(
+        "This endpoint is deprecated; pass a list of holdings symbols directly to `/equity/price/performance` instead. Deprecated in OpenBB Platform V4.1 to be removed in V4.2.",
+        category=OpenBBDeprecationWarning,
+    )
     def holdings_performance(
         self,
         symbol: Annotated[
@@ -781,6 +787,13 @@ class ROUTER_etf(Container):
         >>> from openbb import obb
         >>> obb.etf.holdings_performance(symbol='XLK', provider='fmp')
         """  # noqa: E501
+
+        simplefilter("always", DeprecationWarning)
+        warn(
+            "This endpoint is deprecated; pass a list of holdings symbols directly to `/equity/price/performance` instead. Deprecated in OpenBB Platform V4.1 to be removed in V4.2.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
 
         return self._run(
             "/etf/holdings_performance",

--- a/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
@@ -137,7 +137,7 @@ class FMPEtfHoldingsData(EtfHoldingsData):
     def replace_empty(cls, v):
         """Replace empty strings and 0s with None."""
         if isinstance(v, str):
-            return v if v not in ("", "0") else None
+            return v if v not in ("", "0", "-") else None
         if isinstance(v, (float, int)):
             return v if v and v not in (0.0, 0) else None
         return v if v else None

--- a/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings_performance.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings_performance.py
@@ -54,7 +54,7 @@ class FMPEtfHoldingsPerformanceFetcher(
         # Split into chunks of 500
         chunks = [holdings_list[i : i + 500] for i in range(0, len(holdings_list), 500)]
         # Get price performance for the holdings
-        holdings_performance: list = []
+        holdings_performance: List[Dict] = []
         for holding_chunk in chunks:
             holdings_str = (
                 ",".join(holding_chunk) if len(holding_chunk) > 1 else holding_chunk[0]

--- a/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
@@ -71,7 +71,8 @@ class FMPPricePerformanceFetcher(
     ) -> List[Dict]:
         """Return the raw data from the FMP endpoint."""
         api_key = credentials.get("fmp_api_key") if credentials else ""
-        symbols = list(set(query.symbol.upper().split(",")))
+        symbols = query.symbol.upper().split(",")
+        symbols = list(dict.fromkeys(symbols))
         chunk_size = 200
         chunks = [
             symbols[i : i + chunk_size] for i in range(0, len(symbols), chunk_size)
@@ -85,7 +86,8 @@ class FMPPricePerformanceFetcher(
             )
             for chunk in chunks
         ]
-        return await get_data_urls(urls, **kwargs)
+        data = await get_data_urls(urls, **kwargs)
+        return data
 
     @staticmethod
     def transform_data(
@@ -95,7 +97,8 @@ class FMPPricePerformanceFetcher(
     ) -> List[FMPPricePerformanceData]:
         """Return the transformed data."""
 
-        symbols = list(set(query.symbol.upper().split(",")))
+        symbols = query.symbol.upper().split(",")
+        symbols = list(dict.fromkeys(symbols))
         if len(data) != len(symbols):
             data_symbols = [d["symbol"] for d in data]
             missing_symbols = [

--- a/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
@@ -73,13 +73,18 @@ class FMPPricePerformanceFetcher(
         api_key = credentials.get("fmp_api_key") if credentials else ""
         symbols = list(set(query.symbol.upper().split(",")))
         chunk_size = 200
-        chunks = [symbols[i:i + chunk_size] for i in range(0, len(symbols), chunk_size)]
-        urls = [create_url(
-            version=3,
-            endpoint=f"stock-price-change/{','.join(chunk)}",
-            api_key=api_key,
-            exclude=["symbol"],
-        ) for chunk in chunks]
+        chunks = [
+            symbols[i : i + chunk_size] for i in range(0, len(symbols), chunk_size)
+        ]
+        urls = [
+            create_url(
+                version=3,
+                endpoint=f"stock-price-change/{','.join(chunk)}",
+                api_key=api_key,
+                exclude=["symbol"],
+            )
+            for chunk in chunks
+        ]
         return await get_data_urls(urls, **kwargs)
 
     @staticmethod

--- a/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/price_performance.py
@@ -9,7 +9,7 @@ from openbb_core.provider.standard_models.recent_performance import (
     RecentPerformanceData,
     RecentPerformanceQueryParams,
 )
-from openbb_fmp.utils.helpers import create_url, get_data_many
+from openbb_fmp.utils.helpers import create_url, get_data_urls
 from pydantic import Field, model_validator
 
 
@@ -71,14 +71,16 @@ class FMPPricePerformanceFetcher(
     ) -> List[Dict]:
         """Return the raw data from the FMP endpoint."""
         api_key = credentials.get("fmp_api_key") if credentials else ""
-
-        url = create_url(
+        symbols = list(set(query.symbol.upper().split(",")))
+        chunk_size = 200
+        chunks = [symbols[i:i + chunk_size] for i in range(0, len(symbols), chunk_size)]
+        urls = [create_url(
             version=3,
-            endpoint=f"stock-price-change/{query.symbol}",
+            endpoint=f"stock-price-change/{','.join(chunk)}",
             api_key=api_key,
             exclude=["symbol"],
-        )
-        return await get_data_many(url, **kwargs)
+        ) for chunk in chunks]
+        return await get_data_urls(urls, **kwargs)
 
     @staticmethod
     def transform_data(
@@ -88,7 +90,7 @@ class FMPPricePerformanceFetcher(
     ) -> List[FMPPricePerformanceData]:
         """Return the transformed data."""
 
-        symbols = query.symbol.split(",")
+        symbols = list(set(query.symbol.upper().split(",")))
         if len(data) != len(symbols):
             data_symbols = [d["symbol"] for d in data]
             missing_symbols = [

--- a/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_etf_holdings_performance_fetcher.yaml
+++ b/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_etf_holdings_performance_fetcher.yaml
@@ -13,54 +13,52 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA52a23LbyBGG7/cpUL7w1S5qzofcDQGIhIgDBYCUqFQuGJtlK2tLLlFaV5LKu6ch
-        ipRMzIygWdfWrjE+8GN3//13D/7+WxT9F/6Nog+b3W778OFv0YeFMW3cXlcfft8f3G6+b/fPq8iU
-        WZMn8D9tXqyyJkrqZnH4dTe7m9v+1x1+/ulxd/Ojf0CE0ESSw/Pd1839dlc9fv/n9h6OBUIKjp8P
-        f25vvnx9WGzvP21vHzZf+r8Y0xhR8Xz+fXP/5/Zhtfn22B8pSjWlSsT8+fjxx+fNw/bz09+KCPsD
-        kT8w+wBn//vdQjor16eQM9OUdbWOpnWRRmVe5dUUIKOiS08xly3DlGBBEcID5OORAxojRjnVykON
-        YmKHFlwAMqcxI0HUZnoKfZY3bReV5jxruzzxxTYxlCApVhjRIfTxyAVNJHxuIdzQOpaY2aEJZkTC
-        lyJFEHRiTelk82P3cHe7jZK7Hz+29/Cf+x9vpvOkXPOrtXZASiQ4I9TNyGMhlJWRCsIVZEWMZBDj
-        ZDUErEso29xEadZns2mjyTKrzCqrumVjonZRV23dZGlk0maY4AQxxhTkKhp8Cccjx9dAiGaCYt/X
-        wBi2fw1MIc05iUnY1zArBkWdJYWJyqdStpQxIRIxjAQZUB6PXMFmQiDlCTaLBZdWSqKl0kLiGIdR
-        mrWxZTQ83mvXx5cyLqNqsXo7reeaIY0dpJRioZWndFmMHGlNBCJCIhIjHUSaFamNFB7XjanSes/b
-        q1VUZZc979uss+tz7ixhggQVzKPNNNaU2Fk55lxKFOMwbYaY2Vj3oUyarJfprDNFG+VV8jbmerWm
-        qavxQo/iTHMfpqB2SkoIVtB2aRhlaaY2Snj8uveMiiQoJqbUhUjAHrx4Bysic1gLgrVCXLGYqCDG
-        M3sk4XE9zjVNynRWzlxk4C80tAsfGXWSUYYY7ws2iGw2KW1ks2U6Meu+y2TN6ARFfJJeOTUH0pMw
-        b/SwixEhgTXFcViCtm1jZYTnB1MIeOOl9UyWi8ItN1JSwnyYSNrlBmvBCWVgKYIwp6arTxH7Z+2h
-        DC0xXLZUKKgpjPTQFRyPXFmrOcbMk7UYlNXuCjChHEkmYxXm9dOFNaLpskqzLFo0WZLXy/aVuo6S
-        nwlCq9RteJVgVPlMfqwkt+NirRnFLNZh8tOu7Am8byS9uj6RjgYF686IcFUqR5gjrv2gjhTGWoJG
-        49Bppi6sPqi+/7aJypvbm9svUfHw+U2+yfp6eq5dakspYmDrfXySu/j6qYiSmIX5vDw7RctXpprV
-        WZQVWdLBNG6vUvi8UiUYqWGVHo9caQsdAgvipXV4d4xBkRWRMQ5TpCQd4CZ1tnytuvGQFWsCNBwx
-        PWA9HrkiqzQojsfBY3DwjsgiDv6dqvg47b2P9WyVWx1C3XTLyhwkuO+n4/WIUAXF5NIjirFk3Atr
-        VyPNtYLpIGZhYpRdzU8pM5Bds6ohst5tA9Fg8NYYUTZEPRy5NKlfOgnkg2XU7m81FpwyGthV28yq
-        SPB40uTpNNvPK2PsEQH3w7irmSoulPD2Uqrtmas0IhrJmIYlbjW1DmTV9mc0vfv2OcpvP72NpojQ
-        TDrQhBYUEW/jpMy+KFJcC8FRfFTr97HN6iQe7g/qZNYms/y4EjzFm4IPmOCzSw7f67C17A9cacoI
-        Fsdp0YqKmN3kCgHipRGcB6FW2ZUZxBCeRTBmRm1kTiGLJZYIM4icHu7+CiEp155NCRFSeBooiqW2
-        aw9HStJA4ZnaM3VaP5UgcIIAJdnIWUWgSbVwLXQ5FUz69rk9oL0aOYLvjuHQ9cjq2u6AVjf/2YEH
-        am++/TV+s6lWk2sXInxGKbFnUQ+I1B5DJhHhhMQ0zAOZJreub/vnL0v6MTP1xbxJLpwzNQO59d1E
-        IKcXgK+GaqViFRZDk3Z4KDsmbXLTL+Sfh5JFcQr4pDsFKvgUDRvk84ELVoBlP2akFZYfq+5kQQuD
-        mEY0dD9bLq9OScsku8yqpw2t1cxyGCv1giLOB5THI1dhIkSwZw8NmETbMSmMb0SFGve0XVkHzrxN
-        ajA866PxGb9GqFKwYS47AE2PUO0lZdqxcceMsn4VHWZ4ks3u68f64St8jBPY/iT6GP1y5sQb/jGn
-        ixIOH4aI2NtGqLb7gtPf/D7E1B7LuijW0co0aXa8EbXcFA4DuV6sL2Yu48oYFdxfmVTaA0mo5FJS
-        CHQQ5TypYjMozjnIazs1XQaJWrUDOrNET//Abx7aAsHAhFPX2oDIfsnqsehAyh2XCmBgNQqeSMCK
-        269P4PlzIA/uYGRnKdct5i4R0mCaFPfWJnWoEIyvXFIZi7C1l7GvvUw/flWDtdc41Cptxco5UBOY
-        QZG3iRLlWB6AgSKCxjwMtU2uAXV1itqaqjNJs7w+TtTQZUZVqSzmfOEaUbTmTPtuT4DTtfICr6Ap
-        uKUgTFN31ohCW+leWdoxhARxaBmuhgJhFIR5xZYw+wANlSC0lDEPq86ysxbnU5IWMJ906/56s2sy
-        U+b7YO57aHb5JvJkfjklhdvFS479MT2uKQfEGGMdup2ulvYrsf5Cc2GS/OzFBY6r0fKSa/caHkml
-        mVeOCLHrLmYCxlEVeiu2bO2yu3+tqN2vRkCcXm2F3mady+SicnVTsLlC+ZaZwIrtUwumsv8R0zDW
-        s7ydWRdBJi/6s6ip16aAXB4X0bTjE+GMKIMmgbyZi+39pV/2ahJ8GWhae3/56+b27jB7ftyvhcqb
-        2+1u1DKeMOm5bCAcKaW8HQYfjweXDYxAldIwfzRtV411n/C4ud3863HzcPcybo8CnZRpKYlzCyY5
-        YcKzrgVQx9slGCHGAFSG9Ziysu5NSqhMU5j1qzYzLnfPL4qpdF03CCrwG+F0rBWU4EqR0Jujcl5b
-        ITd/3h1ujsZtTapZxa9cLYVxJJjX4mKH1CqYW1l/xR1EV9hXX0U+yfr++fLOzJhrBRAfyWauPKVM
-        cYG9RgEje56CNOv+9U0cxHh2eW29Qbm53/7cbkFxtg+bb7uRUSyvEa1cqyEJ7VJ63kQAQjsflRqL
-        0NVeW1qtXptnTWPe9SKQopPmwrkKwv1FA/HRIcdyVqBeUF96y/v4OrO08XVft7ub3fi7hEk5TavC
-        eZspMRhZr9lBrs2skhKyk4TRzbvKRje/u3vY3m7+fWgVowgbvF4lLkKNCEXe1TNSdonhkJ8Yxyqs
-        /FpHO2wfv39/5+L5fMHUynV3AN2BK9/tew9o1xfO+9iH6ssksZqbSWbAmTZZNn9+p3SkihIO2SRc
-        UaQgMFBLfkq7yvD+HQoJrieIspza38bLK7NsluX468oJnTOydqkM4Rgx7NVQxO27O8o4wyy0z0/r
-        ZviW0+v7H6uJWbb9/Ks6jLjlTffDkasiKYEh34vqeIGCCKIkiWWY5JSNtSGWeWPauni62Hselt8O
-        JlJ81ThdDdPs+BntgNRekYQyhGSswnJ1UrSVnopTwLYuJ03W1E+E/bsSo9bpv/5Zp6sAxZXwulLk
-        nKgI0iLUehPFILusYZzXdZdVv9jvMWXpqkfCtDdH7XBC0piEFWJnXaJ3TbYyRf6+e7zFgibnrgFR
-        C6m1LzmtZOhNpt/+8X8LG5B3LzUAAA==
+        H4sIAAAAAAAAA52aXVPbWBKG7+dXqHKRqxnlfH/snWyMIdhgLOMEtvZCsc+CJkaiJJupzNT+920F
+        EInOR5KThKoUDcYP3eftt/vo378lyT/wkSRvirY1+zf/St4ssix/8/vTJ6vi3nz9XFEl2b1pyg38
+        Jy93j6ZJxnXz8PJ1ZVtW3deNM6GlRggjpV9im0NbPnTBPvQSae+KxrTnh/tPpoEvoIozrehz8C9T
+        3t7tF6bZmGpf3HZvQ6VYi+fwfdF8Nvt1sTt0ESG5lIrjVOvn+OFhW+zNtvu5BBH2B4J/8g3E/ve7
+        g3m0Ph8ij8si2ZpkXlZFm4wOpioe4Y0cmiLJs2zIfZUTxBhTGDFkcfchDzfDBH4pzM8tU02lm5sz
+        RhSmqSZR3Cfz6yH3SdHc19WXZFrvth19Wd1CqpPZfmtDM0wJFhSSakH3IQ+0pApyHYYm1ANNiYCX
+        T7mIgh4fTaxkX0yulsn89Pz0fJqcno9TmxXrLkscMbuw+5CHFWPIkUIBWJEK4YaFI8EInIyUqSjY
+        k5mVYLPZFa+ZdWSVEIkYRoLYWX0JeUg14gTOYQgUSewGRUhgjXCKeBRoNh2CHpdNu0/mxZ+m3Zeb
+        sGxRgqRYY0TtSu5DHmZOsCRC+JkZVLJ2MjMkGOGIpJhFMX9YzIfQH+5Msa+rZNGYTVkf2mRu9sWu
+        9WBrQZTUGBFpYfch3wHGFN58iJpKt2hRgZRSkqc6jjq7ztLVxRA8+1I8adbbl0yfVhubGHEmxBgj
+        zS3i0ZlmSGMPLxWYEY1DwKQv3QEwExIjjtK+uf0acH46Ww9xnxjH8A73Lyl28iqiqKAYYZu3D/n6
+        EuNYaeknpqnyHGYKkgidHqcsrh9ny9XUleNmb+7L9inPDlxHSmerS+E7uUxBXqgKAUrm5kOKaq15
+        SmQU39xWK/hUWKI414hego0QFmYf8oCCQoFRCMgyhdp19x8i4ExokKi40j3OLYU6rpv9oSpeYKER
+        GU/tUqY15tBabU/Vh3yp1ViokCiTVCG3KBOKuWJUpSrOXkw+ng2RJ9XWFI/1oQlnmGjC1TV0Gmbx
+        9iEPr0JC8JB3JqkUHl4CQgDSlqq4s5qvrRQ/UW4A8ofaxBcAZVd0H/LwcvAZgqAQL6fus0tgNmEM
+        0TQuvdPM1qUptNw20HaucioUYELbcZTyS8h7eAkSfW6cqFS5UWFc4koqmaK405tnVmZN8akpt7fG
+        q8GQVozh9EHDs8u4D3lYMZaKoGBaqbvjgHXkmEU6iuPlJE8to3wM76wqd7s6WczGQ8zpCKERuVyc
+        vce2TX4O+BIqERjCQF8lKWHuORcrTghWIlabRhezNF8NQUf1rtwamPBHQ8p8ghDkA0YbbDvE0eJ6
+        dcOlh5JTRXGgt3azuieVAoZHGGtfU/1rkPnZxOEd8s8GZvhkaVrQ4Q20HMdEC7VLERcLibkDd340
+        l8JrD5HQlAeSisFLeJLKqAZTilMRx7u+mbkM8br8u90VoY7jQFTr0Y1vZAc+hVkwpaLP+ACRUjCT
+        WqaKRCFOphbeZLetm2JbPwmRp6EqBtaFI00t1D7kgYVCAKUKsXLiEV3CBWVMx+5kFsvruSOdi6a8
+        N69j+89k82y1ms99HRTKVQgZzCZj7gEORJxiwWVK4kb1k4uxrbYn9eau3dyVr1snn+ri4w8wM9tr
+        mOeAj1eCCeZhXg8tZ6CA0ETjNPc0u/o4hC3/UChUuFA+nM8wErYM9SFf4cLgxUNeH6eUu70+7lC7
+        qS2ucLOjVZpZqNm2KYtu//LsBB1Zza7Q1z9MSkcvPSKYr3yGAfoSTC4kSOvpMjBWgLUiqYgr4un0
+        yHFKp/XXrL52GfdgoxDj4OaJYwkh0Oh84ZNgGNgJCeNCEp28MC4pJXRK4ppMni9tm58vX86qE1Mq
+        JikCE29ntQ95QKHPyNdNoQMUpUq626kkRII6xR7XxeTtxQzs4Nyq5NNqe2j3UM1QxKaqd5DdPBt1
+        lwTj9RB+/nHBebdNYo7FC2Gsc7kedCqhfQQmOSDn7klOItX5/chRfXVsbxNXTfmwM8nxrrj9yY2i
+        0kLqOQbDaGH3Id9ZhqH+B+DEyS0k1wizlETq1sXKtWtqN/X+R3YRMSrYFMTYYTAQJ1T77AWcUgr+
+        IzDpAC1yNyQhKAFrnfK4G4Gj9cIh00fm0ezqh2S6qz8VOxftk0pjqeFg2rJ1vr6E5uxVaSEJDqZW
+        cs8NF2FUchbbkhYuK5V165ifW5E7QI9ysfaVsOpOvAiCvnquwf0H1LBWLGVxpzdfzxxZ/W7H5s0p
+        QvDdykbFJ/P3J77OC51IEimDrJy6F+IMlFEqFbs9PRufO1jPoA+1t/AykMiq7Uba7iVD1PA6tkoJ
+        pomk3p041DEMM0Fo7D62jIC+IZ3yuB3FNF8vXYbjUFTFn4diX79Oei5mO7vdOEt80zu0J/AZNGAj
+        Uco8cky1ZNDzUxJXyavpaAi5KlrzufaXMbQdKThoKhKOndNLyCfFglPQ4iCp7yYLRmIkVKQ45eOb
+        b5xDf2QL+Lmb5vD3NwvyzmH9VE7l7IwvfDnFshvDRdBUMe5WJyqlokTFmuVsuvjo8FOPBposzEGA
+        Wd3Du0jeJtmtqTZfkkXd7P8LZ7iGcfodxe/INzezXnxFOPxVyitZnGnaSSwJ/grcw5H1zb/2G5hO
+        zl2taGoq08B4VFeBPMPAIDHTI4y0Xd6j45vrs9cbg2HOFYzqmoZz3vum4bWl1HBwUhw3MYyL9u7t
+        xf4O3scAuotAqr+LeZNqv8wwq5QIAUNr6LEDgPTcb1nf/WuQ+dzlHfPSNE3xg7sPQfUHUCVH31V0
+        tLz0eSkocRDXwGYKea8DKBZMIhF7735qPTZz+lhUd7VJJjuzgcFo06Em75KrfMh7lTPBpRo77/L6
+        kIcYHKDmweRS7E4u4d1jVzSNu9jK7LvL7LGs+kb7tn9GyjsecGgsAqZcG/ol4itqTJSUwaZEkbsp
+        EQ7jI6JpnLe6yu2n/7KnJ//awfMV7gEQYAU5wgjZl3p9yAMN4yHUQjDTxLPMkXAkaPQ91/jM9bTB
+        +M60xYMpPhv/qs5iJFpopfzPR2lNApcEyHsP/3WCAqsRKcZzewc530z+MlVggXOVc4WoXlDE7R1G
+        H/I1HnCBOuiTse/SkmOFu0c548bb0djVZ0emgIJtjPn8Syt0AsokhE+YmMaUsMBjfQDJ3KsaTAgU
+        u05VnBSv5pdDwlVT7urbL+GmowXBoLTcXp73IV8+EesuqUKsSLgPJ0dcMRJ7u5UdrbB9W/ATW+Wv
+        dwUzNONT5HBNTwEfLMGhmwJA9axmOtkGixi3eRzN8nM9FUPU/GI+Wk6WF8lyknfPpibnC2vd6OD7
+        7rWGHkJxJYIyhHyPA3FFdcriegvpHqtBN47jeVbXe1MVX8KLc4vSg0cI08HFhBMNRTGt1g6cVWMe
+        i10ZkpruMHKK34O+OBzgYkHH3ucHujWqDjwPEov323/+D4d1IBEPMAAA
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -80,9 +78,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 14 Feb 2024 22:54:36 GMT
+      - Tue, 16 Apr 2024 20:21:32 GMT
       Etag:
-      - W/"352f-DpJzehE7HALHT2ijZ/TGcQU1YpQ"
+      - W/"300f-gld1XF+QRWWO5yqpn8ZXulQWwS4"
       Server:
       - nginx/1.18.0 (Ubuntu)
       Transfer-Encoding:
@@ -106,31 +104,63 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: https://financialmodelingprep.com/api/v3/stock-price-change/PAAS.SZN,HMY,AG,CS.SZN,BVN,HL,AYA.SZN,ELD.SZN,SIL.SZN,MAG.SZN,FIL.SZN,HBM.SZN,SSRM.SZN,GATO,DPM.SZN,SVM.SZN,OLA.SZN,IE,CDE,FVI.SZN,EXK,SEA.SZN,NGD.SZN,HOC.L,NEXA,GGD.SZN,VZLA.SZN,ARIS.SZN,ADT1.L,MUX,DSV.SZN,CASH&OTHER,DV.SZN,KCN.AX,ABRA.SZN,APM.SZN,SCZ.SZV,AOT.SZN,MTA.SZN,NUAG.SZN,USA.SZN,FISH.SZN,ASM.SZN,GSVR.SZN,MND.SZN,MKO.SZN,LGD.SZN,FWZ.SZN,SMT.SZN,TAU.SZN,KTN.SZN,SSVR.SZN,BCM.SZN,MGG.SZN,GORO,MRZ.SZN,BLSN9G6,284380Z.SZN,TV.SZN?apikey=MOCK_API_KEY
+    uri: https://financialmodelingprep.com/api/v3/stock-price-change/CASH&OTHER,CDE,BCM.TO,IE,CKG.TO,SKE.TO,GENM.TO,AGPXX,AYA.TO,BOL.ST,MUX,TFPM,EGO,PAAS,USAS,ADT1.L,VZLA.TO,AG,KCN.AX,SMT.TO,ASM,SVM,TMQ,APM.TO,GSVR.TO,WPM,HMY,SILV,PRYM.TO,AOT.TO,IAUX,284380Z.TO,BVN,ARTG.TO,EXK,SSRM,PE&OLES.MX,SCZ%20CV,GGD.TO,HL,DVP.AX,SVL.AX,HOC.L,BLSN9G6,GATO,FSM,MAG,SA,ADT.AX,TGB,TV.TO,FRES.L?apikey=MOCK_API_KEY
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA31Wu24dNxDt/RWCai/BeXBIplMkQQ5sSUDgBDIMFwlSxkiRFDGC/HsOl0veO7Rv
-        JKjQYHfJ85gz8/HV1dU/+Lu6uv7zy+df//j9+rur6zePH65f9yLdoRBD0pKOSmqVLYdYNdXx1GOr
-        WZAorEdNWo2CmczHrJWUA1EpdtS+/PVbe7eGJFXz+N4H1CwFskSjJq0mNbDGROMurUaFA0pcxsux
-        VTMHJcnj6M+//N0ejfjv39ffwnzz4CBTqDHyArlKrePoDpklSOUJZse8kYZMlOUc9SYRN5dxnQM1
-        l8AWi4O9aQy1RnG4t5yC1pod8I0rVIinK+3AN9NQYuZx+Y58yzlQiSVdJOD7n58cA5BJZGBI3QZQ
-        PJKJk11Ai04IOwPZAp+5Yyeg4rkmnSNAA1O2+bldzWhBZ2kHn3BwJRokd+w5cMx5fK5DpxK0KI1i
-        R45Dg7afi8jfvFuA48NeeqicY/ZuZ3hbY5w37dKXUCzX8XaXnnNzvI3GGNpbsMQ6Eeyo4G+iFGcP
-        dUNIKIXTKO74BVeSkz6H9BGna0oiwxKH+CUGfDXKRQoebt4/OxI2CqLTWZ0FwudZZkN2GkrIghY/
-        Z4E4jP93AqT1p9LozwM/mgQfmwDa/RulTDbY6+iNgL7yjJ+9SLieyaT0gL9UD/CjehH8D/ceuiB3
-        dLptLyHaTE9uG21Oil9nAGitVMXh3xIIIamDuGEAQfPXMru3a10RoupDr/U5mdkopm8VDwqW6kHB
-        qF6k4PbOcyBIfN/8GwfGzWbIHuJbicmlH8GYhtY8J8BCpZgW+JRDIfb2Z0ZP5Tg/2Ds9tlOis/+m
-        JRAbL/5H8ODa5kN/qyVEMyoX0d+/vF3mHQ706DGLuPAS/hQ4m89+MJ1Ypqhdf4iqpSzZ18DCFdGl
-        35ZAH01YBwEtJu10oZ4UEkyY59sHARAuk45HDwIM2Rv5/xLw+Ta8WyhQXUKwTbVSvQFaBnJ0I7/1
-        hajTX5F0dV516C/Qqoqzv2BwSE3jjA4/pcDn+8fQXzgtkw/pif0jr+hzs59elv/p/uXGJwDiUotH
-        z0ghKjNw+kwHguLAw9SYaHNA9viDnTjSsvC4d3fw2LJqjqTVqy+Y/BptmfyGyW+6qI+oZFNZmn9U
-        L+K/uXtPYZ2BvEYgNiI9bTqdgNxiwgUgYY8r881u/xqqlTToHPKnNtTE9z9Q8SlQ95HQZid+ztFj
-        lYAPxYu/FDv2UbwI/fGnlzX7v9r7Ktapah54aTtKWnyP6EckOec3mGxlNvQADzdlYt/6EeZFdKpP
-        v9TKPFuiy4/VOBVLa/PXfRXz6w/Fyzvv29uncPMVAZznNpeObigaEaunYf3YxcKGwE59xPdpmz32
-        3vY9W3u/mWkG2pH95Daarj7izCI79a35GfvxEGnMftwyluJnPzoxpFTK5d5/eP7RLz4IvnPwOAvi
-        +9DDrXIsHnk7P0qa5x+DH2MjYSHz6AUBaTSXxA4f+3ktq/iV4DOeOnfxqyIQbNG+IiWIZIk+jE4F
-        +Q39q0//AVuAvzfrDQAA
+        H4sIAAAAAAAAA41aS2+cyQ28768wfMhpp9Fs9jO3sSVrDUuWs9IqNoIcEuSYRQ7JIYsg/z3Ffg57
+        /AlZYA9ujEZdZLFYZOtPP7x58x/8/+bN23/+9utf//H3t79/8/b9ze3bH9sh3eDg5IwPwfejUI+K
+        YY40PvWAI/bG+mJzP2M5i9bESCn2syhniY0nl/rRb//6m/xsNCG6ML7uG47IGptCGJ9jOTuFYGxO
+        PL4v1A8GUyiQGz9s6yd9NiFnNy7961/+XW8dTcoxRRz+98fvQf+4IWeDOxSF3JqUvPfM42oVPa4b
+        C9H4fRU9ZcPRuhGRih7f6DOX8ZUNvjPZZs+X8E/44eDID6gdv7HFrft856zD14cdfT88BP/06dY8
+        P6oAkEmuzHB3/D5S4DyvVvEn41PQySdvAvHMdIXvDeU4PjXAc2I/01ev7/B1MfKWfG/YpjJIV9ED
+        jvHyn4Ifce1BppF5xJjw3yH4u9vPDzt6ewl8/IN6GpNd96vQvLpJy7ZjZLH4ceeGGKmlTFlDDvhk
+        okmCBjkh2AG1dwk5OjMLpaLlcbMGle0hxvO38w4xoPC8Km2WwplEbuQOyG52k4u13B1KO/G4b4Wb
+        UV5IkM4vPuitS5Og39oZcVFYC6gRnFVQg2UTOc5679ktiEqKpNlN1kbcCHc6hP/u8d48PesCJ0N2
+        3GPw24GO0Wp1QwgC6HMZAWcNO19GGmsEIIsQo3HfFgCcpRnOVtvRFOtm2Ct+yF2AtCVSEQBVCqUy
+        ItoC4ALC5/1gX8NfMhIHucmH8B9++bpjL6hjBT4aZ51TyB1ULDk7ot10PRtXXFTKxgX67yarG/YQ
+        JauzAVT4jgxfqEBnunH4Pq1sbpZcFzVCieSiK9uFjLpDzA9xP3/48qCBS1WRVjUGIRF+lXIPWY6z
+        +FrO0eQ4sNI0KgYZmhXTa7xIPqPOe0DTTFPqKnBEElKwsvCds856fdjAj8ND7Ld3jzt0F71uaJVM
+        q/l2tsc4UzmaWY48Rb8ir4rMTtc7iTXwrOvdQy7R9y6RMyOUOY9QhsHsWHgRsDfzZOAieC94yGhk
+        5kPwX87np53xgVYD6ehDsVH1clcM0k5K3VEF4IISdwfTQp4GqKnttlivrAzUsxRd7Sd0C45u+pOK
+        HmdQncnBit0zinTcuDM+B+P8K338l6cr3NBRR7rUJZ+WFeNF06HUmvHBEEENL5GjMk1GBWkXA8Y7
+        shvjyeTZihvyjLShXga5WqlnD9Utaaah5b2QBIk058XERZ/tcSs/3zyTub/iPU/FnEbO2sI+zELr
+        Ri7ERZLG/SQl4lWvk0SHsEk9eph0oMsQEBkXFnNa0aNEnEvKyZC3CLSbzrCFYD/t1B+nxyG40/Cz
+        iWmFvHECiWUE8hI8pBlirft8MLAlblxgMD9e4OzMB6PzMvYt/xE9gaeB7D4uQy8DKckjMC8H1jZO
+        bCCEPWjBP0UWNbDuEPyn95/NWfc6ECkV1efh17MvTEG3eWTfRd6VL4hnVxGAt01xm2LQByx5JXwn
+        4bUPSvjQEzm7ovD7iN4AS62nmL3F+2CyDBmHyJ8enq8dvFuqPSSPsy1K8JenHNbmcnpqhEdswOTd
+        y+LLXE6a8lZXfEq4dpqjXBgsCBkdUmcc+m89qLplHErLkMZD3Ocn3eFlRgua7oyuxFruQGOkgRTd
+        MTqgHeQBsg0tcBhufl2vdKQC2q+TLU6A8tKOeghfRIW1h8e865O9GtowVHg379jBoyuQzxSOk/6y
+        2Rs0dLQWhR6/L5Qt5anOzcrXBZnh3bxra/Iw9baUTejQvGc7b+CR5Jyt7nJcO9oqvEp/XM9i3FXY
+        of/o+3nPu8wE2R9X+vPDH64afA66wcN6wLDNUAskTJch6XEGMh3EzSvk0uQ2WwcngmDo0Q12nsNy
+        UJ30xaA76Gn1lFFXNs2GOPKejIWgbdN6RpOAchwX+x+/7KS3KWvsBDNSkko7ZJ9LnsrCLR5ub/FQ
+        AGJyGr1wnrXAgQclsYKOHy3iSi+REwZhG3kKYe9uMBwWAVHACaE0xed0nPafHr7taY9RT3Eo45zL
+        jpzwvaqzB0DKSyragkoKlsp1veelFV3noIguJKXuGWXlOCn0mCzEyETNeSgFLFhxmvQQy1f0/eP9
+        yxXhQ94JX5xfI1dt4hAwN5vL2M6QW92vCR3a9arMBlxUoujVHCT/og80uiO/MFLb8ArviGGDNd3F
+        0Kn9Rx9l5vEh+vPjVXeT1eQU4QZfEuVYZZ7Rf6LOe0To3ayM1uCcQzqd2xKfm/yqxBdZaUxT1iJQ
+        t32rFNokp3xSL3eZKwtHDR+cz7L/OQT/8byN77DgVJSjRRUEl5XSiTahIWWl8tX6JedV7k9iaaAM
+        epg7IYXFXmx6R5eGBV3bvnoIT5pj0JPsfjjmOX06Gl0/PQzBu5fPWwSgKNrTy67pYhtYgWGa85EU
+        +bPY3KvdlQ+wYQo+1D4nq8xNKTJKRZV7cMSCc3qkkW1rWJ2ibW7YuDz99VhgENxKSq8M8V8/adJ7
+        DJR6aXeCDysXWjIWGFDraaa4l7iMtkrwcKmLQbxv7Vg6VVa0PzE8G9R5hrLhxG3iGhCGnc+y47lK
+        O2gzv7OnnWEcrM/H8J+efr4yOLlYbXBknPZX9g451mP8KVjEjkj1OpkoyHLRuReWx7TaYh9ooOS0
+        hpcWgpgR/BC2/At53Obo5V0CX0q65UF4MIkfT3Nfbn/3eH/7ZB6+7nEIa482xd9S1OonQ11xSgJY
+        rmH1RAtPh9Fnqmnfztd3Db2/xFSGjykWBIxDYRmvynUUClzFhh/JZu91BZB9ZZK9u7u5En2Z3IvO
+        v4wYPqnCJ8i+259kxA1q4ZP1rM58kDjoVn9CEC0uvkkeIhFLVrChixqx7gFd7WWmpBxesTjb/oKE
+        TLunT7i5knvJ1kV91qMga+HZq8b8nnzcHqFQsxR4knhONM7CvCnYMMGQgVndveKR7uJZpzsWcZHT
+        Cg5n6+XJ55Ved/PyZR/gT/XlSBudrJ9+HvrdoIJu63eoABtVCE6y60olabMj7Q6p1+Os5D5htNG5
+        h2xRWc+O4XuHnQHb6dK9enoYhaeX+z0Kxw9SINTas9UcizjYqQTN4aDvB9om2e2wP8ChkfpcNGTS
+        rzHN2m7DjANRIa+a7qeShKv+eEf/0+P7fWNHEOrFseZv4LrWRSvKVGc0PcKDyCXrXW3Cz7octh6H
+        0rcXr0tVyGADip5nToIJsdT7CwQjkF3DkO19j61jva8VzYdhTscPU3fn/eHReApa2MmwS9rcIeeY
+        NLxKe6hvztNiNIVjU5ZQdI1LsrdZ28aaS1hn+PWttxmfQ1E5h4cQGuhpZjvsOtcPD5F/eLp6mslp
+        rgGHoXeYQPTfGmC8SzEpaXfyJBu0swni/PPMR29pKGdEVxFeQunK8gpN3kXz84YdRGLeuhpMtic7
+        FwpD5pw8erzyxwYP+5aW6k5yA4+bbpyXP0rgomydq0uiojgvI07enyfkjy9oSlkXeZI3kH1txSCt
+        Y0X67TcvW5cKzdY40IOIx08zT+ed79dTbKK1M5x+Ni+lan4WTChrPGt+Fo4UDmXLOoqdkh5k5C8U
+        wnqE6SqH33wxBXaVk/ewZQla1q2sp+do3F/fvYzf8BiH0M83z1fNTZ7D5zJ51DuV5ROHoaFgo0r8
+        dKJN4KWqS9B2xtdFlN5cbN8kZ7KwwvyoccvLR1rjQgdeogYtB4d4n+/eKbAgOetVfN3a6bdXZCtj
+        ppi+o2q4TPZR72pkKQ0L5rW4JdnD2vU3DLVwMY+5onO9/ZbGcSQQY+Wsht7WrEho3IQ9yy8/Bv7y
+        //89yfgHX/6jGZXtuaAhnD9cKZvRmC9xnYo87q0/V2gdC5OrLNw3cyKndq2LRsOW1ZR7ZfP64WfM
+        I/c7i12YdqB3bMtJkxhKVdIieyNxNM5jbrnEHdCw19DSa1iGvO2FycnmOG01zKJ9y+eH8ckS05ZY
+        0Tl4u235SrJH4FxJ/cOf/wfd0De8JScAAA==
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -150,9 +180,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 14 Feb 2024 22:54:36 GMT
+      - Tue, 16 Apr 2024 20:21:32 GMT
       Etag:
-      - W/"deb-ohIc7f5uvZzz1koNd5fmMzuDvvU"
+      - W/"2725-T4n9Btnw2jv62CbOcyoGpr0GJJw"
       Server:
       - nginx/1.18.0 (Ubuntu)
       Transfer-Encoding:

--- a/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_etf_holdings_performance_fetcher.yaml
+++ b/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_etf_holdings_performance_fetcher.yaml
@@ -9,56 +9,95 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: https://financialmodelingprep.com/api/v3/etf-holder/SILJ?apikey=MOCK_API_KEY
+    uri: https://financialmodelingprep.com/api/v3/etf-holder/QQQ?apikey=MOCK_API_KEY
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA52aXVPbWBKG7+dXqHKRqxnlfH/snWyMIdhgLOMEtvZCsc+CJkaiJJupzNT+920F
-        EInOR5KThKoUDcYP3eftt/vo378lyT/wkSRvirY1+zf/St4ssix/8/vTJ6vi3nz9XFEl2b1pyg38
-        Jy93j6ZJxnXz8PJ1ZVtW3deNM6GlRggjpV9im0NbPnTBPvQSae+KxrTnh/tPpoEvoIozrehz8C9T
-        3t7tF6bZmGpf3HZvQ6VYi+fwfdF8Nvt1sTt0ESG5lIrjVOvn+OFhW+zNtvu5BBH2B4J/8g3E/ve7
-        g3m0Ph8ij8si2ZpkXlZFm4wOpioe4Y0cmiLJs2zIfZUTxBhTGDFkcfchDzfDBH4pzM8tU02lm5sz
-        RhSmqSZR3Cfz6yH3SdHc19WXZFrvth19Wd1CqpPZfmtDM0wJFhSSakH3IQ+0pApyHYYm1ANNiYCX
-        T7mIgh4fTaxkX0yulsn89Pz0fJqcno9TmxXrLkscMbuw+5CHFWPIkUIBWJEK4YaFI8EInIyUqSjY
-        k5mVYLPZFa+ZdWSVEIkYRoLYWX0JeUg14gTOYQgUSewGRUhgjXCKeBRoNh2CHpdNu0/mxZ+m3Zeb
-        sGxRgqRYY0TtSu5DHmZOsCRC+JkZVLJ2MjMkGOGIpJhFMX9YzIfQH+5Msa+rZNGYTVkf2mRu9sWu
-        9WBrQZTUGBFpYfch3wHGFN58iJpKt2hRgZRSkqc6jjq7ztLVxRA8+1I8adbbl0yfVhubGHEmxBgj
-        zS3i0ZlmSGMPLxWYEY1DwKQv3QEwExIjjtK+uf0acH46Ww9xnxjH8A73Lyl28iqiqKAYYZu3D/n6
-        EuNYaeknpqnyHGYKkgidHqcsrh9ny9XUleNmb+7L9inPDlxHSmerS+E7uUxBXqgKAUrm5kOKaq15
-        SmQU39xWK/hUWKI414hego0QFmYf8oCCQoFRCMgyhdp19x8i4ExokKi40j3OLYU6rpv9oSpeYKER
-        GU/tUqY15tBabU/Vh3yp1ViokCiTVCG3KBOKuWJUpSrOXkw+ng2RJ9XWFI/1oQlnmGjC1TV0Gmbx
-        9iEPr0JC8JB3JqkUHl4CQgDSlqq4s5qvrRQ/UW4A8ofaxBcAZVd0H/LwcvAZgqAQL6fus0tgNmEM
-        0TQuvdPM1qUptNw20HaucioUYELbcZTyS8h7eAkSfW6cqFS5UWFc4koqmaK405tnVmZN8akpt7fG
-        q8GQVozh9EHDs8u4D3lYMZaKoGBaqbvjgHXkmEU6iuPlJE8to3wM76wqd7s6WczGQ8zpCKERuVyc
-        vce2TX4O+BIqERjCQF8lKWHuORcrTghWIlabRhezNF8NQUf1rtwamPBHQ8p8ghDkA0YbbDvE0eJ6
-        dcOlh5JTRXGgt3azuieVAoZHGGtfU/1rkPnZxOEd8s8GZvhkaVrQ4Q20HMdEC7VLERcLibkDd340
-        l8JrD5HQlAeSisFLeJLKqAZTilMRx7u+mbkM8br8u90VoY7jQFTr0Y1vZAc+hVkwpaLP+ACRUjCT
-        WqaKRCFOphbeZLetm2JbPwmRp6EqBtaFI00t1D7kgYVCAKUKsXLiEV3CBWVMx+5kFsvruSOdi6a8
-        N69j+89k82y1ms99HRTKVQgZzCZj7gEORJxiwWVK4kb1k4uxrbYn9eau3dyVr1snn+ri4w8wM9tr
-        mOeAj1eCCeZhXg8tZ6CA0ETjNPc0u/o4hC3/UChUuFA+nM8wErYM9SFf4cLgxUNeH6eUu70+7lC7
-        qS2ucLOjVZpZqNm2KYtu//LsBB1Zza7Q1z9MSkcvPSKYr3yGAfoSTC4kSOvpMjBWgLUiqYgr4un0
-        yHFKp/XXrL52GfdgoxDj4OaJYwkh0Oh84ZNgGNgJCeNCEp28MC4pJXRK4ppMni9tm58vX86qE1Mq
-        JikCE29ntQ95QKHPyNdNoQMUpUq626kkRII6xR7XxeTtxQzs4Nyq5NNqe2j3UM1QxKaqd5DdPBt1
-        lwTj9RB+/nHBebdNYo7FC2Gsc7kedCqhfQQmOSDn7klOItX5/chRfXVsbxNXTfmwM8nxrrj9yY2i
-        0kLqOQbDaGH3Id9ZhqH+B+DEyS0k1wizlETq1sXKtWtqN/X+R3YRMSrYFMTYYTAQJ1T77AWcUgr+
-        IzDpAC1yNyQhKAFrnfK4G4Gj9cIh00fm0ezqh2S6qz8VOxftk0pjqeFg2rJ1vr6E5uxVaSEJDqZW
-        cs8NF2FUchbbkhYuK5V165ifW5E7QI9ysfaVsOpOvAiCvnquwf0H1LBWLGVxpzdfzxxZ/W7H5s0p
-        QvDdykbFJ/P3J77OC51IEimDrJy6F+IMlFEqFbs9PRufO1jPoA+1t/AykMiq7Uba7iVD1PA6tkoJ
-        pomk3p041DEMM0Fo7D62jIC+IZ3yuB3FNF8vXYbjUFTFn4diX79Oei5mO7vdOEt80zu0J/AZNGAj
-        Uco8cky1ZNDzUxJXyavpaAi5KlrzufaXMbQdKThoKhKOndNLyCfFglPQ4iCp7yYLRmIkVKQ45eOb
-        b5xDf2QL+Lmb5vD3NwvyzmH9VE7l7IwvfDnFshvDRdBUMe5WJyqlokTFmuVsuvjo8FOPBposzEGA
-        Wd3Du0jeJtmtqTZfkkXd7P8LZ7iGcfodxe/INzezXnxFOPxVyitZnGnaSSwJ/grcw5H1zb/2G5hO
-        zl2taGoq08B4VFeBPMPAIDHTI4y0Xd6j45vrs9cbg2HOFYzqmoZz3vum4bWl1HBwUhw3MYyL9u7t
-        xf4O3scAuotAqr+LeZNqv8wwq5QIAUNr6LEDgPTcb1nf/WuQ+dzlHfPSNE3xg7sPQfUHUCVH31V0
-        tLz0eSkocRDXwGYKea8DKBZMIhF7735qPTZz+lhUd7VJJjuzgcFo06Em75KrfMh7lTPBpRo77/L6
-        kIcYHKDmweRS7E4u4d1jVzSNu9jK7LvL7LGs+kb7tn9GyjsecGgsAqZcG/ol4itqTJSUwaZEkbsp
-        EQ7jI6JpnLe6yu2n/7KnJ//awfMV7gEQYAU5wgjZl3p9yAMN4yHUQjDTxLPMkXAkaPQ91/jM9bTB
-        +M60xYMpPhv/qs5iJFpopfzPR2lNApcEyHsP/3WCAqsRKcZzewc530z+MlVggXOVc4WoXlDE7R1G
-        H/I1HnCBOuiTse/SkmOFu0c548bb0djVZ0emgIJtjPn8Syt0AsokhE+YmMaUsMBjfQDJ3KsaTAgU
-        u05VnBSv5pdDwlVT7urbL+GmowXBoLTcXp73IV8+EesuqUKsSLgPJ0dcMRJ7u5UdrbB9W/ATW+Wv
-        dwUzNONT5HBNTwEfLMGhmwJA9axmOtkGixi3eRzN8nM9FUPU/GI+Wk6WF8lyknfPpibnC2vd6OD7
-        7rWGHkJxJYIyhHyPA3FFdcriegvpHqtBN47jeVbXe1MVX8KLc4vSg0cI08HFhBMNRTGt1g6cVWMe
-        i10ZkpruMHKK34O+OBzgYkHH3ucHujWqDjwPEov323/+D4d1IBEPMAAA
+        H4sIAAAAAAAAA51cW3PbRpN9/34Fyi/78hmZ+2XfQJC6rEmKIWlJ9tY+wBQsoQwRKpC0rWztf98e
+        2oQTzfQomSROUmyb4mHfzunpwX//K8v+F35l2Ztqt6v3b/4zezNbna3f/PvHi9vqsT6+1mz6btd9
+        3mdl1z+drM2u2Trr+5W0wlJDiZAn2+awa56ccTCdLLuHqq9388Pjp7qH3yC5MkIZ9tP6rW7uH/aL
+        ut/U23117366yY0+mR+r/ku9v67ag7MwxoiinBrFcmF+/pbD0121r+/cz2aEibdEvKX6Ddj+798B
+        tEWxmL5EWzw9tXV2ud34QAnXhnNKiA90MCFAKaVSaaI4jlTnypogUmqZUpIqSmwudBLS+fW4eIl0
+        fn05viwQp7oPq87Bc8TDOpgwrIYoxlXEqSoH14WhSsm5odQKng/v8M+gFrOPc8+pj9Uf3TbfdI+I
+        ZxmnXFKitO/ZkwlBqyURRlCFo5W5xNBC1BBuCRUyt2loZ5O159hZva+yRVvtP3f94y6MmBP4e0YJ
+        8xEPJgQxk8xoTSKhLHMiRRgxU8IqpZWmEO5JiIvr86uXiEd9V92h3oXk4/KMEso8rIMJwWqU0JZa
+        HKrIJbNhqJRzoQWxUuSUJkE9v7o69wtU+/RQfar3WCQTbd9xIm0gkn+aEKyCSfCL1DhYlise9quS
+        lguupLE5SQtkhzUFKoV/IVDBhEElVjOtaAyqlGG/KkEk0xT+fE55EtTyauU12bLb7TdddvPQtfWu
+        gg4ULsuMUUUAmKQe5sGEhTIzRMSqMsu5DtcpaONaWQAmc66SIK9XU69MretdW4VdawxgWUJaCg/m
+        YEJgcmGY5VTGcLKhi77AqZhgXGsDDSoJ5vxseuu12Xr/uW2+h4EqQSmZQnfx/TmYMH8SyFUTwUlz
+        i4SwsIQzyhxz0jIJaDEbe8l697Xabuq77MgXs3H9tdnUSPchkJ4E6JI2fuqeTJh/CZXgo0hJBtyc
+        hnEbLgizgtCcpTHGxWTxEveifto1ZRcGqikXAgiw8f07mNA2q+DzDn00CFRTBCgz1FqmCcnTStT0
+        0uNQ02Z7V2eLafkS5eWEELKyH1Za+Q1WQilmETJhrFHKRtgTzaUNZyu3VgHphqKWBLEYjyZ+DHef
+        MPJPNBNhEjGYMIwCipKIZqo04b7KrZJO53DgGUkoy1XpsaWy2UGrWT3v9jVGD117k1BlGffQDiYE
+        rZZQRiH0YnCFDDcaroSkDBixyNPycz17v/L6zNtZ96mBlvp+hXQbzSSQ8JDWGUxYkjIK/YZHuDCA
+        pYhvJbfaMTWTk7QQ/r28mr1E+/v7Ygovz5B6JLRkoGa48qAOJgwqMUAQRYQeOqgcg6oJVDtNUqX6
+        5Xz9/iXUy+3+0CDkUCgK7wpofAYxmBCgkHBC82i6Mh1W6pxaoCdCG5NIIIpZ4VFDN5FoXF+F9+mb
+        qsV6KjcMwjFEDQcTghhUNwg2Hm01TCNRTI2lIByUzGka5nJWrjxyWHaPm2qHjZwYAY06h4rrU//B
+        hJUnbgWzKoqVKhnEygCp1MBNCKi+JKwQxuVLqBDGdYsAFdJQoCuE+E4dTBhQY6wrXVGgAgEKuhfK
+        GpE8T1Ou61uPP6zr75UL3d2+PzzCZ0DC2ECVISZcjE8mLIyBSIDKiVJDysKZyyBDlIYKBWGc1mmL
+        2Xlg7nRfb7F0pVRBTpKAej2ZMJzAt4gxJoaTqDAzZMpN2KTWLDdplXjm1eEj4d9m63rzsO3a7v45
+        jFhaSamruz7pH0xo71GQAjrSe0hubVjsQMwAKCcLc5E2cbpcLb3RxI/e03yts9Whv282VRvpQxMV
+        IlKDCQGtoNsaEclfhxnx8g/NATwsF0mQL668WL7otvXzt7p1QKERbat9021R2NwcB9bK5xmDCYtu
+        RoEr8DhuEW5GjCvXy0AfJvbf6bL0BPy0esyW9a6u+s0DdgQCZYVAYzABAXQyYaEtBDg6HtkMqdIc
+        yKfWWpGcpEX26N3ci+xR131ptvfZRdfewX8xtmGN1FOAFShfJxMW11yDbosB/lXbvCMfppmyVuYs
+        DfD1cu3597ru9/X3bAGf8rHa1Ie9y2YENriCM5B6xE/nwYTAhgIEzCQa1hrhHRR4B9AWQdIqdjH2
+        hhbFYd89QgZvsnHlDgv6blPvds7tYW9LN3YJyobBhMB2zNDE6BbAFmF3U+PyBlAnU8vlxO/Jyxp6
+        cu0a1t/yuJbGKHCr9g/9BhPatajgMjJxBegsLJjcoSmBKsl5KvTV6L0X6at91X86bL7skDJmpIRy
+        RIkNjF1PJgwrdXXuFbA03KGptm7ATEE1mbR2VYwvvQiH3tTdvzKG5ECHBCKZfpoQvJDtIHajZRu6
+        GAJXEausZjbXadO5d9PCUxHwGqYhDNABEmSagwnzqmRcxpNXIZMrqilITma5ST0zmI2nH1+inHXb
+        u7qt//g7HAS+ZeY6r/T55mBCcVNQAyzCsAE4wrBBPEpitdQ8FfiimN+8BL6AaM6Kdt9l83r/reu/
+        ICENcSXccbX0z3UHE9aX3Wg8Nt8BzMjcjipBLKhRAsIjTT2dX069E4Xzpq2ru2y1aeotmsNcSwlK
+        ONSaBhPmZc6E+y1RxNjprtTAMylQ2ZylIV7NF96ocvW87Z52z5g01lS5qNU+1MGEQTUC4jXuW6w6
+        S2E44UKy1OWTYjXzT7HhtRPFzObXPtg50UTaP6vgAexgQsBC36Q6Ns1yYBGmJbkbZwGBTZXH5Xju
+        ubWs7lwEQzPaNffbVybvTPMj7/ETeDAhuCUxhMWZtRrYhIcb2ArwFZo6oF2MvfyFl/6iIrJivPQB
+        a8Y4gU7L/DI9mDBHM6EEs9EElgoJa8GEFIJpmcu0BJ4Vy5eIZ1XfN91+77en334dmP5JNgIjAqJB
+        WEA2nkyYrwVhxEbpluRIseaCWs4VNCidxi1nk6nHt2bww6u7btp86pETNGk05+EzpcGEoLXCVbc4
+        WCShObdAYgjRqYFdrjweDS8hXMvtN7kRJffVwmBCMHLgDRa+iChK5HwFuLfQhBujc5qGshjNR16N
+        bvpP20/Ycagl0FEI9cvzYEKAGqqBXsW9SRBFCPKfCGOYztOoVbm88cpU2Xff7nb7vvlSvzL0YEwb
+        UwKD8iN4MCGgodpoI6KEMgba1UGdBnnxwV9yXVTPQChfQQv6RZIPwXntYMIKs4W/jHwFbvhYH+AS
+        qH3WuFPxJMTluvBbcAM/GdO9FLSYS83A0txgwpACXYCYjANFeq47TnVbPiZxSHu1nH54ifPqP5Z1
+        07bP2XHC0x0n1GGhAESCXwBjDAiFkwnDDLmtSdS5QiPiiGrgKJxTntPEcC79trsoSngVE0Rcu2mK
+        CajAkwnrOloDKY7jxEQgECptlCvINg3n/Hbh9Vh4LVvVj80GVPBhs+/6XYA6z6cEKjDwWKg3HuS5
+        klbd4mMcKFJSDwcpYciI3nerMcotXuYmbTZbTrxZdNltgSq37ZFIZZNt3d8/Y0fCELN6Dcj8eB5M
+        CGgJ1YbrKJcSHKnN8E1LEPvKJC6szJbXXnUGFvnVnbO8eqDm5ADQY+GPrwYTlsKKgvi1UbIRw0zg
+        /a1KHXAsr7yB9LJ7qvtfiBtM7kNKKquCC5ODCW9KTiVHITOkVBMpoSnBN5rIO2Zzf+V3dgzuPhvV
+        X+sePgF2EwNqpnApG7iJcTKhiB3Tt69AxhATbTi1LE/L5ptx4TWnm67/clch0QwNn5uL4M7vYEJw
+        AkTwTmSJEGASRB8cq5Z2hTpVHyyWgW3up6pHNpOY4wsiGMGDCfOndg4VUerMbdih1jC386ts6srv
+        +Lb0ls3G9Xf01gWTjHLoCtr352BCcGoHUkQHONyE2aNVhghBqMpVGqkaF6sLD2bX9eNq94ABNcQi
+        O/knEwYUpL+1caA6LPlAwXNoPYQlVqSz9dwL27Ou3zdb7L4FF1baCVQbH+dgwgJXMOgXsaVtAKrC
+        7cYyqoBkU5KrxPHjePXuJVLHju/q3RfsuJNpZSEPA4fbJxNaiiyU3Ghf5So8l7FUKWbcuYFNC92r
+        8ZnHJa7au2zcPTZbR6DO+uPnyabgZEwVWImcFQ0mBLkgCshflC1zGU5aY7mQUKFV4rbZrLzwCMVx
+        KWnz0Dy9TqOAzlCQPCIwhTuZsLgmxAgW17kc2bEzCtgGJBNJTOBl4BbRstvtshUIA5w+GeY4UkjT
+        n0wIVohN9muYGoaKDOEMt0pJLlRu0nrPovjgDeEW1fPmoUbu1bgNIqaCd8MGE4bT3dmLSyAeLsnw
+        /QguOdOpE+V3F/6xbl993mcXdbP9A/jhb+uHOhDAhGh3Vq38TjuYELCMKXcHNap9OLIyaRgwYgMt
+        KPmmrn+Zpnis+2ZTgdZr680e/jdbdN+AI2P3awiTILTdPMKv1CcTAh1IpbubHkVOw/UKaJhQFopW
+        rtMK1jt/I+ddfeib+2zcZ4v6yWmh8F6dZZpeu7Lj4R1MmKsllFn7CqtCjsW0geIPb598TflyfOsl
+        8OV4cnubTatPXV9ByUIln5BAAMZQhAO7hCcTVp/dYnvsdgZARrY0tKLwD3SsXKbRjun7qbcpOz20
+        h7Z+hFZc7B/a2u0dIT3JLa3SoOgbTGhKSyAgcQaCTCS1VMDkgD+nrrcXgav3u31ffay3NUBdTMvw
+        GSD4FgpneJvwZEJbsFGuhsXwMuTBClq4x09QaVMZ11nh9+CzClS9O/UrOx8oqB6nVeEr9oAOJhSo
+        0kbEj/yYDVNL19IMAbmQeqo9W879xwwAg+63SACDptYkfDl7MCFANQVNRF9xKIpTUuhXPFXMn0/8
+        Fnw+gf5btfuHEj7m3xhRccWOz8cIrGkgiMGtbjUnjhhJWU6NEfCzUjnHeOzfux9X++quQ3ZBQckR
+        MQ0ecQ4mBKeEDmLig1aG6HoNzdo1c5mTtFQtL9beuUEJH29/ZBePj4ctFGM3Zsb2MhTk58Lto3qw
+        BxNWkfVRJ0RhIxfKlFUgEqS2iSLhrPAXvMdNBR3o7lO1+XIaqWMDHG3Cg8fBhCDmnBMio3NHhsw1
+        lOHm+CCKxAuvk1svgSff6xZabni8yt2abfgq2WDCKrJRkgkVbbUsHM5Kuz8K9Dl1c3+99s6x1311
+        d9wxOk41wlLBGM7tfwVnVYMJK1LAlGTseQMAFtm1URrIp3v71LtV5ercI8xl59aZs/O+Ozxhx/VU
+        uauAoQA+mbAepJi7XBcHi7jWHZ9Sxmwu07Z7y7U/gSy7+23zR7Xd/3maseraw4+KhRxrW3e5JHyJ
+        +2RC8Ftm3X5RFD/yiB+ga4orkNC5TuvBE49p/BCDHVTorOixi4PMSLdWAj/Y9/bJhKAV1ljCo+cH
+        TCLlinMjNXzFied/o3deVxpVX6AnXRzuH+pdkERCP2AMCAbxW9FgwkuW1jL27CaAihwJKaKIYyos
+        54lZPPbWmuGlY/D+Np74OCmTVAAYE1qm+mnCWq4E3SATYQoJrEq427FJMK+X/rz5uu4bqMvuUsIz
+        qD70dhEX8kNwkDOYMMBKS8PigJHzXGlBRgP9FKmAy9If5JTdpnpbdm2VTQ5991Rtms9umAN8CxjH
+        LvQYkfMRIaNxuZgT4WfwOTQQbnFxZKCbUhuHj4yxgJS6tVmlfm02/DP460nhHYwV+xbsTYWxDsAI
+        2jO8PncyYZ627hzvFajhMY57vpE1AsQCT9P3txPvgOF2U7dRGmmB0NlRcGQ1mLBqBSLDvjKdRE7s
+        pSRAWJQrVmleLeYrb4kMXvuAPEME2odivwcvmwwmDKWCzNRxYoXsfUrQupaYYf/sn0EcXV56O5+j
+        psOvrFui2K1bpvExnkxY0Gq37RZnyihGbrikkidKIP8m89X8r1tU2OKFYW67L3iV5mRC4Gqn5+Pb
+        Nb/Y1Qu4UOi5O+bPE297jqe+0B13bQtced3XyLkfk0o7PmhCWu+nCcEqiHIlNI41TBUlsW6mRUzy
+        uObMy9Hz6dWomJ5dvZ+Pl5eTYLa++3DO7Y+bFD6zGExoTQLtoGWUGv/qRH/F6y7SGALaOLUoffTg
+        ftxtqhY7LQBaa8g5Dd0vGExowirzyswigtJaK9xGTRLI2dirSrNue9+NR9io0XK9CD5rYDBhznSL
+        C6/4EhlIQY+WTHH38KY0mbde33hP5loD9X+7/uYOu/Z1X21+PGCi+7z/VmG3KoybeSJ3dk8mBD2n
+        7pnF0cZDTZhJCAWCSCplE6c0NyNvfHFT9Vu3Ddd3u2zsnlD2te4xSsGFYDy4+DiYsGolJdMsflxA
+        ZZhTcOMUkDseSSzNl9OZ14wu2/bw2GBjdAHtwI0PAyOMwYRlsHt0XPx5AxTZ5QXWBaGtEknizcgT
+        8DdVew+9Z7vLRl0HAr5o28Y9LBJzLxVMB0etgwlLaHez19J43UKIBoNOBJWLs8QtlNXl0tvYXjV9
+        c9hlt7NX7lq41QszCg7VBxMCWdPjbYxoRBPsOTEM2DU0JPl3tM+//uf/AaS/SugyXgAA
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -78,9 +117,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Apr 2024 20:21:32 GMT
+      - Wed, 17 Apr 2024 16:43:17 GMT
       Etag:
-      - W/"300f-gld1XF+QRWWO5yqpn8ZXulQWwS4"
+      - W/"5e32-2V5eXB4F7xydvsbJCpdYbUQZt7g"
       Server:
       - nginx/1.18.0 (Ubuntu)
       Transfer-Encoding:
@@ -104,63 +143,143 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: https://financialmodelingprep.com/api/v3/stock-price-change/CASH&OTHER,CDE,BCM.TO,IE,CKG.TO,SKE.TO,GENM.TO,AGPXX,AYA.TO,BOL.ST,MUX,TFPM,EGO,PAAS,USAS,ADT1.L,VZLA.TO,AG,KCN.AX,SMT.TO,ASM,SVM,TMQ,APM.TO,GSVR.TO,WPM,HMY,SILV,PRYM.TO,AOT.TO,IAUX,284380Z.TO,BVN,ARTG.TO,EXK,SSRM,PE&OLES.MX,SCZ%20CV,GGD.TO,HL,DVP.AX,SVL.AX,HOC.L,BLSN9G6,GATO,FSM,MAG,SA,ADT.AX,TGB,TV.TO,FRES.L?apikey=MOCK_API_KEY
+    uri: https://financialmodelingprep.com/api/v3/stock-price-change/MSFT,AAPL,NVDA,AMZN,META,AVGO,GOOGL,GOOG,COST,TSLA,NFLX,AMD,PEP,LIN,ADBE,CSCO,TMUS,QCOM,INTU,AMAT,CMCSA,INTC,TXN,AMGN,MU,ISRG,HON,LRCX,BKNG,VRTX,ADP,REGN,SBUX,ADI,KLAC,MDLZ,PANW,GILD,SNPS,ASML,CDNS,PDD,MAR,MELI,CSX,ABNB,CRWD,PYPL,CTAS,ORLY,PCAR,NXPI,CEG,MRVL,ROP,MNST,WDAY,CPRT,DXCM,DASH,FTNT,ADSK,ODFL,MCHP,ROST,PAYX,KHC,AEP,KDP,IDXX,LULU,AZN,FAST,MRNA,GEHC,DDOG,CHTR,FANG,EXC,TTD,CSGP,CTSH,EA,BKR,CDW,VRSK,CCEP,TEAM,XEL,ANSS,BIIB,ON,DLTR,GFS,ZS,MDB,TTWO,WBD,ILMN,WBA,SIRI?apikey=MOCK_API_KEY
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA41aS2+cyQ28768wfMhpp9Fs9jO3sSVrDUuWs9IqNoIcEuSYRQ7JIYsg/z3Ffg57
-        /AlZYA9ujEZdZLFYZOtPP7x58x/8/+bN23/+9utf//H3t79/8/b9ze3bH9sh3eDg5IwPwfejUI+K
-        YY40PvWAI/bG+mJzP2M5i9bESCn2syhniY0nl/rRb//6m/xsNCG6ML7uG47IGptCGJ9jOTuFYGxO
-        PL4v1A8GUyiQGz9s6yd9NiFnNy7961/+XW8dTcoxRRz+98fvQf+4IWeDOxSF3JqUvPfM42oVPa4b
-        C9H4fRU9ZcPRuhGRih7f6DOX8ZUNvjPZZs+X8E/44eDID6gdv7HFrft856zD14cdfT88BP/06dY8
-        P6oAkEmuzHB3/D5S4DyvVvEn41PQySdvAvHMdIXvDeU4PjXAc2I/01ev7/B1MfKWfG/YpjJIV9ED
-        jvHyn4Ifce1BppF5xJjw3yH4u9vPDzt6ewl8/IN6GpNd96vQvLpJy7ZjZLH4ceeGGKmlTFlDDvhk
-        okmCBjkh2AG1dwk5OjMLpaLlcbMGle0hxvO38w4xoPC8Km2WwplEbuQOyG52k4u13B1KO/G4b4Wb
-        UV5IkM4vPuitS5Og39oZcVFYC6gRnFVQg2UTOc5679ktiEqKpNlN1kbcCHc6hP/u8d48PesCJ0N2
-        3GPw24GO0Wp1QwgC6HMZAWcNO19GGmsEIIsQo3HfFgCcpRnOVtvRFOtm2Ct+yF2AtCVSEQBVCqUy
-        ItoC4ALC5/1gX8NfMhIHucmH8B9++bpjL6hjBT4aZ51TyB1ULDk7ot10PRtXXFTKxgX67yarG/YQ
-        JauzAVT4jgxfqEBnunH4Pq1sbpZcFzVCieSiK9uFjLpDzA9xP3/48qCBS1WRVjUGIRF+lXIPWY6z
-        +FrO0eQ4sNI0KgYZmhXTa7xIPqPOe0DTTFPqKnBEElKwsvCds856fdjAj8ND7Ld3jzt0F71uaJVM
-        q/l2tsc4UzmaWY48Rb8ir4rMTtc7iTXwrOvdQy7R9y6RMyOUOY9QhsHsWHgRsDfzZOAieC94yGhk
-        5kPwX87np53xgVYD6ehDsVH1clcM0k5K3VEF4IISdwfTQp4GqKnttlivrAzUsxRd7Sd0C45u+pOK
-        HmdQncnBit0zinTcuDM+B+P8K338l6cr3NBRR7rUJZ+WFeNF06HUmvHBEEENL5GjMk1GBWkXA8Y7
-        shvjyeTZihvyjLShXga5WqlnD9Utaaah5b2QBIk058XERZ/tcSs/3zyTub/iPU/FnEbO2sI+zELr
-        Ri7ERZLG/SQl4lWvk0SHsEk9eph0oMsQEBkXFnNa0aNEnEvKyZC3CLSbzrCFYD/t1B+nxyG40/Cz
-        iWmFvHECiWUE8hI8pBlirft8MLAlblxgMD9e4OzMB6PzMvYt/xE9gaeB7D4uQy8DKckjMC8H1jZO
-        bCCEPWjBP0UWNbDuEPyn95/NWfc6ECkV1efh17MvTEG3eWTfRd6VL4hnVxGAt01xm2LQByx5JXwn
-        4bUPSvjQEzm7ovD7iN4AS62nmL3F+2CyDBmHyJ8enq8dvFuqPSSPsy1K8JenHNbmcnpqhEdswOTd
-        y+LLXE6a8lZXfEq4dpqjXBgsCBkdUmcc+m89qLplHErLkMZD3Ocn3eFlRgua7oyuxFruQGOkgRTd
-        MTqgHeQBsg0tcBhufl2vdKQC2q+TLU6A8tKOeghfRIW1h8e865O9GtowVHg379jBoyuQzxSOk/6y
-        2Rs0dLQWhR6/L5Qt5anOzcrXBZnh3bxra/Iw9baUTejQvGc7b+CR5Jyt7nJcO9oqvEp/XM9i3FXY
-        of/o+3nPu8wE2R9X+vPDH64afA66wcN6wLDNUAskTJch6XEGMh3EzSvk0uQ2WwcngmDo0Q12nsNy
-        UJ30xaA76Gn1lFFXNs2GOPKejIWgbdN6RpOAchwX+x+/7KS3KWvsBDNSkko7ZJ9LnsrCLR5ub/FQ
-        AGJyGr1wnrXAgQclsYKOHy3iSi+REwZhG3kKYe9uMBwWAVHACaE0xed0nPafHr7taY9RT3Eo45zL
-        jpzwvaqzB0DKSyragkoKlsp1veelFV3noIguJKXuGWXlOCn0mCzEyETNeSgFLFhxmvQQy1f0/eP9
-        yxXhQ94JX5xfI1dt4hAwN5vL2M6QW92vCR3a9arMBlxUoujVHCT/og80uiO/MFLb8ArviGGDNd3F
-        0Kn9Rx9l5vEh+vPjVXeT1eQU4QZfEuVYZZ7Rf6LOe0To3ayM1uCcQzqd2xKfm/yqxBdZaUxT1iJQ
-        t32rFNokp3xSL3eZKwtHDR+cz7L/OQT/8byN77DgVJSjRRUEl5XSiTahIWWl8tX6JedV7k9iaaAM
-        epg7IYXFXmx6R5eGBV3bvnoIT5pj0JPsfjjmOX06Gl0/PQzBu5fPWwSgKNrTy67pYhtYgWGa85EU
-        +bPY3KvdlQ+wYQo+1D4nq8xNKTJKRZV7cMSCc3qkkW1rWJ2ibW7YuDz99VhgENxKSq8M8V8/adJ7
-        DJR6aXeCDysXWjIWGFDraaa4l7iMtkrwcKmLQbxv7Vg6VVa0PzE8G9R5hrLhxG3iGhCGnc+y47lK
-        O2gzv7OnnWEcrM/H8J+efr4yOLlYbXBknPZX9g451mP8KVjEjkj1OpkoyHLRuReWx7TaYh9ooOS0
-        hpcWgpgR/BC2/At53Obo5V0CX0q65UF4MIkfT3Nfbn/3eH/7ZB6+7nEIa482xd9S1OonQ11xSgJY
-        rmH1RAtPh9Fnqmnfztd3Db2/xFSGjykWBIxDYRmvynUUClzFhh/JZu91BZB9ZZK9u7u5En2Z3IvO
-        v4wYPqnCJ8i+259kxA1q4ZP1rM58kDjoVn9CEC0uvkkeIhFLVrChixqx7gFd7WWmpBxesTjb/oKE
-        TLunT7i5knvJ1kV91qMga+HZq8b8nnzcHqFQsxR4knhONM7CvCnYMMGQgVndveKR7uJZpzsWcZHT
-        Cg5n6+XJ55Ved/PyZR/gT/XlSBudrJ9+HvrdoIJu63eoABtVCE6y60olabMj7Q6p1+Os5D5htNG5
-        h2xRWc+O4XuHnQHb6dK9enoYhaeX+z0Kxw9SINTas9UcizjYqQTN4aDvB9om2e2wP8ChkfpcNGTS
-        rzHN2m7DjANRIa+a7qeShKv+eEf/0+P7fWNHEOrFseZv4LrWRSvKVGc0PcKDyCXrXW3Cz7octh6H
-        0rcXr0tVyGADip5nToIJsdT7CwQjkF3DkO19j61jva8VzYdhTscPU3fn/eHReApa2MmwS9rcIeeY
-        NLxKe6hvztNiNIVjU5ZQdI1LsrdZ28aaS1hn+PWttxmfQ1E5h4cQGuhpZjvsOtcPD5F/eLp6mslp
-        rgGHoXeYQPTfGmC8SzEpaXfyJBu0swni/PPMR29pKGdEVxFeQunK8gpN3kXz84YdRGLeuhpMtic7
-        FwpD5pw8erzyxwYP+5aW6k5yA4+bbpyXP0rgomydq0uiojgvI07enyfkjy9oSlkXeZI3kH1txSCt
-        Y0X67TcvW5cKzdY40IOIx08zT+ed79dTbKK1M5x+Ni+lan4WTChrPGt+Fo4UDmXLOoqdkh5k5C8U
-        wnqE6SqH33wxBXaVk/ewZQla1q2sp+do3F/fvYzf8BiH0M83z1fNTZ7D5zJ51DuV5ROHoaFgo0r8
-        dKJN4KWqS9B2xtdFlN5cbN8kZ7KwwvyoccvLR1rjQgdeogYtB4d4n+/eKbAgOetVfN3a6bdXZCtj
-        ppi+o2q4TPZR72pkKQ0L5rW4JdnD2vU3DLVwMY+5onO9/ZbGcSQQY+Wsht7WrEho3IQ9yy8/Bv7y
-        //89yfgHX/6jGZXtuaAhnD9cKZvRmC9xnYo87q0/V2gdC5OrLNw3cyKndq2LRsOW1ZR7ZfP64WfM
-        I/c7i12YdqB3bMtJkxhKVdIieyNxNM5jbrnEHdCw19DSa1iGvO2FycnmOG01zKJ9y+eH8ckS05ZY
-        0Tl4u235SrJH4FxJ/cOf/wfd0De8JScAAA==
+        H4sIAAAAAAAAA31dy24kR3bdz1cIWk8l4v3wrprFbjVEsntISt0twwsbXnrghb3wwPC/+5yIzIi8
+        N5UFQQsFyGLd17nnPiL0z3/56af/xb8//fTzf/3j7//2n//x8z/99PPz28f3n//aT+0NJxez5BD9
+        ehTbkVtqstVuP/bMM7vY4ut65HkUlxR9CetR4pHzS3XGl/XsH//97zi0ZqnRJbd93A+cBbeE4tL4
+        PJ7Fuhiftr8af7TPy/hAX+P2u4an1ZUlpFy2P/P3f/2f9pHehrwUF2LG+f/99c/Ev16/Pmnxk4vb
+        J3Xx/RJMyUJ6fN1qzSZCE/+Cv5VMFvJfwlJLCFL+S128q2WTtclvl5KNHZ/XZA347jUMS3T5LSSt
+        ZvvALn+ueckmpe0rdvmttybgx/E17an8L7/frlJ+v9jkh9LbEQzrStm+SFeA59n4uW5/uxib8yZX
+        U0B1cIo8nKIrIMcl+50QTTILLdfhd00DgZ/o41BzU4HNBj5Qitk+s+vAFhv8Ev1UdteCM8llWCZ4
+        78+94PmPF6kFu/gSk/KCVIUT4CAkvx01FdgK7dnxi00FcNkI42xnXQXOLDHjm+1VALXUWLJQQV6c
+        C0L+6pdSUlbSw3egPjcMsrpACdFB2TGE8xB4fnxXLuAW548u4I0VLoAodjUmY4QTeBjclxHxTQPR
+        LMW4sAnbNQDXNPj1ASpNDOAFfm4I11SQLFyoShywGT9Y0/C1NQ6AAzWXgSyrEmwuiwEylXP7//7p
+        i1ZBtmb79K6CsPjkBuI1FQR8sxSE/DYvNg4bNvFDWpwJbvuxFQThKd7GAWTdimnBv1GIb3MFNqQk
+        nMAbYpJXXuAM9BfhbBIIcqkWkeFyOlXApy9fPkkcNItL49vFNSZqDXZEbQtvKCD48X37UaBb7BVg
+        aX9Ag1SAW0wAQu8VAE2ZUqKAQR8Xh5gfX6XpJPAPeydhEMC45OLK9qNd+gR1LNkBbu5Kr4UPXkY/
+        hDcmb2er8LXGgWKb8EgVwvrMdkCEo/DR2fFxq/A14Nsq4Qs+cHyVJnxkOjbDn1bhSyRWDt9ZhYeH
+        Le5U8Icvb4fkn3yQoQ80yDNM19wPC1eR/ZDoi/Wb6rfkX1IdFu6SI/cFO5JaFzzgm9skBEfeiNZF
+        ifwF9kXkS6uDSSzFmih9PnlYPQb8cyr8+9vTVYM+Ms74k/3IANCNHWHaxI+QYTpfT/6AHpuqgL2L
+        r/CjGblr9kc+AHwL3LtY4rypwvEvML4xLgsCkGMCDJlJnlb4z3ColBTyVWQnZNpYzpXw8vHp+0EJ
+        bkT0lvms8VX4vllCxpmxQgswRYYlt2/RtJBBFF1Swe8QO96K7Ffg1RFoKrxgydVK78fHRXAnJb9F
+        2glwdil/NDkzI4DQnSrg+nyT8oclTq6zJT8H/ieA72LL4rO1ggAjVECKgsC+gJ9DWG4ONMI/IgoE
+        A8xkLxM4tyhwxc081GEi4xN9VNgHHQP6i5NhAFSAt6UaTuX/+vhVQR+sIGLANAjy2QkHgKg1jZTe
+        Ux8tM4zaMz/w0CvqQ0AxfmipBwC0hACQiQ9x7ZwVed/DFX210vqVIrphipX3ucig8gDyU9mfPr9o
+        9LMuy6wP7wW4iKxPUg+OLEwP4Af2Cu7fvn8c5K0LX6C2KnHfOcBknh/XQA1kI8xgWJNeho87Ffqs
+        iNKsulbHh+cvoD3l3O7X24dHLXzcxdp6BLfP0RsJ/x5hCe63l/9CQutmNuwAaGF/G1X510IH9YSo
+        /8BSfcxOAmBB5i/jbMU/KNUqB4AtlpzdqBM2DwhgxIBFsKJTNTy8PXzRanBJMT8YCBRa1j9u8bZO
+        tNr8oswiblUBKonqhrJWFUDaHCX+8beBvFIDdYETFBECVKoFdZAlMHwUdDxYlQVtTmFBuo3nHOD9
+        +bc3hQDWFqkAA1qWwfOGM48WgDcjLwwItJPW9kAg2QleQiB/uU6TNRUgtcFaA1OaX1iARbKS/cHX
+        MkoMhYAAQCepn6dXgcXWU+H/9vDlWRN//JaE/8CMaKT5gXV2UpsOf2AAyBwCA8DpcoxZWh+4hGpg
+        0pgGbOxrVFH6QfRMDxaiG8ZEjdL/UeEvASAtiz/UR41ZBX8u/+eX99+08SeH3IyPmgqSFQkCMGq1
+        RhjfgScYRf1RJGeApVTAEnxOAgQ9C2cXRAKIrEOLbIBAbQiyGSZb4QeoR90nURBGI/mG357Kf32+
+        KgLMXG8kAQ5EtlmoPHelgLL6ZJNAQdCagBQsvJ+SwYyK/yAPwC6y/M88kx2QCB9wU8s9B0ZynVQk
+        ANSAOj9MVN26H8RvfEaw507w8PzwdtUgGGaG3kDQmyFZV0IhiQsyD6DUdioILgAA+KwqgS6tKpw/
+        2tMAQjgPR+sY6Fi9p4lIa2qIxg/4XSsBKDUOXrTVARmFUUX9d94AQRA8/EkDREKgB2LXIcIKAsjw
+        adRhK/55lmGSBQEtUtVBcAE4FZ9kGoROXC2yDXpBFLuSnVQA3CokVQp5YKpxRuYA1AaVOS3f6X+8
+        fz8QIQirC2BU1kGSYAQ3HEBhAKLCCgxADZJjUdJbHkoMvJDH2VFjd+EtywcnMmBAXWlVBQBatCDX
+        DfDZCqAMZmDivdbP86eD7GFW5pvssVgnZYdN7Ww5d+MD7YypsvtzQVlfD75vWf/PlmrPflCmFaaH
+        0wUzUK0LD5qQhiut+A/cAfJWyYAzIAJGAzae059nif4waNR2R1YF+RGBT88ts0nXEh3rhjLs1O1u
+        yA+CNHxA6bPrXvLrF3avfRF5H/VczlWY3bLGjaYqn4dz4ytbiXtgjRHlFFL0qeif315l04cuabOE
+        fnYwvJGol8CPZndobX6gxlKwD5aGBKkSn1t23Zye+AopihWoz44xyJzs+uB3xy/2pMeTasevbi1f
+        h2QYiUunov/y5eDy8DM583DksrLmpzbgCaLtc2HfR7J+WAnFqHL4CtPlILCOv4oSWkjORkgGYMmc
+        j8goaRSCW8kPWha9l4wP9QKYAHjqecA/vT6ojgfy+xwxbIyvTNBpwiNgc5jctAmKtMbewl74AKgA
+        TsqKxxGb/PjB7vRghnY2Vfq8I3MwFgTQI0NwIKXYPpmdjSZK6YOFPtge8ued3g+/vnw6YP0M0uH2
+        IEGq4VNYSJmoEI+9CDHxQXmSrDkAHuqwKpu95EB5lttdA4CMamSzt7CjXovM9bYQB02QCsiefCnd
+        Ify/v75/P/h+VfM+IEotMTmV7jkAKoOHdPlJ+FIRsIfAt0kNOy7NWQe367me3S0v/R/pirEjyx1C
+        iS9GukBECgHVHA604h44MLAopTsTz9vXg/3zLLDWI3ihCbMgWV0Auc3AawXyO3atFd9BwWzmLK+r
+        gEk7zkZCj2EEVZIDL46r7LR2z3mF8yPV8WLGN8Y7mfTAnnwbDd1BgNdHlfJZzKkIIAkIMVrV+WHi
+        K5rxgRiXJFygNG4mQYDMLlnvBPqD7yEEZAwUMItQ5LwHDgVu6+bMeJ338Pv4KsseUH1iizHnIPD2
+        4TcZBQahKCd+/SSEIFMAsDJnNyy2JkSH2lUo4MI+l5EKwJmtXpZ9bBsBViTfZUNfhQDCB3RGQUBg
+        XNSk5r0xVPaXkBdPxb/ePh+mHnEMcrf8F0sd2WUredm4lx1vxvWgrNvAx4DJHdodJcp6Dw6BkjeX
+        scywVf0os0azuYmfEpv7swHVjR8re/CS93AEgTKocIZ6Kv6vT9cHnQFLkBkQWGdKls7PBrVLQny2
+        WEu2wvaeeyCTLY+eR2YRs1cACl6UZarpa1holSTMHxjSrMGFAkrN7JipihfkMiM3oli7w3pvT38o
+        9/dJ2Z/WIdwp/08gcJO3bzkgwVdk34czy/HNZsHLnqGc/HA6b2TPC7yu+NlH7DQA/oPkPhyo1/xs
+        Ttuh/a3tSaSFm56K//X68k2Jj4pH0z84p2x5gO0wfoXooGbssO9FB++GF6pqD/G7Swhbxwv5RQkO
+        bZQwpy/NzzkUDmmy5rXlBQIANuKV/wdGRbxn/E+fn246+p2R+c+CW0w83JodJUQrxXfsFibZ7aRO
+        kOpVz++CbO+RrSQDxiEqVDXvB1A42fXj/oBRuw5QqZG4bw2yGFcFzoddby9fZa+XXdg5ZVgjH4Tu
+        sO2UEQmC+YBnmlnKrFkPVhqDzS43xxB1tNP7uBdom4KTlrcMezNjsHlIIuksTsF+6+pGo/Z8UIBZ
+        8gF7h/m8Patdr0LPknGf2eeZOLUmvZBU0DtWgWak+B70rLviaEGs3D+27CjsDg2AXc69kXaGhMM1
+        HaEAVBPk5jLqkdk5p5r7NGvaxwFXasCeTzXwcHtR9mdJPVdrVgeIeY4At2YHEpXc9krcbEsC9Sz3
+        rOYkftS8qAa8jH12sXOWLmCgvjxbr5sHsFugqh9QsNZVFvJbUC58zXPhv94OcZ9m16HLHgEeTuHe
+        nwY+GYMZbrK2uUCNggp7R7NOcO2NHk9uISe9nOqYFJT4pS7sBkr7A0RIOqz0/3F6Kv/z9VU3e1Cn
+        yeDPJB9zMW8Nfq46iuAPbfqxFx4KCXVqaQt+hzpSuz6wTBK+xA0ZJylPhjpQ3kjQ92yuVj98aY18
+        BB2C0d0pep8fnw6MD4AqbQ/Yxl+UtgcTjXZ2pnoshBbm0vNJF72X4pMEIw8I8EscaVQR+a0ZWI0c
+        dNvCnq21yvPhSuAQsxYcU37f6us7kf92XPOoTgY+klmpyvjA7zQV1RVAE/oYslRB5UJaUe5PAEd+
+        nE2qXvUgn5gdlWiOAbmSGvbDpyYiblUfS55QZOxzfg7wT/c4/4eXD4r0uJ3Ot9QXnZpxcgNjWKFz
+        XtY7s5Lt7s/Ea7JkPfhBNl+F/VnLk8pKB+B8VW55ooLk4FDILs9WyfvZud1fv9004vs5Pts8v7Jc
+        VIZH+T/0s6b8nGSdGxMrMD3eLFSjNLht+5Ritu257hZVZ9/41hMRYqvD1eXXw1PBv/44LnZXkyTP
+        Y3t3bp1sTQ4gQ5wd7xXwYPGs/L2mWc2vyR4xW0daWzlegehlsJVu8UyOWAa89ZFO4NhpjvC3Li83
+        w7wE++3w3Ozv17cD4Im+Pv87R7nQDGsWO0Tqzu65bCAIvqvkt6NkGVke7EVtc6IOA48WVq80W5aL
+        LaACIJM1S7ODznKlYe7SrmhfK1lzvLfZ9+X16Ydub8zebRPfskOVpMsTEqskOZZLMXqvJ3IVdNTB
+        I9aNV9usjotOVrF7E7lNkESys82eWYF9CmWZmlrdPqIS4k5NvFPePehEDxYZswx5x8BVK/1I9NbJ
+        sQ4712HW8lt9D1auKjyWNzbL9h5Xz5waaCNVg2+O+dXa3QEhSkkle7a8AECqvYPCnncagnPnGy0v
+        379+PijADkTamB5bBLK/E7g8XbQDICQVzQ1sXB9CP5oq9/m55Oi8bO7BT2C96Ys9HSJQADqyznEg
+        f+DDqsNtQbyWO2n+8TDT2pm5Sx6YgYpwfQ5ZSxmTtc7vUfX4IiscWBRxOlykS46KO5XpqB3wA8qe
+        OP9KR3zPDuAs3OKfHa5MT52uHHc7PZX/+fX3J53udgRuU0DZ9azsymlQPuD7yoUWNl3iIHAd/SLv
+        PXmFfm1FyAkVJI6VihUaCK7V+2q6xQW+6ecb1U2wnPcy/FEis147t//rF73NaX2Q0rNG2k3Pm/Qc
+        +9oiMh5jJqld1shaZvD00dh0CAZpfd5tKMLv4eIGREpk+9ga3ZMadsENzAMRJeq7mDhhzsCOc9u/
+        HJfZoxnYtWU9A0nrXL1tsrLM8nKPAV6CtF2F/BVcsA6MW+XPDKcsSJ5Dgpjr4U0jXGOrcoellnbN
+        RoK+L2x1Vl3iABwjedud8u7b7aqTnrNqkZsDY3PY4chgIpLhF15YGQVmBz2kHWeSpHr8ZWazvfCe
+        81+rurqIrtkY6XEf26RP9bQd+85VNbVRFQOKkHJOZX/4+no0/dxMGuVNClYaHn9ud/FgJTyuFtnS
+        ZMYPUV1kwA+S8kvZKzPtYHB9pMfOd5IJH3YnoTxs8Re2l32UVBelFif9sNx5dXP7/nDYY0SsHnr6
+        Vl7fsQipXYLqHNCE5IT4cD2ErpS+sH6efZmexhAJKuw5jp4lZTc8b+NNZ9iaepHbACFIv0eeP8e6
+        2/Xtl4PMYXjUVtqknR42rGe1FeUkl1cXsppjZl76kTyHt5HcnFms1U3kIsAw26zqU0zC6S/c0EpV
+        9bL1aZd9nJ4q4OP7y7uKeIivNxloTt3IBysfFGy1eua26F54Mp/i9eYmL23FJNCOF+NKGlSqSU+i
+        4ObwtDt9bEHpJeCBhkauMqgFHl+MORX8env7VQ+wapUEnzcK/GFhL/CerFphqByuyRKHWw3TngPo
+        PYws4p2FOxxJ1nbs+Oa57dhlr20FWjI8ZGZOHpIM9+DhX6eif7l9fNKilzkE3wLd5qB2NcljeREk
+        Crs3J5XRzoFssODZ0vIc61hV3/AyhgvC8KmSDgwbr30cXikPenyL+nWJLowEuBo+pdR29u5E/vPD
+        L4cdht2doE0Je/q6EXxj58LOOsDl1R6hgcz1QhX3pEO71bPm46BtSQ5vLa9FzesdvZPJC1VFtXLa
+        8BaZU7OcGnmFEXXEqeyvhyt7tgklZAfFT+qy8oVtCHVnr68ujEJm62S65LLyfc+5nLI+13LmenqH
+        e7ZYrIh60IGYJ63eapvA9q5it6iVCuvyfAfzvl5/HBqZu/t5M9HpxQWzlJpJfgTqc/kFX8+XomLA
+        cL14Xshb0Q8Jrki2A60WxXT5110VOS8kQpyRPmArq/5ZSK/z68zWr41Ik6dK+PWXB4X7pkaBfox2
+        B84lQSChzDZVuD90BUOoG6tsUrtRjg4XqM7KjdUGiU4yXTYz445U9RoHgIo/LQHgEurC6zIq7W2n
+        p9Jf1Y01Lj2rndW+vKi7G6ZOUPTdzIXLN/KyOoWf912H8GRhqrHn+etFAMCltUHmBYof6y9ndVM7
+        RqZq1cYHW0c8hnLH8LfDZT2jKH67usz5hEA+FJPRq2VlEF03m/Cr7MBudWPtwqXEJJcXKTvqGQl+
+        zK61KOFtZuJT97Vc4rjCqgEm/APo6e5U959v3w/BX4O6p4Ba1swvsdV3vqi9Ve4Yebmv3NrwRk/w
+        AIg+zpXELr/h7gHCRk6x8XfYQBXys4Pm542SrakL/FM3FVAOFDLoOxc1nn57+k25/m7zedq/+Ki3
+        F9rKthn5ZoV/lBsuyxdb2vpCSIcEAGAGKRD9PS7DRDcSZc//YPFOUB9r2HHQTzWAGCM/H67s+dR2
+        8dy5Dq7qpQ7DVwQk/eHt9CoH2ACE6qUHEPjmt1pl5yLMqIXHDMuy311UX597xlHe1PC8Kp/l6lom
+        9Ae9w8CKwczCeY1/B1gw/Oqn0n+8Hnsc3qmldcsdpZls1uwPTI4C/XhdzcjVVUviYPRrLcicVq5u
+        80pOUqurAC+uSwnbV3Z7d0y0C59Z5OvNbS70ZE6k4Sun4j+/vhwuKuV82FwvIP665CvsPuUgIJBP
+        lRjpAray/DdSA9AeV81l7mtvDoU5LelQz66dkXUPu5awrLqyhg8ko1Tt7XF6qoJPjyr5s9UxU9iM
+        ACfvbLC5bcusUZuwyN8hq+39zMu9qtVhSf+ykN+3IbBI/Zxflamm+Cdnq+zycBV9PTyV/Hb7cmhu
+        12Rl+uNqRZILHC13K+JrGbxynufl7aOtzQHeVgT2ZzbH5j5Ll5wktKi9Nd+ek5CBrw431OuHp5I/
+        /PL+qkDvcDmLriiTnm2XuNT1PJdbJEjYg+qz028UXLxnR0RuLjGPWKOuaLFmSfMH4xYeHAgpyut4
+        bzIr3s/WbkZKPDf9x6u+tMC3aAb+bEUPakaBeijE/W4G0azsmbNko4N3MfM4W8c5HElmubfjW8NW
+        PtBiI34wWrmtXbiDX5TT8/pSRMZQ8yxDvz8V/PG7Zvpz2j5C3TgrwR4VYbCjAbFOMpBt5SQDbKWU
+        eVNx1LnGBrmpyd0kX3db3z2F8WkKtbC3xJjnst86vedUUW/pI9h8udfNfn+/HQ2eJMohA88mXpOc
+        E0Mvt1VcQBQMN1y7O9ar3XTyMdZLwtztjveoBFZz8ymhJPGdE4tc1WNEcEXWuElN7ufxqegPb58O
+        3Y3d21td9iS+28Zyk/VyQReGsy4L6TMr7MG7uvjEk1Tz3PrsWLUEtoz28l9ahaJWtepiyPGl2Tmm
+        NHOVt0tfyfx5NeTOk0TvuqsL/lXUk0TkCUXdyOcMZ+ZBv0EgL7Go2p5NsOR0e68sBRgqO9q84+ll
+        O5/BkFKU2zowh3G7Lb/e3kOJEaza1/Eu8J0nZJDz9tbjVcW8S6q3ydjzqsEXeSN6ULcuP2dTVfZ3
+        qLuU1WNkdKcY5HY+e2qed7aCiPtLe7fMCQ/wf/YgH3c3nZ0rvav/B9Q5fNUnnVP8D7++ag+AbqUH
+        cEzh1P5Ca/E4fT2FkZ3lBkNbuIqHdT1osFY50OHTa1U+y4BsV+0uHFuohP2DYWt7I3J1JqgHuThS
+        uNPde7h907Bng7qMzLrdOWl8cpwkX6QqTGCDunTgIzuavZKN3kd8mmztURNu+lJHOfzZaITY3NeP
+        adZ7a3HreV9dPURk2e1CCXKnq/X7q+7qtzfopPCmNV2zdQfnV72ddlNDbWm2C+Zz3X74fgvHvQIQ
+        4w5fVdid1EXt5yYu1uj1XPY2Y5qbVZvdG5tKd16ieXg8wH6IMtm3dxRmHbrKmXfNuq2rySeBXJQL
+        yu1eSVI9zTYpLSVHuafLCDFeslxAOhBWPkYBnhRCVu0NIJzPczl+8wBO8Gvw5x7w/niVU0x7aGzy
+        9jUf9NqrgCux8hHG9jID/FBan+OxhAj3SgO8tV+TWlHltew073r9WH8wlckxe/bjhuzcBO8KKJ7P
+        YPiBWV0D4/RUAd8f9SOMYYbhBv2Fm+5S/gD2LD2AbXwzk/cKe2zD2sNkA7pCRSBnei60lzRl6iP5
+        j1XYn732PAf2XfwE5ZWgGtvJWWrvTgRcX94OS4u7XectBHLc3SZYDctZenFyks0saeVbDJVb2pL5
+        XdpleQF/lg+syqdoGpOoQRK/zBdBo+J9KBDIufQbpIiGdinU3rmZ/fnzBy1+ympBP8JVnZS+sZQi
+        1zZ5QQG5UHZ3WPxFZ51yf57WbIT7s/hLSa7u8QdrzHJ379KW4er0HrP9Ot/jkaw/8Z2iO92d46sE
+        aXaJNsqPvC0XdvkNUEXJfd02fbdB3s2/OABYsocrGiyXfJT+b0lpnPCByAsCac7XO0xA/OKDFB+4
+        y6vio7+w+kCi/sq9DsfT+4H5ZHN4jQrWVpurnrtBSWqgcgI/aOrW3s++yPRPUItZRQAxwdgs1/dQ
+        S/jdQlETP/B5NSulBxYvnB/rCAihPa93h/t/+niI/6qv5sX2/rUUn6NNpzMAsVrjH5JHmJ3xTQFA
+        qxDUZIt5zc480xkAhC1VoL88WgmAOFtpbz87lfyPg+BFD3Yi37WYg5SNx5Y8Kesa+m2DzAnL84Jr
+        TLt3JKbsnM6Kug8lWuadjb3ofOcABYf0/cwrYG4u16y9Pen1+O9TqZ9vCvBsG0kJsduzQ3M1vEvI
+        xpZcZKC9s9EPsIIW7uJilRn8ffduSB/le3FTx6++jUwrk70F4wMtUCLXzBc5Z9t8rXW301Px39+/
+        Hd4erHO/cGP7dXfjyXZjQtBQsr6XxBstWd5LYWosZLIjnQ0l8JKfTHu8fHuY5rbFlfk+RnMQbjmo
+        ezkJ0A5tKcT3cK6lxHvF7rcPstFjuLemG/oI+PHJWzfbgnmrkKeTFuUC4CwmHG7jMhMYJ58hugTm
+        vKJGerAiL7aJxH/hbSNeChQquPChbhvVrVwyscwLtaca+Pz0rEdadV533vJeKV7dSk1c4xp3zGfa
+        c/PxhNnnK+o1joaPYfema9dAe5lT7m5esml1sUz7fG5rt+WwaoCsM8+Xqcdgk5d/8nnB/+3DYaqz
+        u0sweK+vaqejPS+qw4APkSb9Ap1znEvqXqdvOw2y68H/5YCxivgic7tkJRZcUh+CaSfg+kceitmY
+        v0t83O/cCd4+vx5uKOaq3iTgyHQ+mGQ3yaAYOde58ILx7vWKtfHDqzdOba7T6U0uXiqBVD2r16ij
+        4dXF0VCIm8Psy8RVB8SHnHdYtIYCd4GAJlTCX/7l/wF2De6tjmQAAA==
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -180,9 +299,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Apr 2024 20:21:32 GMT
+      - Wed, 17 Apr 2024 16:43:18 GMT
       Etag:
-      - W/"2725-T4n9Btnw2jv62CbOcyoGpr0GJJw"
+      - W/"648e-k76Hijq+oGLG6HSSxeTTBMtZTLg"
       Server:
       - nginx/1.18.0 (Ubuntu)
       Transfer-Encoding:

--- a/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_price_performance_fetcher.yaml
+++ b/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_price_performance_fetcher.yaml
@@ -3,33 +3,33 @@ interactions:
     body: null
     headers:
       Accept:
-      - '*/*'
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
     method: GET
-    uri: https://financialmodelingprep.com/api/v3/stock-price-change/AAPL,SPY,QQQ,MSFT,AMZN,GOOG?apikey=MOCK_API_KEY
+    uri: https://financialmodelingprep.com/api/v3/stock-price-change/MSFT,AAPL,GOOG,SPY,AMZN,QQQ?apikey=MOCK_API_KEY
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WUvW5UMRCF+zzFautkNP/20K2ESENIVqEJEQWIkogCCiLEuzO+vr6JV2yxzZHv
-        er5zzvjxYrf7k7/dbv/z+enrj+/7N7v94XD3fn/ZVXqbCgEL2qpYU64QUD3MncfBmy6bFDEqscqy
-        yCQg5FJW0ZuIIBaGyLqqz7++pSwOZFbGbfTQ7idAkzo+l6aZg1kUGlM1jWmZNLaZsKmVGBiLjZGe
-        vvxu/ylsxYGLVUr97+X/nLi/ezgxgpL5xAhGNyxSJyMYSiUdg3QXApjqkHz1CysVVRtyNyGABOW1
-        BQUcC4+rFwfYoDriuHdxwATMJYYr3QBKT5W4DP+6AVXze2ItZ+mPx+MpPftUgxyfOUjLGGzAW8Y9
-        hujwFaK6j3MLfQW2GgNzjZ8BhX2MSiuoi9L2f4sWIMoxxU+YBzl0BN3phQlKIM70VgUCieMs/c39
-        u48TfraojK6O7EOrhtg2bsNyqFxpWgBM/6XUoS30AaVEDKnTK+aozFt/2/wZkxBuvVno3aEQT8kz
-        ZZwoL0n07ltmURXH1x1e1Kum+0x+Fv9w8+nDhC9QYzNx4aeMnxQ3uxuVgkQ56X1CsTllhK/5W32N
-        tlS7AaYZddmqQ2vUtmW64F/lnrv59nLY6gmG0bz7WQegXPGZn8RUpL0zLmcNuL69vT6pf6BOBchn
-        iavM3U8Adt2eqkUzMA6euk/5zEWGcBo/1bAp/lyIqlKnzW8uFX15kfuSt9XnzeO1/DWgFtJxtPNn
-        ZbFxX3z+BxdaXH0ABgAA
+        H4sIAAAAAAAAA3WUO29UMRCF+/yK1dbZ0TzsmTHdSog0LEkUmoAoQJREFFAQIf4743tt53phi23O
+        Xj/Od87449Vu9zt+u93+x/PTl+/f9q92+9PDm/f761Wl16EgMBs3JVflwKBSlPpXp6ohpESulL3J
+        UmWNxQX7aq0Sp1gtnJr2/PNriERgPpbSY0hJIGdW6dtVLRdApC7lx2U7AXbUfgZhVQsrkDt19enz
+        r7plbFf/IMs59D/X/wNwPN69nQAcCAqpbQkgKJkVk5kBgZsW3QI4GJgi9dULgUMOKop5InBwsOxe
+        tggYMpH27xYCcX3OPOg1BAgY4kTAKfgV5g5rJUASGRlwXNMvEri5vb2ZCUQHiLrX3KAkM++7L/4L
+        GAeVrX2Po+LIrfuIGqWUvvIlfys+F0ChAhn7VU1y9IQHusU+5QQsxgMdrqsZSJl6Gqt/pYQXfT/c
+        PZ7bpjIK2KsvkfA4qsXOqaQeSes9ok21pwxJaThcbYdD8tzLsWZOoLWmU+jRt/wyHotrk1qOUazV
+        NFmMobt0tYWOqWIrRhetH08f3v3jXWXUrEXuQmnUrLrKQLiZ0cVoAS00mrGYFwdBznPmzFGOqMLW
+        vTkkwTlzA89JpqEvCo7oPdtmHkUCu1gvanPvRnEni9egXPR/f39/9ughlvPk0THPyUcuKVpbZHr0
+        Yry15Ln0GlDGy7D6t9jwZbqp1ZvRR0n6xGPyMldeCCizzyOfMOZUGOf0LaWAj87V/NWnvzBMedH1
+        BQAA
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Headers:
       - X-Requested-With, content-type, auth-token, Authorization, stripe-signature,
-        APPS
+        APPS, publicauthkey, privateauthkey
       Access-Control-Allow-Methods:
       - GET, POST, OPTIONS
       Access-Control-Allow-Origin:
@@ -43,9 +43,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 31 Oct 2023 12:26:07 GMT
-      ETag:
-      - W/"600-x3+R/EIjLOnwqmRci/IeiPVQcrY"
+      - Tue, 16 Apr 2024 20:21:31 GMT
+      Etag:
+      - W/"5f5-YOfcGWSFlAMQeQP8Lw/jMZliWe8"
       Server:
       - nginx/1.18.0 (Ubuntu)
       Transfer-Encoding:

--- a/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_price_performance_fetcher.yaml
+++ b/openbb_platform/providers/fmp/tests/record/http/test_fmp_fetchers/test_fmp_price_performance_fetcher.yaml
@@ -9,21 +9,20 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: https://financialmodelingprep.com/api/v3/stock-price-change/MSFT,AAPL,GOOG,SPY,AMZN,QQQ?apikey=MOCK_API_KEY
+    uri: https://financialmodelingprep.com/api/v3/stock-price-change/AAPL,SPY,QQQ,MSFT,AMZN,GOOG?apikey=MOCK_API_KEY
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WUO29UMRCF+/yK1dbZ0TzsmTHdSog0LEkUmoAoQJREFFAQIf4743tt53phi23O
-        Xj/Od87449Vu9zt+u93+x/PTl+/f9q92+9PDm/f761Wl16EgMBs3JVflwKBSlPpXp6ohpESulL3J
-        UmWNxQX7aq0Sp1gtnJr2/PNriERgPpbSY0hJIGdW6dtVLRdApC7lx2U7AXbUfgZhVQsrkDt19enz
-        r7plbFf/IMs59D/X/wNwPN69nQAcCAqpbQkgKJkVk5kBgZsW3QI4GJgi9dULgUMOKop5InBwsOxe
-        tggYMpH27xYCcX3OPOg1BAgY4kTAKfgV5g5rJUASGRlwXNMvEri5vb2ZCUQHiLrX3KAkM++7L/4L
-        GAeVrX2Po+LIrfuIGqWUvvIlfys+F0ChAhn7VU1y9IQHusU+5QQsxgMdrqsZSJl6Gqt/pYQXfT/c
-        PZ7bpjIK2KsvkfA4qsXOqaQeSes9ok21pwxJaThcbYdD8tzLsWZOoLWmU+jRt/wyHotrk1qOUazV
-        NFmMobt0tYWOqWIrRhetH08f3v3jXWXUrEXuQmnUrLrKQLiZ0cVoAS00mrGYFwdBznPmzFGOqMLW
-        vTkkwTlzA89JpqEvCo7oPdtmHkUCu1gvanPvRnEni9egXPR/f39/9ughlvPk0THPyUcuKVpbZHr0
-        Yry15Ln0GlDGy7D6t9jwZbqp1ZvRR0n6xGPyMldeCCizzyOfMOZUGOf0LaWAj87V/NWnvzBMedH1
-        BQAA
+        H4sIAAAAAAAAA3WUP29VMQzF936KpzcXy/G/xGyVEF0obVWWghhAjFQMMFAhvjtO7nVKHnS4y1Gu
+        45/PcT6cHQ6/4jscjt8fHz5/+3p8eTheXNy8OZ5vankVygsEI227pENiEGw1T111iUC8IO0aD61C
+        M6yyazY0AW8iWe7xx5cuOjB58yx4H1qBVrHMel0igUYunK0MjQuIOWbBgl2tXqGiWbb48OlnL8kF
+        JY5HmyX03+f/47+7uT/Fr1QWeoJWeGobfgGXWvO+ga/QRD0JBn0RMEXLiWz0CtU0oQY7xZ1mtMIj
+        sFvLXwd8pU5ZdWEv1oAQ58U7O3IFi5HWZ8lvb29X8gJkJU1J4xWRs4mJjjwDMtAFlLEl04auYKiW
+        vU50xlmtd8/9BppzHOT9z9pmAgckVRBhmmMb6OwMDTWd2chrlDQx82fBr+5ev/vHc5mWpOkewzg1
+        vTTOAe2eh5VtSTwxOCGviS8IrmTp0UCXWKFGNut1TR2QbcZvS3yNguyr604t9uBpShu7xHpIbCGJ
+        Pu/7xdX7t6fGc8M18zFDL7asfEg6t2DQF4dIX8nOBn50q0XIFvwIs/ZV/hu/KvR858GBX4EYy7Lw
+        3WKvMjvZMh8vBWhMPq/eQx8LyL1spWfpL6+vLxd6BBLOLnSfhyPW1Aa8g7viEnqPRJ6GPmwuOse2
+        e0+AMbhZbnhv8X4YLvDcHxBss5UBqj2H+PT4DHxpGjFRzXlu9FZUYYCfffwDDUGZzesFAAA=
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -43,9 +42,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 16 Apr 2024 20:21:31 GMT
+      - Wed, 17 Apr 2024 16:43:17 GMT
       Etag:
-      - W/"5f5-YOfcGWSFlAMQeQP8Lw/jMZliWe8"
+      - W/"5eb-Y1janTBJnrcROzV/drQMXgAsvnA"
       Server:
       - nginx/1.18.0 (Ubuntu)
       Transfer-Encoding:

--- a/openbb_platform/providers/fmp/tests/test_fmp_fetchers.py
+++ b/openbb_platform/providers/fmp/tests/test_fmp_fetchers.py
@@ -652,7 +652,7 @@ def test_fmp_etf_countries_fetcher(credentials=test_credentials):
 @pytest.mark.record_http
 def test_fmp_etf_holdings_performance_fetcher(credentials=test_credentials):
     """Test FMP ETF holdings performance fetcher."""
-    params = {"symbol": "SILJ"}
+    params = {"symbol": "QQQ"}
 
     fetcher = FMPEtfHoldingsPerformanceFetcher()
     result = fetcher.test(params, credentials)


### PR DESCRIPTION
1. **Why**?:

    - For the endpoint: `obb.equity.price.performance(provider="fmp")` the URL string could be too long when passed a large list of symbols.

2. **What**? (1-3 sentences or a bullet point list):

    - This PR chunks the URL into groups of 200 symbols.
    - Add `to_upper()` validator for the symbol parameter of `obb.etf.holdings()`.
    - Clear "-" as a symbol from FMP response of ETF holdings, replacing with `None`.

3. **Impact** (1-2 sentences or a bullet point list):

    - Large lists of symbols can be passed to the endpoint, with FMP as the provider.
    - Upper case symbols are not required for ETF Holdings any more.
    - Deprecate `obb.etf.holdings_performance()` in favour of making the user define the list of symbols themselves and use `equity.price.performance()` instead.

4. **Testing Done**:

The the list of holdings tickers in IWM as the list, it creates an error.

Before:
```
ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: text/html', url=URL...
```
Where the root error code is: `414 Request-URI Too Large`

After:

![Screenshot 2024-04-16 at 12 35 28 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/4ce02859-d32a-449a-8d4e-c309900ac572)
