### PR TITLE
[HotFix] Fix missed unit_measurements

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/etf_equity_exposure.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/etf_equity_exposure.py
@@ -35,7 +35,7 @@ class EtfEquityExposureData(Data):
     weight: Optional[float] = Field(
         default=None,
         description="The weight of the equity in the ETF, as a normalized percent.",
-        json_schema_extra={"units_measurement": "percent", "frontend_multiply": 100},
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     market_value: Optional[Union[int, float]] = Field(
         default=None,

--- a/openbb_platform/core/openbb_core/provider/standard_models/eu_yield_curve.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/eu_yield_curve.py
@@ -25,5 +25,5 @@ class EUYieldCurveData(Data):
     rate: Optional[float] = Field(
         description="Yield curve rate, as a normalized percent.",
         default=None,
-        json_schema_extra={"unit_measurement": "percent.", "frontend_multiply": 100},
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )

--- a/openbb_platform/providers/finviz/openbb_finviz/models/price_performance.py
+++ b/openbb_platform/providers/finviz/openbb_finviz/models/price_performance.py
@@ -48,12 +48,12 @@ class FinvizPricePerformanceData(RecentPerformanceData):
     volatility_week: Optional[float] = Field(
         default=None,
         description="One-week realized volatility, as a normalized percent.",
-        json_schema_extra={"unit_measurement": "percent", "fontend_multiply": 100},
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     volatility_month: Optional[float] = Field(
         default=None,
         description="One-month realized volatility, as a normalized percent.",
-        json_schema_extra={"unit_measurement": "percent", "fontend_multiply": 100},
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     price: Optional[float] = Field(
         default=None,


### PR DESCRIPTION
There were a few stragglers that escaped detection, this adds `x-` in front of `unit_measurement` in `json_schema_extra` Fields.