### PR TITLE
[Feature] `to_df` where `results` is a model of arrays.

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/obbject.py
+++ b/openbb_platform/core/openbb_core/app/model/obbject.py
@@ -155,12 +155,19 @@ class OBBject(Tagged, Generic[T]):
                         dict_of_df[k] = pd.DataFrame(v)
 
                 df = pd.concat(dict_of_df, axis=1)
-
             # List[BaseModel]
             elif is_list_of_basemodel(res):
                 dt: Union[List[Data], Data] = res  # type: ignore
-                df = basemodel_to_df(dt, index)
-                sort_columns = False
+                r = res[0] if isinstance(res, list) and len(res) == 1 else res
+                if all(
+                    prop.get("type") == "array"
+                    for prop in r.schema()["properties"].values()
+                ):
+                    sort_columns = False
+                    df = pd.DataFrame(r.model_dump(exclude_unset=True))
+                else:
+                    df = basemodel_to_df(dt, index)
+                    sort_columns = False
             # str
             elif isinstance(res, str):
                 df = pd.DataFrame([res])

--- a/openbb_platform/core/openbb_core/provider/standard_models/options_snapshots.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/options_snapshots.py
@@ -4,7 +4,7 @@ from datetime import (
     date as dateType,
     datetime,
 )
-from typing import Optional
+from typing import List, Union
 
 from pydantic import Field
 
@@ -20,56 +20,60 @@ class OptionsSnapshotsQueryParams(QueryParams):
 class OptionsSnapshotsData(Data):
     """Options Snapshots Data."""
 
