### PR TITLE
[BugFix] FMP Key Metrics

### DIFF
--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -15754,15 +15754,15 @@
                 ],
                 "fmp": [
                     {
-                        "name": "date",
+                        "name": "period_ending",
                         "type": "date",
-                        "description": "The date of the data.",
+                        "description": "Period ending date.",
                         "default": "",
                         "optional": false,
                         "choices": null
                     },
                     {
-                        "name": "period",
+                        "name": "fiscal_period",
                         "type": "str",
                         "description": "Period of the data.",
                         "default": "",
@@ -15772,7 +15772,7 @@
                     {
                         "name": "calendar_year",
                         "type": "int",
-                        "description": "Calendar year.",
+                        "description": "Calendar year for the fiscal period.",
                         "default": null,
                         "optional": true,
                         "choices": null
@@ -15781,6 +15781,14 @@
                         "name": "revenue_per_share",
                         "type": "float",
                         "description": "Revenue per share",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "capex_per_share",
+                        "type": "float",
+                        "description": "Capital expenditures per share",
                         "default": null,
                         "optional": true,
                         "choices": null
@@ -15850,15 +15858,7 @@
                         "choices": null
                     },
                     {
-                        "name": "enterprise_value",
-                        "type": "float",
-                        "description": "Enterprise value",
-                        "default": null,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "price_to_sales_ratio",
+                        "name": "price_to_sales",
                         "type": "float",
                         "description": "Price-to-sales ratio",
                         "default": null,
@@ -15866,7 +15866,7 @@
                         "choices": null
                     },
                     {
-                        "name": "pocf_ratio",
+                        "name": "price_to_operating_cash_flow",
                         "type": "float",
                         "description": "Price-to-operating cash flow ratio",
                         "default": null,
@@ -15874,7 +15874,7 @@
                         "choices": null
                     },
                     {
-                        "name": "pfcf_ratio",
+                        "name": "price_to_free_cash_flow",
                         "type": "float",
                         "description": "Price-to-free cash flow ratio",
                         "default": null,
@@ -15882,7 +15882,7 @@
                         "choices": null
                     },
                     {
-                        "name": "pb_ratio",
+                        "name": "price_to_book",
                         "type": "float",
                         "description": "Price-to-book ratio",
                         "default": null,
@@ -15890,7 +15890,7 @@
                         "choices": null
                     },
                     {
-                        "name": "ptb_ratio",
+                        "name": "price_to_tangible_book",
                         "type": "float",
                         "description": "Price-to-tangible book ratio",
                         "default": null,
@@ -15906,7 +15906,7 @@
                         "choices": null
                     },
                     {
-                        "name": "enterprise_value_over_ebitda",
+                        "name": "ev_to_ebitda",
                         "type": "float",
                         "description": "Enterprise value-to-EBITDA ratio",
                         "default": null,
@@ -15941,6 +15941,14 @@
                         "name": "free_cash_flow_yield",
                         "type": "float",
                         "description": "Free cash flow yield",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "debt_to_market_cap",
+                        "type": "float",
+                        "description": "Debt-to-market capitalization ratio",
                         "default": null,
                         "optional": true,
                         "choices": null
@@ -15989,14 +15997,6 @@
                         "name": "income_quality",
                         "type": "float",
                         "description": "Income quality",
-                        "default": null,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "dividend_yield",
-                        "type": "float",
-                        "description": "Dividend yield, as a normalized percent.",
                         "default": null,
                         "optional": true,
                         "choices": null
@@ -16066,38 +16066,6 @@
                         "choices": null
                     },
                     {
-                        "name": "graham_number",
-                        "type": "float",
-                        "description": "Graham number",
-                        "default": null,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "roic",
-                        "type": "float",
-                        "description": "Return on invested capital",
-                        "default": null,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "return_on_tangible_assets",
-                        "type": "float",
-                        "description": "Return on tangible assets",
-                        "default": null,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "graham_net_net",
-                        "type": "float",
-                        "description": "Graham net-net working capital",
-                        "default": null,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
                         "name": "working_capital",
                         "type": "float",
                         "description": "Working capital",
@@ -16117,6 +16085,14 @@
                         "name": "net_current_asset_value",
                         "type": "float",
                         "description": "Net current asset value",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "enterprise_value",
+                        "type": "float",
+                        "description": "Enterprise value",
                         "default": null,
                         "optional": true,
                         "choices": null
@@ -16202,7 +16178,7 @@
                         "choices": null
                     },
                     {
-                        "name": "roe",
+                        "name": "return_on_equity",
                         "type": "float",
                         "description": "Return on equity",
                         "default": null,
@@ -16210,9 +16186,41 @@
                         "choices": null
                     },
                     {
-                        "name": "capex_per_share",
+                        "name": "return_on_invested_capital",
                         "type": "float",
-                        "description": "Capital expenditures per share",
+                        "description": "Return on invested capital",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "return_on_tangible_assets",
+                        "type": "float",
+                        "description": "Return on tangible assets",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "dividend_yield",
+                        "type": "float",
+                        "description": "Dividend yield, as a normalized percent.",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "graham_number",
+                        "type": "float",
+                        "description": "Graham number",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "graham_net_net",
+                        "type": "float",
+                        "description": "Graham net-net working capital",
                         "default": null,
                         "optional": true,
                         "choices": null

--- a/openbb_platform/openbb/package/equity_fundamental.py
+++ b/openbb_platform/openbb/package/equity_fundamental.py
@@ -2420,14 +2420,16 @@ class ROUTER_equity_fundamental(Container):
             Market capitalization
         pe_ratio : Optional[float]
             Price-to-earnings ratio (P/E ratio)
-        date : Optional[date]
-            The date of the data. (provider: fmp)
-        period : Optional[str]
+        period_ending : Optional[date]
+            Period ending date. (provider: fmp)
+        fiscal_period : Optional[str]
             Period of the data. (provider: fmp)
         calendar_year : Optional[int]
-            Calendar year. (provider: fmp)
+            Calendar year for the fiscal period. (provider: fmp)
         revenue_per_share : Optional[float]
             Revenue per share (provider: fmp, yfinance)
+        capex_per_share : Optional[float]
+            Capital expenditures per share (provider: fmp)
         net_income_per_share : Optional[float]
             Net income per share (provider: fmp)
         operating_cash_flow_per_share : Optional[float]
@@ -2444,21 +2446,19 @@ class ROUTER_equity_fundamental(Container):
             Shareholders equity per share (provider: fmp)
         interest_debt_per_share : Optional[float]
             Interest debt per share (provider: fmp)
-        enterprise_value : Optional[int]
-            Enterprise value (provider: fmp, intrinio, yfinance)
-        price_to_sales_ratio : Optional[float]
+        price_to_sales : Optional[float]
             Price-to-sales ratio (provider: fmp)
-        pocf_ratio : Optional[float]
+        price_to_operating_cash_flow : Optional[float]
             Price-to-operating cash flow ratio (provider: fmp)
-        pfcf_ratio : Optional[float]
+        price_to_free_cash_flow : Optional[float]
             Price-to-free cash flow ratio (provider: fmp)
-        pb_ratio : Optional[float]
-            Price-to-book ratio (provider: fmp)
-        ptb_ratio : Optional[float]
-            Price-to-tangible book ratio (provider: fmp)
+        price_to_book : Optional[float]
+            Price-to-book ratio (provider: fmp, intrinio, yfinance)
+        price_to_tangible_book : Optional[float]
+            Price-to-tangible book ratio (provider: fmp, intrinio)
         ev_to_sales : Optional[float]
             Enterprise value-to-sales ratio (provider: fmp)
-        enterprise_value_over_ebitda : Optional[float]
+        ev_to_ebitda : Optional[float]
             Enterprise value-to-EBITDA ratio (provider: fmp)
         ev_to_operating_cash_flow : Optional[float]
             Enterprise value-to-operating cash flow ratio (provider: fmp)
@@ -2469,6 +2469,8 @@ class ROUTER_equity_fundamental(Container):
             Earnings yield, as a normalized percent. (provider: intrinio)
         free_cash_flow_yield : Optional[float]
             Free cash flow yield (provider: fmp)
+        debt_to_market_cap : Optional[float]
+            Debt-to-market capitalization ratio (provider: fmp)
         debt_to_equity : Optional[float]
             Debt-to-equity ratio (provider: fmp, yfinance)
         debt_to_assets : Optional[float]
@@ -2481,8 +2483,6 @@ class ROUTER_equity_fundamental(Container):
             Interest coverage (provider: fmp)
         income_quality : Optional[float]
             Income quality (provider: fmp)
-        dividend_yield : Optional[float]
-            Dividend yield, as a normalized percent. (provider: fmp, intrinio, yfinance)
         payout_ratio : Optional[float]
             Payout ratio (provider: fmp, yfinance)
         sales_general_and_administrative_to_revenue : Optional[float]
@@ -2499,20 +2499,14 @@ class ROUTER_equity_fundamental(Container):
             Capital expenditures-to-depreciation ratio (provider: fmp)
         stock_based_compensation_to_revenue : Optional[float]
             Stock-based compensation-to-revenue ratio (provider: fmp)
-        graham_number : Optional[float]
-            Graham number (provider: fmp)
-        roic : Optional[float]
-            Return on invested capital (provider: fmp)
-        return_on_tangible_assets : Optional[float]
-            Return on tangible assets (provider: fmp)
-        graham_net_net : Optional[float]
-            Graham net-net working capital (provider: fmp)
         working_capital : Optional[float]
             Working capital (provider: fmp)
         tangible_asset_value : Optional[float]
             Tangible asset value (provider: fmp)
         net_current_asset_value : Optional[float]
             Net current asset value (provider: fmp)
+        enterprise_value : Optional[int]
+            Enterprise value (provider: fmp, intrinio, yfinance)
         invested_capital : Optional[float]
             Invested capital (provider: fmp)
         average_receivables : Optional[float]
@@ -2533,14 +2527,21 @@ class ROUTER_equity_fundamental(Container):
             Payables turnover (provider: fmp)
         inventory_turnover : Optional[float]
             Inventory turnover (provider: fmp)
-        roe : Optional[float]
-            Return on equity (provider: fmp)
-        capex_per_share : Optional[float]
-            Capital expenditures per share (provider: fmp)
-        price_to_book : Optional[float]
-            Price to book ratio. (provider: intrinio, yfinance)
-        price_to_tangible_book : Optional[float]
-            Price to tangible book ratio. (provider: intrinio)
+        return_on_equity : Optional[float]
+            Return on equity (provider: fmp);
+            Return on equity, as a normalized percent. (provider: intrinio);
+            Return on equity, as a normalized percent. (provider: yfinance)
+        return_on_invested_capital : Optional[float]
+            Return on invested capital (provider: fmp);
+            Return on invested capital, as a normalized percent. (provider: intrinio)
+        return_on_tangible_assets : Optional[float]
+            Return on tangible assets (provider: fmp)
+        dividend_yield : Optional[float]
+            Dividend yield, as a normalized percent. (provider: fmp, intrinio, yfinance)
+        graham_number : Optional[float]
+            Graham number (provider: fmp)
+        graham_net_net : Optional[float]
+            Graham net-net working capital (provider: fmp)
         price_to_revenue : Optional[float]
             Price to revenue ratio. (provider: intrinio)
         quick_ratio : Optional[float]
@@ -2569,10 +2570,6 @@ class ROUTER_equity_fundamental(Container):
             Invested capital growth, as a normalized percent. (provider: intrinio)
         return_on_assets : Optional[float]
             Return on assets, as a normalized percent. (provider: intrinio, yfinance)
-        return_on_equity : Optional[float]
-            Return on equity, as a normalized percent. (provider: intrinio, yfinance)
-        return_on_invested_capital : Optional[float]
-            Return on invested capital, as a normalized percent. (provider: intrinio)
         ebitda : Optional[int]
             Earnings before interest, taxes, depreciation, and amortization. (provider: intrinio)
         ebit : Optional[int]


### PR DESCRIPTION
1. **Why**?:

    - Fixes issues using `with_ttm` parameter.
    - Fixes field name aliases - we actually need both `__alias_dict__` and `alias` in the Field definition.

2. **What**?:

    - General model clean-up.
    - Identify more fields that are `%` values, and add `json_schema_extra` to the Field definition.

3. **Impact**:

    - Expands a few field names to be more verbose.
      - `roe` -> `return_on_equity`

4. **Testing Done**:

    - Multiple symbols
    - `quarter` and `annual`, `with_ttm` True/False
