### PR TITLE
[BugFix] Handle space separated arguments

### DIFF
--- a/cli/openbb_cli/controllers/base_controller.py
+++ b/cli/openbb_cli/controllers/base_controller.py
@@ -4,6 +4,7 @@ import argparse
 import difflib
 import os
 import re
+import shlex
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from pathlib import Path
@@ -240,7 +241,7 @@ class BaseController(metaclass=ABCMeta):
         else:
             try:
                 (known_args, other_args) = self.parser.parse_known_args(
-                    an_input.split()
+                    shlex.split(an_input)
                 )
             except Exception as exc:
                 raise SystemExit from exc


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - CLI was not capable of proper handling of space separated arguments, even when using quotes or escape characters.

2. **What**? (1-3 sentences or a bullet point list):

    - Use [shlex](https://docs.python.org/3/library/shlex.html) to handle the user's input.

3. **Impact** (1-2 sentences or a bullet point list):

    - Significant UX improvement, allowing users to use space separated arguments where applicable

4. **Testing Done**:

    - Use space separated options: 
       - `filings --symbol aapl  --form_type "NT N-MFP" --provider fmp`
       - `filings --symbol aapl  --form_type NT\ N-MFP --provider fmp` 

> Before those would result in an choices error: "Choose from..."

5. **Reviewer Notes** (optional):

    - The examples above are illustrative and will most likely result in empty data error.
