### PR TITLE
[BugFix] - Case insensitive credentials

### DIFF
--- a/assets/extensions/provider.json
+++ b/assets/extensions/provider.json
@@ -160,7 +160,7 @@
     },
     {
         "packageName": "openbb-polygon",
-        "reprName": "Polygon",
+        "reprName": "Polygon.io",
         "description": "The Polygon.io Stocks API provides REST endpoints that let you query\nthe latest market data from all US stock exchanges. You can also find data on\ncompany financials, stock market holidays, corporate actions, and more.",
         "credentials": [
             "polygon_api_key"

--- a/openbb_platform/core/openbb_core/app/model/credentials.py
+++ b/openbb_platform/core/openbb_core/app/model/credentials.py
@@ -52,7 +52,7 @@ class CredentialsLoader:
                 formatted[c] = (
                     Optional[OBBSecretStr],
                     Field(
-                        default=None, description=origin
+                        default=None, description=origin, alias=c.upper()
                     ),  # register the credential origin (obbject, providers)
                 )
 
@@ -88,7 +88,7 @@ class CredentialsLoader:
         self.from_obbject()
         return create_model(  # type: ignore
             "Credentials",
-            __config__=ConfigDict(validate_assignment=True),
+            __config__=ConfigDict(validate_assignment=True, populate_by_name=True),
             **self.prepare(self.credentials),
         )
 

--- a/openbb_platform/core/openbb_core/app/service/hub_service.py
+++ b/openbb_platform/core/openbb_core/app/service/hub_service.py
@@ -253,7 +253,7 @@ class HubService:
         settings = self._hub_user_settings or HubUserSettings()
         for v4_k, v in sorted(credentials.items()):
             v3_k = self.V4TOV3.get(v4_k, None)
-            # If v3 key was there, we keep it
+            # If v3 key was in the hub already, we keep it
             k = v3_k if v3_k in settings.features_keys else v4_k
             settings.features_keys[k] = v
         return settings

--- a/openbb_platform/providers/polygon/openbb_polygon/__init__.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/__init__.py
@@ -39,7 +39,7 @@ company financials, stock market holidays, corporate actions, and more.""",
         "MarketIndices": PolygonIndexHistoricalFetcher,
         "MarketSnapshots": PolygonMarketSnapshotsFetcher,
     },
-    repr_name="Polygon",
+    repr_name="Polygon.io",
     v3_credentials=["API_POLYGON_KEY"],
     instructions='Go to: https://polygon.io\n\n![Polygon](https://user-images.githubusercontent.com/46355364/207825623-fcd7f0a3-131a-4294-808c-754c13e38e2a.png)\n\nClick on, "Get your Free API Key".\n\n![Polygon](https://user-images.githubusercontent.com/46355364/207825952-ca5540ec-6ed2-4cef-a0ed-bb50b813932c.png)\n\nAfter signing up, the API Key is found at the bottom of the account dashboard page.\n\n![Polygon](https://user-images.githubusercontent.com/46355364/207826258-b1f318fa-fd9c-41d9-bf5c-fe16722e6601.png)',  # noqa: E501  pylint: disable=line-too-long
     logo_url="https://polygon.io/_next/image?url=%2Flogo.svg&w=640&q=75",


### PR DESCRIPTION
1. **Why**?

    - User might want to specify their key names in uppercase

2. **What**?

    - Create uppercase alias in the `Credentials` model

3. **Impact**:

    - Locally `~/.openbb_platform/user_settings.json` allows uppercase credential name
    - OpenBB Hub, same as above

4. **Testing Done**:

Local test (user_settings.json)
```python
# Set an uppercase key such as BIZTOC_API_KEY -> biztoc_api_key
from openbb import obb
obb.user.credentials.show()
```

Hub test
```python
# Set an uppercase credential here https://my.openbb.dev/app/platform/credentials
# Such as BIZTOC_API_KEY -> biztoc_api_key
%env OPENBB_HUB_BACKEND=https://payments.openbb.dev
from openbb import obb
obb.account.login(pat="...")
obb.user.credentials.show()
```