-    underlying_symbol: str = Field(description="Ticker symbol of the underlying asset.")
-    contract_symbol: str = Field(description="Symbol of the options contract.")
-    expiration: dateType = Field(description="Expiration date of the options contract.")
-    dte: Optional[int] = Field(
-        default=None,
+    underlying_symbol: List[str] = Field(
+        description="Ticker symbol of the underlying asset."
+    )
+    contract_symbol: List[str] = Field(description="Symbol of the options contract.")
+    expiration: List[dateType] = Field(
+        description="Expiration date of the options contract."
+    )
+    dte: List[Union[int, None]] = Field(
+        default_factory=list,
         description="Number of days to expiration of the options contract.",
     )
-    strike: float = Field(
+    strike: List[float] = Field(
         description="Strike price of the options contract.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    option_type: str = Field(description="The type of option.")
-    volume: Optional[int] = Field(
-        default=None,
+    option_type: List[str] = Field(description="The type of option.")
+    volume: List[Union[int, None]] = Field(
+        default_factory=list,
         description=DATA_DESCRIPTIONS.get("volume", ""),
     )
-    open_interest: Optional[int] = Field(
-        default=None,
+    open_interest: List[Union[int, None]] = Field(
+        default_factory=list,
         description="Open interest at the time.",
     )
-    last_price: Optional[float] = Field(
-        default=None,
+    last_price: List[Union[float, None]] = Field(
+        default_factory=list,
         description="Last trade price at the time.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    last_size: Optional[int] = Field(
-        default=None,
+    last_size: List[Union[int, None]] = Field(
+        default_factory=list,
         description="Lot size of the last trade.",
     )
-    last_timestamp: Optional[datetime] = Field(
-        default=None,
+    last_timestamp: List[Union[datetime, None]] = Field(
+        default_factory=list,
         description="Timestamp of the last price.",
     )
-    open: Optional[float] = Field(
-        default=None,
+    open: List[Union[float, None]] = Field(
+        default_factory=list,
         description=DATA_DESCRIPTIONS.get("open", ""),
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    high: Optional[float] = Field(
-        default=None,
+    high: List[Union[float, None]] = Field(
+        default_factory=list,
         description=DATA_DESCRIPTIONS.get("high", ""),
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    low: Optional[float] = Field(
-        default=None,
+    low: List[Union[float, None]] = Field(
+        default_factory=list,
         description=DATA_DESCRIPTIONS.get("low", ""),
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    close: Optional[float] = Field(
-        default=None,
+    close: List[Union[float, None]] = Field(
+        default_factory=list,
         description=DATA_DESCRIPTIONS.get("close", ""),
         json_schema_extra={"x-unit_measurement": "currency"},
     )

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -2060,7 +2060,7 @@
                 "standard": [
                     {
                         "name": "underlying_symbol",
-                        "type": "str",
+                        "type": "List[str]",
                         "description": "Ticker symbol of the underlying asset.",
                         "default": "",
                         "optional": false,
@@ -2068,7 +2068,7 @@
                     },
                     {
                         "name": "contract_symbol",
-                        "type": "str",
+                        "type": "List[str]",
                         "description": "Symbol of the options contract.",
                         "default": "",
                         "optional": false,
@@ -2076,7 +2076,7 @@
                     },
                     {
                         "name": "expiration",
-                        "type": "date",
+                        "type": "List[date]",
                         "description": "Expiration date of the options contract.",
                         "default": "",
                         "optional": false,
@@ -2084,15 +2084,15 @@
                     },
                     {
                         "name": "dte",
-                        "type": "int",
+                        "type": "List[int]",
                         "description": "Number of days to expiration of the options contract.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "strike",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "Strike price of the options contract.",
                         "default": "",
                         "optional": false,
@@ -2100,7 +2100,7 @@
                     },
                     {
                         "name": "option_type",
-                        "type": "str",
+                        "type": "List[str]",
                         "description": "The type of option.",
                         "default": "",
                         "optional": false,
@@ -2108,73 +2108,73 @@
                     },
                     {
                         "name": "volume",
-                        "type": "int",
-                        "description": "Total trade volume from the beginning of the session.",
-                        "default": null,
+                        "type": "List[int]",
+                        "description": "The trading volume.",
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "open_interest",
-                        "type": "int",
+                        "type": "List[int]",
                         "description": "Open interest at the time.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "last_price",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "Last trade price at the time.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "last_size",
-                        "type": "int",
+                        "type": "List[int]",
                         "description": "Lot size of the last trade.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "last_timestamp",
-                        "type": "datetime",
+                        "type": "List[datetime]",
                         "description": "Timestamp of the last price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "open",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The open price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "high",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The high price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "low",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The low price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "close",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The close price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     }
@@ -2182,97 +2182,97 @@
                 "intrinio": [
                     {
                         "name": "bid",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The last bid price at the time.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "bid_size",
-                        "type": "int",
+                        "type": "List[int]",
                         "description": "The size of the last bid price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "bid_timestamp",
-                        "type": "datetime",
+                        "type": "List[datetime]",
                         "description": "The timestamp of the last bid price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "ask",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The last ask price at the time.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "ask_size",
-                        "type": "int",
+                        "type": "List[int]",
                         "description": "The size of the last ask price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "ask_timestamp",
-                        "type": "datetime",
+                        "type": "List[datetime]",
                         "description": "The timestamp of the last ask price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "total_bid_volume",
-                        "type": "int",
+                        "type": "List[int]",
                         "description": "Total volume of bids.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "bid_high",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The highest bid price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "bid_low",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The lowest bid price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "total_ask_volume",
-                        "type": "int",
+                        "type": "List[int]",
                         "description": "Total volume of asks.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "ask_high",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The highest ask price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "ask_low",
-                        "type": "float",
+                        "type": "List[float]",
                         "description": "The lowest ask price.",
-                        "default": null,
+                        "default": "",
                         "optional": true,
                         "choices": null
                     }
@@ -32049,7 +32049,7 @@
                     {
                         "name": "volume",
                         "type": "float",
-                        "description": "Volume (Millions of \u20acEUR).",
+                        "description": "The trading volume. (Millions of \u20acEUR).",
                         "default": null,
                         "optional": true,
                         "choices": null

--- a/openbb_platform/openbb/package/derivatives_options.py
+++ b/openbb_platform/openbb/package/derivatives_options.py
@@ -253,59 +253,59 @@ class ROUTER_derivatives_options(Container):
 
         OptionsSnapshots
         ----------------
-        underlying_symbol : str
+        underlying_symbol : List[str]
             Ticker symbol of the underlying asset.
-        contract_symbol : str
+        contract_symbol : List[str]
             Symbol of the options contract.
-        expiration : date
+        expiration : List[date]
             Expiration date of the options contract.
-        dte : Optional[int]
+        dte : List[Optional[int]]
             Number of days to expiration of the options contract.
-        strike : float
+        strike : List[float]
             Strike price of the options contract.
-        option_type : str
+        option_type : List[str]
             The type of option.
-        volume : Optional[int]
-            Total trade volume from the beginning of the session.
-        open_interest : Optional[int]
+        volume : List[Optional[int]]
+            The trading volume.
+        open_interest : List[Optional[int]]
             Open interest at the time.
-        last_price : Optional[float]
+        last_price : List[Optional[float]]
             Last trade price at the time.
-        last_size : Optional[int]
+        last_size : List[Optional[int]]
             Lot size of the last trade.
-        last_timestamp : Optional[datetime]
+        last_timestamp : List[Optional[datetime]]
             Timestamp of the last price.
-        open : Optional[float]
+        open : List[Optional[float]]
             The open price.
-        high : Optional[float]
+        high : List[Optional[float]]
             The high price.
-        low : Optional[float]
+        low : List[Optional[float]]
             The low price.
-        close : Optional[float]
+        close : List[Optional[float]]
             The close price.
-        bid : Optional[float]
+        bid : List[Optional[float]]
             The last bid price at the time. (provider: intrinio)
-        bid_size : Optional[int]
+        bid_size : List[Optional[int]]
             The size of the last bid price. (provider: intrinio)
-        bid_timestamp : Optional[datetime]
+        bid_timestamp : List[Optional[datetime]]
             The timestamp of the last bid price. (provider: intrinio)
-        ask : Optional[float]
+        ask : List[Optional[float]]
             The last ask price at the time. (provider: intrinio)
-        ask_size : Optional[int]
+        ask_size : List[Optional[int]]
             The size of the last ask price. (provider: intrinio)
-        ask_timestamp : Optional[datetime]
+        ask_timestamp : List[Optional[datetime]]
             The timestamp of the last ask price. (provider: intrinio)
-        total_bid_volume : Optional[int]
+        total_bid_volume : List[Optional[int]]
             Total volume of bids. (provider: intrinio)
-        bid_high : Optional[float]
+        bid_high : List[Optional[float]]
             The highest bid price. (provider: intrinio)
-        bid_low : Optional[float]
+        bid_low : List[Optional[float]]
             The lowest bid price. (provider: intrinio)
-        total_ask_volume : Optional[int]
+        total_ask_volume : List[Optional[int]]
             Total volume of asks. (provider: intrinio)
-        ask_high : Optional[float]
+        ask_high : List[Optional[float]]
             The highest ask price. (provider: intrinio)
-        ask_low : Optional[float]
+        ask_low : List[Optional[float]]
             The lowest ask price. (provider: intrinio)
 
         Examples

--- a/openbb_platform/openbb/package/fixedincome_rate.py
+++ b/openbb_platform/openbb/package/fixedincome_rate.py
@@ -657,7 +657,7 @@ class ROUTER_fixedincome_rate(Container):
         percentile_75 : Optional[float]
             Rate at 75th percentile of volume.
         volume : Optional[float]
-            Volume (Millions of €EUR).
+            The trading volume. (Millions of €EUR).
         transactions : Optional[int]
             Number of transactions.
         number_of_banks : Optional[int]

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/options_snapshots.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/options_snapshots.py
@@ -45,57 +45,57 @@ class IntrinioOptionsSnapshotsQueryParams(OptionsSnapshotsQueryParams):
 class IntrinioOptionsSnapshotsData(OptionsSnapshotsData):
     """Intrinio Options Snapshots Data. Warning: This is a large file."""
 
-    bid: Optional[float] = Field(
-        default=None,
+    bid: List[Union[float, None]] = Field(
+        default_factory=list,
         description="The last bid price at the time.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    bid_size: Optional[int] = Field(
-        default=None,
+    bid_size: List[Union[int, None]] = Field(
+        default_factory=list,
         description="The size of the last bid price.",
     )
-    bid_timestamp: Optional[datetime] = Field(
-        default=None,
+    bid_timestamp: List[Union[datetime, None]] = Field(
+        default_factory=list,
         description="The timestamp of the last bid price.",
     )
-    ask: Optional[float] = Field(
-        default=None,
+    ask: List[Union[float, None]] = Field(
+        default_factory=list,
         description="The last ask price at the time.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    ask_size: Optional[int] = Field(
-        default=None,
+    ask_size: List[Union[int, None]] = Field(
+        default_factory=list,
         description="The size of the last ask price.",
     )
-    ask_timestamp: Optional[datetime] = Field(
-        default=None,
+    ask_timestamp: List[Union[datetime, None]] = Field(
+        default_factory=list,
         description="The timestamp of the last ask price.",
     )
-    total_bid_volume: Optional[int] = Field(
-        default=None,
+    total_bid_volume: List[Union[int, None]] = Field(
+        default_factory=list,
         description="Total volume of bids.",
     )
-    bid_high: Optional[float] = Field(
-        default=None,
+    bid_high: List[Union[float, None]] = Field(
+        default_factory=list,
         description="The highest bid price.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    bid_low: Optional[float] = Field(
-        default=None,
+    bid_low: List[Union[float, None]] = Field(
+        default_factory=list,
         description="The lowest bid price.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    total_ask_volume: Optional[int] = Field(
-        default=None,
+    total_ask_volume: List[Union[int, None]] = Field(
+        default_factory=list,
         description="Total volume of asks.",
     )
-    ask_high: Optional[float] = Field(
-        default=None,
+    ask_high: List[Union[float, None]] = Field(
+        default_factory=list,
         description="The highest ask price.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
-    ask_low: Optional[float] = Field(
-        default=None,
+    ask_low: List[Union[float, None]] = Field(
+        default_factory=list,
         description="The lowest ask price.",
         json_schema_extra={"x-unit_measurement": "currency"},
     )
@@ -323,7 +323,4 @@ class IntrinioOptionsSnapshotsFetcher(
         df = df.replace({NaT: None, np.nan: None})
         df = df.sort_values(by="volume", ascending=False)
 
-        return [
-            IntrinioOptionsSnapshotsData.model_validate(d)
-            for d in df.to_dict(orient="records")
-        ]
+        return [IntrinioOptionsSnapshotsData.model_validate(df.to_dict(orient="list"))]


### PR DESCRIPTION
1. **Why**?:

    - `to_df()` does not account for models where the fields are all arrays.
    - Large data sets can be returned as typed arrays, which improves overall execution time.

2. **What**?:

    - Add a condition where if the `results` is a list of 1 item, or just a model, AND all fields in the schema are defined as arrays, use a model dump to create the DataFrame.
    - Implement changes to `options_snapshots` models as a trial case.

3. **Impact**:

    - Improved response time for very large data sets.

    - Changes should only be noticed when the conditions above are realized, and there are not currently any models defined with this pattern.

4. **Testing Done**:

    - Checked `to_df` to ensure that other items have not been affected.
    - The dict[List] pattern is already tested for in `test_obbject`.

Using `relative_rotation` as a test-case that has a mix of arrays and other types, the current behaviour persists while allowing the item as all arrays to be correctly converted.

![Screenshot 2024-06-18 at 3 11 39 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/9a2d7557-e976-4697-8c58-909570fc94a2)
