### PR TITLE
[Feature] Remove remember contexts setting

### DIFF
--- a/cli/openbb_cli/argparse_translator/utils.py
+++ b/cli/openbb_cli/argparse_translator/utils.py
@@ -64,7 +64,9 @@ def get_argument_optional_choices(parser: ArgumentParser, argument_name: str) ->
             or action.dest == argument_name
             and hasattr(action, "optional_choices")
         ):
-            return action.optional_choices
+            return (
+                action.optional_choices  # pylint: disable=no-member # this is a custom attribute
+            )
     return False
 
 

--- a/cli/openbb_cli/controllers/base_controller.py
+++ b/cli/openbb_cli/controllers/base_controller.py
@@ -138,27 +138,10 @@ class BaseController(metaclass=ABCMeta):
 
     def load_class(self, class_ins, *args, **kwargs):
         """Check for an existing instance of the controller before creating a new one."""
-        settings = session.settings
         self.save_class()
         arguments = len(args) + len(kwargs)
-        # Due to the 'arguments == 1' condition, we actually NEVER load a class
-        # that has arguments (The 1 argument corresponds to self.queue)
-        # Advantage: If the user changes something on one controller and then goes to the
-        # controller below, it will create such class from scratch bringing all new variables
-        # in and considering latest changes.
-        # Disadvantage: If the user goes on a controller below and we have been there before
-        # it will not load that previous class, but create a new one from scratch.
-        # SCENARIO: If the user is in stocks and does load AAPL/ta the TA menu will get AAPL,
-        # and if then the user goes back to the stocks menu using .. that menu will have AAPL
-        # Now, if "arguments == 1" condition exists, if the user does "load TSLA" and then
-        # goes into "TA", the "TSLA" ticker will appear. If that condition doesn't exist
-        # the previous class will be loaded and even if the user changes the ticker on
-        # the stocks context it will not impact the one of TA menu - unless changes are done.
-        if (
-            class_ins.PATH in controllers
-            and arguments == 1
-            and settings.REMEMBER_CONTEXTS
-        ):
+
+        if class_ins.PATH in controllers and arguments == 1:
             old_class = controllers[class_ins.PATH]
             old_class.queue = self.queue
             return old_class.menu()
@@ -166,8 +149,7 @@ class BaseController(metaclass=ABCMeta):
 
     def save_class(self) -> None:
         """Save the current instance of the class to be loaded later."""
-        if session.settings.REMEMBER_CONTEXTS:
-            controllers[self.PATH] = self
+        controllers[self.PATH] = self
 
     def custom_reset(self) -> List[str]:
         """Implement custom reset.

--- a/cli/openbb_cli/models/settings.py
+++ b/cli/openbb_cli/models/settings.py
@@ -80,12 +80,6 @@ class Settings(BaseModel):
         command="exithelp",
         group=SettingGroups.feature_flags,
     )
-    REMEMBER_CONTEXTS: bool = Field(
-        default=True,
-        description="remember contexts between menus",
-        command="rcontext",
-        group=SettingGroups.feature_flags,
-    )
     ENABLE_RICH_PANEL: bool = Field(
         default=True,
         description="enable colorful rich CLI panel",

--- a/cli/tests/test_models_settings.py
+++ b/cli/tests/test_models_settings.py
@@ -20,7 +20,6 @@ def test_default_values():
     assert fields["USE_DATETIME"].default is True
     assert fields["USE_PROMPT_TOOLKIT"].default is True
     assert fields["ENABLE_EXIT_AUTO_HELP"].default is True
-    assert fields["REMEMBER_CONTEXTS"].default is True
     assert fields["ENABLE_RICH_PANEL"].default is True
     assert fields["TOOLBAR_HINT"].default is True
     assert fields["SHOW_MSG_OBBJECT_REGISTRY"].default is False


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Removing unnecessary setting - controllers don't hold variables any more so doesn't make sense to have this setting anymore - controllers should be only created once since they hold no state.

2. **What**? (1-3 sentences or a bullet point list):

    - Removed setting and did the necessary adjustments-

3. **Impact** (1-2 sentences or a bullet point list):

    - NA

4. **Testing Done**:

    - Run a few commands on CLI and check that everything works as before.
