### PR TITLE
[Feature] EconDB Main Indicators

### DIFF
--- a/openbb_platform/extensions/economy/integration/test_economy_api.py
+++ b/openbb_platform/extensions/economy/integration/test_economy_api.py
@@ -576,6 +576,19 @@ def test_economy_fred_regional(params, headers):
                 "start_date": "2022-01-01",
                 "end_date": "2024-01-01",
                 "use_cache": False,
+                "frequency": None,
+            }
+        ),
+        (
+            {
+                "provider": "econdb",
+                "country": None,
+                "symbol": "MAIN",
+                "transform": None,
+                "start_date": "2022-01-01",
+                "end_date": "2024-01-01",
+                "use_cache": False,
+                "frequency": "quarter",
             }
         ),
     ],

--- a/openbb_platform/extensions/economy/integration/test_economy_python.py
+++ b/openbb_platform/extensions/economy/integration/test_economy_python.py
@@ -565,6 +565,19 @@ def test_economy_available_indicators(params, obb):
                 "start_date": "2022-01-01",
                 "end_date": "2024-01-01",
                 "use_cache": False,
+                "frequency": None,
+            }
+        ),
+        (
+            {
+                "provider": "econdb",
+                "country": None,
+                "symbol": "MAIN",
+                "transform": None,
+                "start_date": "2022-01-01",
+                "end_date": "2024-01-01",
+                "use_cache": False,
+                "frequency": "quarter",
             }
         ),
     ],

--- a/openbb_platform/extensions/economy/openbb_economy/economy_router.py
+++ b/openbb_platform/extensions/economy/openbb_economy/economy_router.py
@@ -362,6 +362,10 @@ async def available_indicators(
                 "provider": "econdb",
             },
         ),
+        APIEx(
+            description="Use the `main` symbol to get the group of main indicators for a country.",
+            parameters={"provider": "econdb", "symbol": "main", "country": "eu"},
+        ),
     ],
 )
 async def indicators(

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -4108,7 +4108,7 @@
                 "message": null
             },
             "description": "Get economic indicators by country and indicator.",
