### PR TITLE
[Docs] Redirect contributing URL

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -40,6 +40,10 @@ export default {
             from: "/terminal/menus/forecasting",
             to: "/terminal/menus/forecast",
           },
+          {
+            to: "/platform/developer_guide/contributing",
+            from: "/platform/development/contributing",
+          }
         ],
       },
     ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -41,8 +41,8 @@ export default {
             to: "/terminal/menus/forecast",
           },
           {
-            to: "/platform/developer_guide/contributing",
             from: "/platform/development/contributing",
+            to: "/platform/developer_guide/contributing",
           }
         ],
       },


### PR DESCRIPTION
* Some READMEs like https://pypi.org/project/openbb-fmp/, have dead url https://docs.openbb.co/platform/development/contributing
* Redirect this url to [/platform/developer_guide/contributing](https://docs.openbb.co/platform/developer_guide/contributing)
* Only works in prod, not locally, see warnings [here](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects)