### PR TITLE
[BugFix] SEC ETF Holdings - Try Catch for RemoteDisconnect Error

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/models/etf_holdings.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/etf_holdings.py
@@ -2,6 +2,7 @@
 
 # pylint: disable =[unused-argument,too-many-locals,too-many-branches]
 
+import asyncio
 from datetime import date as dateType
 from typing import Any, Dict, List, Optional, Union
 from warnings import warn
@@ -329,9 +330,22 @@ class SecEtfHoldingsFetcher(
         **kwargs: Any,
     ) -> Dict:
         """Return the raw data from the SEC endpoint."""
-        filings = await get_nport_candidates(
-            symbol=query.symbol, use_cache=query.use_cache
-        )
+        # Implement a retry mechanism in case of RemoteDiconnected Error.
+        retries = 3
+        for i in range(retries):
+            filings = []
+            try:
+                filings = await get_nport_candidates(
+                    symbol=query.symbol, use_cache=query.use_cache
+                )
+                if filings:
+                    break
+            except Exception as e:
+                if i < retries - 1:
+                    warn(f"Error: {e}. Retrying...")
+                    asyncio.sleep(1)
+                    continue
+                raise e
         filing_candidates = pd.DataFrame.from_records(filings)
         if filing_candidates.empty:
             raise ValueError(f"No N-Port records found for {query.symbol}.")


### PR DESCRIPTION
1. **Why**?:

This is an attempt to mitigate a RemoteDisconnect error which can occasionally get raised from an SEC search query. In the handful of times I have encountered, the next request is successful. 

![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/ef77906f-ee6c-4feb-9ed8-f52a8b98d843)

2. **What**? (1-3 sentences or a bullet point list):

    - Implement up-to 3 retries with a one-second sleep. If a retry is successful, a warning will be set as a notification.

    - Example: "Updated the risk calculation algorithm to factor in real-time market fluctuations."

3. **Impact** (1-2 sentences or a bullet point list):

    - This may extend the timeout period, but if a response cannot be read within a couple of seconds, there is likely a network error. 

4. **Testing Done**:

    - Extremely hard to recreate,  @montezdesousa, are you able to reliably reproduce and/or does this resolve?