### PR TITLE
[Feature] Fallback to to_df() method when results are a string

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/obbject.py
+++ b/openbb_platform/core/openbb_core/app/model/obbject.py
@@ -105,6 +105,9 @@ class OBBject(Tagged, Generic[T]):
         - Dict[str, List]
         - Dict[str, BaseModel]
 
+        Other supported formats:
+        - str
+
         Parameters
         ----------
         index : Optional[str]
@@ -155,6 +158,9 @@ class OBBject(Tagged, Generic[T]):
                 dt: Union[List[Data], Data] = res  # type: ignore
                 df = basemodel_to_df(dt, index)
                 sort_columns = False
+            # str
+            elif isinstance(res, str):
+                df = pd.DataFrame([res])
             # List[List | str | int | float] | Dict[str, Dict | List | BaseModel]
             else:
                 try:


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - So that the `to_df()` method doesn't break if the results are a string.

2. **What**? (1-3 sentences or a bullet point list):

    - Wraps the string in a list so that it's data framable.

3. **Impact** (1-2 sentences or a bullet point list):

    - Minor UX improvement.

4. **Testing Done**:

    - `res = obb.equity.price.historical(...)`
    - `res.results = "Hello!"`
    - `res.to_df()`