-            "examples": "\nExamples\n--------\n\n```python\nfrom openbb import obb\nobb.economy.indicators(provider='econdb', symbol='PCOCO')\n# Enter the country as the full name, or iso code. Use `available_indicators()` to get a list of supported indicators from EconDB.\nobb.economy.indicators(symbol='CPI', country='united_states,jp', provider='econdb')\n```\n\n",
+            "examples": "\nExamples\n--------\n\n```python\nfrom openbb import obb\nobb.economy.indicators(provider='econdb', symbol='PCOCO')\n# Enter the country as the full name, or iso code. Use `available_indicators()` to get a list of supported indicators from EconDB.\nobb.economy.indicators(symbol='CPI', country='united_states,jp', provider='econdb')\n# Use the `main` symbol to get the group of main indicators for a country.\nobb.economy.indicators(provider='econdb', symbol='main', country='eu')\n```\n\n",
             "parameters": {
                 "standard": [
                     {
@@ -4151,14 +4151,21 @@
                     {
                         "name": "transform",
                         "type": "Literal['toya', 'tpop', 'tusd', 'tpgp']",
-                        "description": "The transformation to apply to the data, default is None.     tpop: Change from previous period     toya: Change from one year ago     tusd: Values as US dollars     tpgp: Values as a percent of GDP    Only 'tpop' and 'toya' are applicable to all indicators.   Applying transformations across multiple indicators/countries   may produce unexpected results.   This is because not all indicators are compatible with all transformations,   and the original units and scale differ between entities.   `tusd` should only be used where values are currencies.",
+                        "description": "The transformation to apply to the data, default is None.   tpop: Change from previous period   toya: Change from one year ago   tusd: Values as US dollars   tpgp: Values as a percent of GDP   Only 'tpop' and 'toya' are applicable to all indicators. Applying transformations across multiple indicators/countries may produce unexpected results.   This is because not all indicators are compatible with all transformations, and the original units and scale differ between entities.   `tusd` should only be used where values are currencies.",
                         "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "frequency",
+                        "type": "Literal['annual', 'quarter', 'month']",
+                        "description": "The frequency of the data, default is 'quarter'. Only valid when 'symbol' is 'main'.",
+                        "default": "quarter",
                         "optional": true
                     },
                     {
                         "name": "use_cache",
                         "type": "bool",
-                        "description": "If True, the request will be cached for one day.Using cache is recommended to avoid needlessly requesting the same data.",
+                        "description": "If True, the request will be cached for one day. Using cache is recommended to avoid needlessly requesting the same data.",
                         "default": true,
                         "optional": true
                     }
@@ -16024,7 +16031,7 @@
                 "sec": [
                     {
                         "name": "cik",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "Lookup filings by Central Index Key (CIK) instead of by symbol.",
                         "default": null,
                         "optional": true
@@ -16174,7 +16181,7 @@
                     },
                     {
                         "name": "act",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The SEC Act number.",
                         "default": null,
                         "optional": true
@@ -16202,42 +16209,42 @@
                     },
                     {
                         "name": "accession_number",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The accession number.",
                         "default": null,
                         "optional": true
                     },
                     {
                         "name": "file_number",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The file number.",
                         "default": null,
                         "optional": true
                     },
                     {
                         "name": "film_number",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The film number.",
                         "default": null,
                         "optional": true
                     },
                     {
                         "name": "is_inline_xbrl",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "Whether the filing is an inline XBRL filing.",
                         "default": null,
                         "optional": true
                     },
                     {
                         "name": "is_xbrl",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "Whether the filing is an XBRL filing.",
                         "default": null,
                         "optional": true
                     },
                     {
                         "name": "size",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The size of the filing.",
                         "default": null,
                         "optional": true
@@ -23630,7 +23637,7 @@
                     },
                     {
                         "name": "rate_tenor_unit_rec",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The rate tenor unit for receivable portion of the swap.",
                         "default": null,
                         "optional": true
@@ -23644,7 +23651,7 @@
                     },
                     {
                         "name": "reset_date_unit_rec",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The reset date unit for receivable portion of the swap.",
                         "default": null,
                         "optional": true
@@ -23693,7 +23700,7 @@
                     },
                     {
                         "name": "rate_tenor_unit_pmnt",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The rate tenor unit for payment portion of the swap.",
                         "default": null,
                         "optional": true
@@ -23707,7 +23714,7 @@
                     },
                     {
                         "name": "reset_date_unit_pmnt",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "The reset date unit for payment portion of the swap.",
                         "default": null,
                         "optional": true
@@ -26788,7 +26795,71 @@
                     }
                 ],
                 "fmp": [],
-                "intrinio": [],
+                "intrinio": [
+                    {
+                        "name": "source",
+                        "type": "Literal['yahoo', 'moody', 'moody_us_news', 'moody_us_press_releases']",
+                        "description": "The source of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "sentiment",
+                        "type": "Literal['positive', 'neutral', 'negative']",
+                        "description": "Return news only from this source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "language",
+                        "type": "str",
+                        "description": "Filter by language. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "topic",
+                        "type": "str",
+                        "description": "Filter by topic. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "word_count_greater_than",
+                        "type": "int",
+                        "description": "News stories will have a word count greater than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "word_count_less_than",
+                        "type": "int",
+                        "description": "News stories will have a word count less than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "is_spam",
+                        "type": "bool",
+                        "description": "Filter whether it is marked as spam or not. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "business_relevance_greater_than",
+                        "type": "float",
+                        "description": "News stories will have a business relevance score more than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "business_relevance_less_than",
+                        "type": "float",
+                        "description": "News stories will have a business relevance score less than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    }
+                ],
                 "tiingo": [
                     {
                         "name": "offset",
@@ -26935,6 +27006,76 @@
                 ],
                 "intrinio": [
                     {
+                        "name": "source",
+                        "type": "str",
+                        "description": "The source of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "summary",
+                        "type": "str",
+                        "description": "The summary of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "topics",
+                        "type": "str",
+                        "description": "The topics related to the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "word_count",
+                        "type": "int",
+                        "description": "The word count of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "business_relevance",
+                        "type": "float",
+                        "description": "How strongly correlated the news article is to the business",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "sentiment",
+                        "type": "str",
+                        "description": "The sentiment of the news article - i.e, negative, positive.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "sentiment_confidence",
+                        "type": "float",
+                        "description": "The confidence score of the sentiment rating.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "language",
+                        "type": "str",
+                        "description": "The language of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "spam",
+                        "type": "bool",
+                        "description": "Whether the news article is spam.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "copyright",
+                        "type": "str",
+                        "description": "The copyright notice of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
                         "name": "id",
                         "type": "str",
                         "description": "Article ID.",
@@ -26943,10 +27084,17 @@
                     },
                     {
                         "name": "company",
-                        "type": "Dict[str, Any]",
-                        "description": "Company details related to the news article.",
-                        "default": "",
-                        "optional": false
+                        "type": "IntrinioCompany",
+                        "description": "The Intrinio Company object. Contains details company reference data.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "security",
+                        "type": "IntrinioSecurity",
+                        "description": "The Intrinio Security object. Contains the security details related to the news article.",
+                        "default": null,
+                        "optional": true
                     }
                 ],
                 "tiingo": [
@@ -27129,7 +27277,71 @@
                         "optional": true
                     }
                 ],
-                "intrinio": [],
+                "intrinio": [
+                    {
+                        "name": "source",
+                        "type": "Literal['yahoo', 'moody', 'moody_us_news', 'moody_us_press_releases']",
+                        "description": "The source of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "sentiment",
+                        "type": "Literal['positive', 'neutral', 'negative']",
+                        "description": "Return news only from this source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "language",
+                        "type": "str",
+                        "description": "Filter by language. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "topic",
+                        "type": "str",
+                        "description": "Filter by topic. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "word_count_greater_than",
+                        "type": "int",
+                        "description": "News stories will have a word count greater than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "word_count_less_than",
+                        "type": "int",
+                        "description": "News stories will have a word count less than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "is_spam",
+                        "type": "bool",
+                        "description": "Filter whether it is marked as spam or not. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "business_relevance_greater_than",
+                        "type": "float",
+                        "description": "News stories will have a business relevance score more than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "business_relevance_less_than",
+                        "type": "float",
+                        "description": "News stories will have a business relevance score less than this value. Unsupported for yahoo source.",
+                        "default": null,
+                        "optional": true
+                    }
+                ],
                 "polygon": [
                     {
                         "name": "order",
@@ -27293,11 +27505,88 @@
                 ],
                 "intrinio": [
                     {
+                        "name": "source",
+                        "type": "str",
+                        "description": "The source of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "summary",
+                        "type": "str",
+                        "description": "The summary of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "topics",
+                        "type": "str",
+                        "description": "The topics related to the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "word_count",
+                        "type": "int",
+                        "description": "The word count of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "business_relevance",
+                        "type": "float",
+                        "description": "How strongly correlated the news article is to the business",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "sentiment",
+                        "type": "str",
+                        "description": "The sentiment of the news article - i.e, negative, positive.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "sentiment_confidence",
+                        "type": "float",
+                        "description": "The confidence score of the sentiment rating.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "language",
+                        "type": "str",
+                        "description": "The language of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "spam",
+                        "type": "bool",
+                        "description": "Whether the news article is spam.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
+                        "name": "copyright",
+                        "type": "str",
+                        "description": "The copyright notice of the news article.",
+                        "default": null,
+                        "optional": true
+                    },
+                    {
                         "name": "id",
                         "type": "str",
                         "description": "Article ID.",
                         "default": "",
                         "optional": false
+                    },
+                    {
+                        "name": "security",
+                        "type": "IntrinioSecurity",
+                        "description": "The Intrinio Security object. Contains the security details related to the news article.",
+                        "default": null,
+                        "optional": true
                     }
                 ],
                 "polygon": [
@@ -27530,7 +27819,7 @@
                     },
                     {
                         "name": "cik",
-                        "type": "Union[str, int]",
+                        "type": "Union[int, str]",
                         "description": "Central Index Key (CIK)",
                         "default": null,
                         "optional": true

--- a/openbb_platform/openbb/package/economy.py
+++ b/openbb_platform/openbb/package/economy.py
@@ -1083,19 +1083,21 @@ class ROUTER_economy(Container):
             The provider to use for the query, by default None.
             If None, the provider specified in defaults is selected or 'econdb' if there is
             no default.
-        transform : Literal['toya', 'tpop', 'tusd', 'tpgp']
+        transform : Optional[Literal['toya', 'tpop', 'tusd', 'tpgp']]
             The transformation to apply to the data, default is None.
 
-                tpop: Change from previous period
-                toya: Change from one year ago
-                tusd: Values as US dollars
-                tpgp: Values as a percent of GDP
+            tpop: Change from previous period
+            toya: Change from one year ago
+            tusd: Values as US dollars
+            tpgp: Values as a percent of GDP
 
-             Only 'tpop' and 'toya' are applicable to all indicators.     Applying transformations across multiple indicators/countries     may produce unexpected results.
-             This is because not all indicators are compatible with all transformations,     and the original units and scale differ between entities.
-             `tusd` should only be used where values are currencies. (provider: econdb)
+            Only 'tpop' and 'toya' are applicable to all indicators. Applying transformations across multiple indicators/countries may produce unexpected results.
+            This is because not all indicators are compatible with all transformations, and the original units and scale differ between entities.
+            `tusd` should only be used where values are currencies. (provider: econdb)
+        frequency : Literal['annual', 'quarter', 'month']
+            The frequency of the data, default is 'quarter'. Only valid when 'symbol' is 'main'. (provider: econdb)
         use_cache : bool
-            If True, the request will be cached for one day.Using cache is recommended to avoid needlessly requesting the same data. (provider: econdb)
+            If True, the request will be cached for one day. Using cache is recommended to avoid needlessly requesting the same data. (provider: econdb)
 
         Returns
         -------
@@ -1130,6 +1132,8 @@ class ROUTER_economy(Container):
         >>> obb.economy.indicators(provider='econdb', symbol='PCOCO')
         >>> # Enter the country as the full name, or iso code. Use `available_indicators()` to get a list of supported indicators from EconDB.
         >>> obb.economy.indicators(symbol='CPI', country='united_states,jp', provider='econdb')
+        >>> # Use the `main` symbol to get the group of main indicators for a country.
+        >>> obb.economy.indicators(provider='econdb', symbol='main', country='eu')
         """  # noqa: E501
 
         return self._run(

--- a/openbb_platform/providers/econdb/openbb_econdb/models/economic_indicators.py
+++ b/openbb_platform/providers/econdb/openbb_econdb/models/economic_indicators.py
@@ -3,7 +3,7 @@
 # pylint: disable=unused-argument
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 from warnings import warn
 
 from openbb_core.provider.abstract.annotated_result import AnnotatedResult
@@ -14,6 +14,7 @@ from openbb_core.provider.standard_models.economic_indicators import (
 )
 from openbb_core.provider.utils.errors import EmptyDataError
 from openbb_econdb.utils import helpers
+from openbb_econdb.utils.main_indicators import get_main_indicators
 from pandas import DataFrame, concat
 from pydantic import Field, field_validator
 
@@ -28,27 +29,32 @@ class EconDbEconomicIndicatorsQueryParams(EconomicIndicatorsQueryParams):
         "country": ["multiple_items_allowed"],
     }
 
-    transform: Literal["toya", "tpop", "tusd", "tpgp"] = Field(
+    transform: Union[None, Literal["toya", "tpop", "tusd", "tpgp"]] = Field(
         default=None,
         description="The transformation to apply to the data, default is None."
         + "\n"
-        + "\n        tpop: Change from previous period"
-        + "\n        toya: Change from one year ago"
-        + "\n        tusd: Values as US dollars"
-        + "\n        tpgp: Values as a percent of GDP"
+        + "\n    tpop: Change from previous period"
+        + "\n    toya: Change from one year ago"
+        + "\n    tusd: Values as US dollars"
+        + "\n    tpgp: Values as a percent of GDP"
         + "\n"
         + "\n"
-        + "     Only 'tpop' and 'toya' are applicable to all indicators."
-        + "     Applying transformations across multiple indicators/countries"
-        + "     may produce unexpected results."
-        + "\n     This is because not all indicators are compatible with all transformations,"
-        + "     and the original units and scale differ between entities."
-        + "\n     `tusd` should only be used where values are currencies.",
+        + "    Only 'tpop' and 'toya' are applicable to all indicators."
+        + " Applying transformations across multiple indicators/countries"
+        + " may produce unexpected results."
+        + "\n    This is because not all indicators are compatible with all transformations,"
+        + " and the original units and scale differ between entities."
+        + "\n    `tusd` should only be used where values are currencies.",
+    )
+    frequency: Literal["annual", "quarter", "month"] = Field(
+        default="quarter",
+        description="The frequency of the data, default is 'quarter'."
+        + " Only valid when 'symbol' is 'main'.",
     )
     use_cache: bool = Field(
         default=True,
         description="If True, the request will be cached for one day."
-        + "Using cache is recommended to avoid needlessly requesting the same data.",
+        + " Using cache is recommended to avoid needlessly requesting the same data.",
     )
 
     @field_validator("country", mode="before", check_fields=False)
@@ -89,12 +95,20 @@ class EconDbEconomicIndicatorsQueryParams(EconomicIndicatorsQueryParams):
     @classmethod
     def validate_symbols(cls, v):
         """Validate each symbol to check if it is a valid indicator."""
+        if not v:
+            v = "main"
         symbols = v if isinstance(v, list) else v.split(",")
         new_symbols: List[str] = []
         for symbol in symbols:
             if "_" in symbol:
                 new_symbols.append(symbol)
                 continue
+            if symbol.upper() == "MAIN":
+                if len(symbols) > 1:
+                    raise ValueError(
+                        "The 'main' indicator cannot be combined with other indicators."
+                    )
+                return symbol.upper()
             if not any(
                 (
                     symbol.upper().startswith(indicator)
@@ -135,6 +149,15 @@ class EconDbEconomicIndicatorsFetcher(
             ).date()
         if new_params.get("end_date") is None:
             new_params["end_date"] = datetime.today().date()
+        countries = new_params.get("country")
+        if (
+            countries is not None
+            and len(countries.split(",")) > 1
+            and new_params.get("symbol").upper() == "MAIN"
+        ):
+            raise ValueError(
+                "The 'main' indicator cannot be combined with multiple countries."
+            )
         return EconDbEconomicIndicatorsQueryParams(**new_params)
 
     @staticmethod
@@ -144,6 +167,15 @@ class EconDbEconomicIndicatorsFetcher(
         **kwargs: Any,
     ) -> List[Dict]:
         """Extract the data."""
+        if query.symbol == "MAIN":
+            query.country = query.country.upper() if query.country else "US"
+            return await get_main_indicators(
+                query.country,
+                query.start_date.strftime("%Y-%m-%d"),
+                query.end_date.strftime("%Y-%m-%d"),
+                query.frequency,
+                query.transform,
+            )
         token = credentials.get("econdb_api_key", "")  # type: ignore
         # Attempt to create a temporary token if one is not supplied.
         if not token:
@@ -299,6 +331,14 @@ class EconDbEconomicIndicatorsFetcher(
         **kwargs: Any,
     ) -> AnnotatedResult[List[EconDbEconomicIndicatorsData]]:
         """Transform the data."""
+        if query.symbol == "MAIN":
+            return AnnotatedResult(
+                result=[
+                    EconDbEconomicIndicatorsData.model_validate(r)
+                    for r in data[0].get("records", [])
+                ],
+                metadata={query.country: data[0].get("metadata", [])},
+            )
         output = DataFrame()
         metadata = {}
         for d in data:

--- a/openbb_platform/providers/econdb/openbb_econdb/utils/main_indicators.py
+++ b/openbb_platform/providers/econdb/openbb_econdb/utils/main_indicators.py
@@ -1,0 +1,227 @@
+"""Main Indicators"""
+
+from datetime import datetime, timedelta
+from typing import Dict, List, Literal
+
+from aiohttp_client_cache import SQLiteBackend
+from aiohttp_client_cache.session import CachedSession
+from numpy import arange
+from openbb_core.app.utils import get_user_cache_directory
+from openbb_core.provider.utils.helpers import amake_request
+from openbb_econdb.utils.helpers import COUNTRY_MAP, THREE_LETTER_ISO_MAP
+from pandas import Categorical, DataFrame, Series, concat, to_datetime
+
+trends_transform_labels_dict = {
+    1: "Change from previous period.",
+    2: "Change from one year ago.",
+    3: "Level",
+    9: "Level (USD)",
+}
+trends_freq_dict = {
+    "annual": "Y",
+    "quarter": "Q",
+    "month": "M",
+}
+trends_transform_dict = {
+    "tpop": 1,
+    "toya": 2,
+    "level": 3,
+    "tusd": 9,
+    None: 3,
+}
+
+main_indicators_order = [
+    "RGDP",
+    "RPRC",
+    "RPUC",
+    "RGFCF",
+    "REXP",
+    "RIMP",
+    "GDP",
+    "PRC",
+    "PUC",
+    "GFCF",
+    "EXP",
+    "IMP",
+    "CPI",
+    "PPI",
+    "CORE",
+    "URATE",
+    "EMP",
+    "ACPOP",
+    "RETA",
+    "CONF",
+    "IP",
+    "CP",
+    "GBAL",
+    "GREV",
+    "GSPE",
+    "GDEBT",
+    "CA",
+    "TB",
+    "NIIP",
+    "IIPA",
+    "IIPL",
+    "Y10YD",
+    "M3YD",
+    "HOU",
+    "OILPROD",
+    "POP",
+]
+
+
+async def fetch_data(url, use_cache: bool = True):
+    """Fetch the data with or without the cached session object."""
+    if use_cache is True:
+        cache_dir = f"{get_user_cache_directory()}/http/econdb_main_indicators"
+        async with CachedSession(
+            cache=SQLiteBackend(cache_dir, expire_after=3600 * 24)
+        ) as session:
+            try:
+                response = await amake_request(url, session=session)
+            finally:
+                await session.close()
+    else:
+        response = await amake_request(url)
+
+    return response
+
+
+async def get_main_indicators(  # pylint: disable=R0913,R0914,R0915
+    country: str = "US",
+    start_date: str = (datetime.now() - timedelta(weeks=52 * 3)).strftime("%Y-%m-%d"),
+    end_date: str = datetime.now().strftime("%Y-%m-%d"),
+    frequency: Literal["annual", "quarter", "month"] = "quarter",
+    transform: Literal["tpop", "toya", "level", "tusd", None] = "toya",
+    use_cache: bool = True,
+) -> List[Dict]:
+    """Get the main indicators for a given country."""
+    freq = trends_freq_dict.get(frequency)
+    transform = trends_transform_dict.get(transform)  # type: ignore
+    if len(country) == 3:
+        country = THREE_LETTER_ISO_MAP.get(country.upper())
+        if not country:
+            raise ValueError(f"Error: Invalid country code -> {country}")
+    if country in COUNTRY_MAP:
+        country = COUNTRY_MAP.get(country)
+    if len(country) != 2:
+        raise ValueError(
+            f"Error: Please supply a 2-Letter ISO Country Code -> {country}"
+        )
+    if country not in COUNTRY_MAP.values():
+        raise ValueError(f"Error: Invalid country code -> {country}")
+    parents_url = (
+        "https://www.econdb.com/trends/country_forecast/"
+        + f"?country={country}&freq={freq}&transform={transform}"
+        + f"&dateStart={start_date}&dateEnd={end_date}"
+    )
+    r = await fetch_data(parents_url, use_cache)
+    row_names = r.get("row_names")
+    row_symbols = []
+    row_is_parent = []
+    row_symbols = [d["code"] for d in row_names]
+    row_is_parent = [d["is_parent"] for d in row_names]
+    parent_map = {d["code"]: d["is_parent"] for d in row_names}
+    units_col = r.get("units_col")
+    metadata = r.get("footnote")
+    row_names = r.get("row_names")
+    row_name_map = {d["code"]: d["verbose"].title() for d in row_names}
+    row_units_dict = dict(zip(row_symbols, units_col))
+    units_df = concat([Series(units_col), Series(row_is_parent)], axis=1)
+    units_df.columns = ["units", "is_parent"]
+    df = DataFrame(r["data"]).set_index("indicator")
+    df = df.pivot(columns="obs_time", values="obs_value").filter(
+        items=row_symbols, axis=0
+    )
+    df["units"] = df.index.map(row_units_dict.get)
+    df["is_parent"] = df.index.map(parent_map.get)
+    df = df.set_index("is_parent", append=True)
+
+    async def get_children(  # pylint: disable=R0913
+        parent, country, freq, transform, start_date, end_date, use_cache
+    ) -> DataFrame:
+        """Get the child elements for the main indicator symbols."""
+        children_url = (
+            "https://www.econdb.com/trends/get_topic_children/"
+            + f"?country={country}&agency=3&freq={freq}&transform={transform}"
+            + f"&parent_id={parent}&dateStart={start_date}&dateEnd={end_date}"
+        )
+        child_r = await fetch_data(children_url, use_cache)
+        row_names = child_r.get("row_names")
+        row_symbols = []
+        row_symbols = [d["code"] for d in row_names]
+        units_col = child_r.get("units_col")
+        metadata.extend(child_r.get("footnote"))
+        row_names = child_r.get("row_names")
+        row_name_map.update({d["code"]: d["verbose"].title() for d in row_names})
+        row_units_dict = dict(zip(row_symbols, units_col))
+        child_df = DataFrame(child_r["data"]).set_index("indicator")
+        child_df = child_df.pivot(columns="obs_time", values="obs_value").filter(
+            items=row_symbols, axis=0
+        )
+        child_df["units"] = child_df.index.map(row_units_dict.get)
+        # Set 'units' to 'Index' when the index is 'CONF'
+        if "CONF" in child_df.index and child_df.loc["CONF", "units"] == "..":
+            child_df.loc["CONF", "units"] = "Index"
+        child_df["is_parent"] = parent
+        child_df = child_df.reset_index()
+        child_df["name"] = child_df["indicator"].map(row_name_map)
+        return child_df
+
+    new_df = df.reset_index()
+    has_children = new_df[
+        new_df["is_parent"] == True  # noqa pylint: disable=C0121
+    ].indicator.to_list()
+
+    async def append_children(  # pylint: disable=R0913
+        df, parent, country, freq, transform, start_date, end_date, use_cache
+    ):
+        """Get the child element and insert it below the parent row."""
+        temp = DataFrame()
+        try:
+            children = await get_children(
+                parent, country, freq, transform, start_date, end_date, use_cache
+            )
+        except Exception as _:  # pylint: disable=W0718
+            return df
+        idx = df[df["indicator"] == parent].index[0]
+        df1 = df[df.index <= idx]
+        df2 = df[df.index > idx]
+        temp = concat([df1, children, df2])
+        return temp
+
+    # Get the child elements for each parent.
+    for parent in has_children:
+        new_df = await append_children(
+            new_df, parent, country, freq, transform, start_date, end_date, use_cache
+        )
+
+    # Cast the shape, specify the order and flatten for output.
+    new_df["name"] = new_df["indicator"].map(row_name_map)
+    new_df.set_index(["indicator", "is_parent", "name", "units"], inplace=True)
+    new_df.columns = new_df.columns
+    new_df.columns = [to_datetime(d).strftime("%Y-%m-%d") for d in new_df.columns]
+    for col in new_df.columns:
+        new_df[col] = new_df[col].astype(str).str.replace(" ", "").astype(float)
+    new_df = new_df.apply(lambda row: row / 100 if "%" in row.name[3] else row, axis=1)
+    new_df = new_df.iloc[:, ::-1]
+    new_df = new_df.fillna("N/A").replace("N/A", None)
+    output = new_df
+    output.columns.name = "date"
+    output = output.reset_index()
+    filtered_df = output[output["indicator"].isin(main_indicators_order)].copy()
+    filtered_df["indicator"] = Categorical(
+        filtered_df["indicator"], categories=main_indicators_order, ordered=True
+    )
+    filtered_df.sort_values("indicator", inplace=True)
+    output = filtered_df
+    output.set_index(["indicator", "is_parent", "name", "units"], inplace=True)
+    output["index_order"] = arange(len(output))
+    output = output.reset_index().melt(
+        id_vars=["index_order", "indicator", "is_parent", "name", "units"],
+        var_name="date",
+        value_name="value",
+    )
+    output = output.rename(columns={"indicator": "symbol_root"})
+    results = {"records": output.to_dict(orient="records"), "metadata": metadata}
+    return [results]


### PR DESCRIPTION
1. **Why**?:

    - A method for recreating this view was requested by @minhhoang1023
  
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/55c6f1bf-dc11-4bc9-a29e-7c15dcd81eb9)

2. **What**?:

    - This adds a custom 'symbol', `main`, compatible with a single country.
    - It returns as a pivot table.
    - Adds a `frequency` parameter that is only active when `symbol='main'`
 
![Screenshot 2024-05-05 at 9 02 20 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/2f42e252-677d-4a1f-b0e0-dd1bc08a6c0e)
    - To rebuild as the example:
 
![Screenshot 2024-05-05 at 9 04 15 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/e2b918df-9121-4128-858c-b545f0864eaf)

3. **Impact**:

    - No impact on default states or changes to returned fields.
    - This requires a separate extraction process with custom parsing.
    - Multiple countries not allowed when `symbol='main'`.
    - Multiple symbols not allowed when `symbol='main'`.

4. **Testing Done**:

    - Additional integration tests added.
    - Specific unit tests cannot be added at this time because current integration tests do not allow differences between entered parameter values and executed ones (transformed)
      - The URL will have a different value for `transform` than is entered by the user.
    - The `transform` parameter does not transform every item in the `main` grouping. The `units` col

```
obb.economy.indicators("main", country="eu,jp")
OpenBBError: The 'main' indicator cannot be combined with multiple countries.
```

```
OpenBBError: 1 validation error for EconDbEconomicIndicatorsQueryParams
symbol
  Value error, The 'main' indicator cannot be combined with other indicators. [type=value_error, input_value='main,gdp', input_type=str]
    For further information visit https://errors.pydantic.dev/2.7/v/value_error
```
