### PR TITLE
[Enhancement] - Sanitize sensitive data from `.cli.his`

### DIFF
--- a/cli/openbb_cli/config/completer.py
+++ b/cli/openbb_cli/config/completer.py
@@ -16,6 +16,7 @@ from typing import (
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion
 from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import AnyFormattedText
+from prompt_toolkit.history import FileHistory
 
 NestedDict = Mapping[str, Union[Any, Set[str], None, Completer]]
 
@@ -401,3 +402,26 @@ class NestedCompleter(Completer):
 
             # This is a WordCompleter
             yield from completer.get_completions(document, complete_event)
+
+
+class CustomFileHistory(FileHistory):
+    """Filtered file history."""
+
+    def sanitize_input(self, string: str) -> str:
+        """Sanitize sensitive information from the input string by parsing arguments."""
+        keywords = ["--password", "--email", "--pat"]
+        string_list = string.split(" ")
+
+        for kw in keywords:
+            if kw in string_list:
+                index = string_list.index(kw)
+                if len(string_list) > index + 1:
+                    string_list[index + 1] = "********"
+
+        result = " ".join(string_list)
+        return result
+
+    def store_string(self, string: str) -> None:
+        """Store string in history."""
+        string = self.sanitize_input(string)
+        super().store_string(string)

--- a/cli/openbb_cli/config/menu_text.py
+++ b/cli/openbb_cli/config/menu_text.py
@@ -204,7 +204,7 @@ class MenuText:
         """
         formatted_name = self._format_cmd_name(name)
         name_padding = (self.CMD_NAME_LENGTH - len(formatted_name)) * " "
-        providers = get_ordered_providers(f"{self.menu_path}{formatted_name}")
+        providers = get_ordered_providers(f"{self.menu_path}{name}")
         formatted_description = self._format_cmd_description(
             formatted_name,
             description,

--- a/cli/openbb_cli/session.py
+++ b/cli/openbb_cli/session.py
@@ -8,8 +8,8 @@ from openbb import obb
 from openbb_core.app.model.abstract.singleton import SingletonMeta
 from openbb_core.app.model.user_settings import UserSettings as User
 from prompt_toolkit import PromptSession
-from prompt_toolkit.history import FileHistory
 
+from openbb_cli.config.completer import CustomFileHistory
 from openbb_cli.config.console import Console
 from openbb_cli.config.constants import HIST_FILE_PROMPT
 from openbb_cli.config.style import Style
@@ -62,7 +62,7 @@ class Session(metaclass=SingletonMeta):
         try:
             if sys.stdin.isatty():
                 prompt_session: Optional[PromptSession] = PromptSession(
-                    history=FileHistory(str(HIST_FILE_PROMPT))
+                    history=CustomFileHistory(str(HIST_FILE_PROMPT))
                 )
             else:
                 prompt_session = None


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - The command history was saved locally with the login details not sanitized which could result in a security issue.

2. **What**? (1-3 sentences or a bullet point list):

    - Introduces sanitization to protected keywords `email`, `password` and `pat`.
    - The user can still use the upper arrow key to get his command unsanitized while the session is still lasting. After restarting the CLI, it can't be grabbed anymore in an unsanitized form.
    - Fix long command names not showing providers

3. **Impact** (1-2 sentences or a bullet point list):

    - Higher security.

4. **Testing Done**:

    - Ensured it works by calling the `login` command and checking the local file.
