### PR TITLE
[BugFix] Only update credentials on login

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/credentials.py
+++ b/openbb_platform/core/openbb_core/app/model/credentials.py
@@ -116,3 +116,7 @@ class Credentials(_Credentials):  # type: ignore
                 [f"{k}: {v}" for k, v in sorted(self.model_dump(mode="json").items())]
             )
         )
+
+    def update(self, incoming: "Credentials"):
+        """Update current credentials."""
+        self.__dict__.update(incoming.model_dump(exclude_none=True))

--- a/openbb_platform/core/openbb_core/app/service/user_service.py
+++ b/openbb_platform/core/openbb_core/app/service/user_service.py
@@ -50,15 +50,6 @@ class UserService(metaclass=SingletonMeta):
         )
         path.write_text(user_settings_json, encoding="utf-8")
 
-    @classmethod
-    def update_default(cls, user_settings: UserSettings) -> UserSettings:
-        """Update default user settings."""
-        d1 = cls.read_default_user_settings().model_dump()
-        d2 = user_settings.model_dump() if user_settings else {}
-        updated = cls._merge_dicts([d1, d2])
-
-        return UserSettings.model_validate(updated)
-
     @staticmethod
     def _merge_dicts(list_of_dicts: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Merge a list of dictionaries."""

--- a/openbb_platform/core/openbb_core/app/static/account.py
+++ b/openbb_platform/core/openbb_core/app/static/account.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from openbb_core.app.static.app_factory import BaseApp
 
 
-class Account:
+class Account:  # noqa: D205, D400
     """/account
     login
     logout
@@ -123,8 +123,8 @@ class Account:
         """
         self._hub_service = self._create_hub_service(email, password, pat)
         incoming = self._hub_service.pull()
-        updated: UserSettings = UserService.update_default(incoming)
-        self._base_app._command_runner.user_settings = updated
+        self._base_app.user.profile = incoming.profile
+        self._base_app.user.credentials.update(incoming.credentials)
         if remember_me:
             Path(self._openbb_directory).mkdir(parents=False, exist_ok=True)
             session_file = Path(self._openbb_directory, self.SESSION_FILE)
@@ -185,10 +185,8 @@ class Account:
             )
         else:
             incoming = self._hub_service.pull()
-            updated: UserSettings = UserService.update_default(incoming)
-            updated.id = self._base_app._command_runner.user_settings.id
-            self._base_app._command_runner.user_settings = updated
-
+            self._base_app.user.profile = incoming.profile
+            self._base_app.user.credentials.update(incoming.credentials)
         if return_settings:
             return self._base_app._command_runner.user_settings
         return None

--- a/openbb_platform/core/openbb_core/app/static/coverage.py
+++ b/openbb_platform/core/openbb_core/app/static/coverage.py
@@ -11,16 +11,13 @@ if TYPE_CHECKING:
     from openbb_core.app.static.app_factory import BaseApp
 
 
-class Coverage:
-    """Coverage class.
-
-    /coverage
-
-        providers
-        commands
-        command_model
-        command_schemas
-        reference
+class Coverage:  # noqa: D205, D400
+    """/coverage
+    providers
+    commands
+    command_model
+    command_schemas
+    reference
     """
 
     def __init__(self, app: "BaseApp"):

--- a/openbb_platform/core/tests/app/service/test_user_service.py
+++ b/openbb_platform/core/tests/app/service/test_user_service.py
@@ -4,7 +4,6 @@ import json
 import tempfile
 from pathlib import Path
 
-from openbb_core.app.model.defaults import Defaults
 from openbb_core.app.service.user_service import (
     UserService,
     UserSettings,
@@ -45,20 +44,6 @@ def test_write_default_user_settings():
 
     # Clean up the temporary file
     temp_path.unlink()
-
-
-def test_update_default():
-    """Test update default user settings."""
-
-    # Some settings
-    defaults_test = Defaults(routes={"test": {"test": "test"}})
-    other_settings = UserSettings(defaults=defaults_test)
-
-    # Update the default settings
-    updated_settings = UserService.update_default(other_settings)
-
-    assert "test" in updated_settings.defaults.model_dump()["routes"]
-    assert updated_settings.defaults.model_dump()["routes"]["test"] == {"test": "test"}
 
 
 def test_merge_dicts():


### PR DESCRIPTION
1. **Why**?

    - Login resets the user preferences to their default

    - If the user changes some preference in `user_settings.json` file and then logs in, it ignores the file changes and uses defaults instead

2. **What**?

    - Make sure only credentials are updated (merged with local credentials) when login

3. **Impact**

    - NA

4. **Testing Done**:

    - Change preferences in `user_settings.json`. Login into the Hub with different credentials than you have in `user_settings.json`. Confirm no preferences were updated and local credentials were updated with values set in the hub.