### PR TITLE
[BugFix] Raise on  "Error Message" with FMP Econ Calendar

### DIFF
--- a/openbb_platform/providers/fmp/openbb_fmp/models/economic_calendar.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/economic_calendar.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 from warnings import warn
 
+from openbb_core.app.model.abstract.error import OpenBBError
 from openbb_core.provider.abstract.fetcher import Fetcher
 from openbb_core.provider.standard_models.economic_calendar import (
     EconomicCalendarData,
@@ -124,6 +125,8 @@ class FMPEconomicCalendarFetcher(
             try:
                 result = await amake_request(url, **kwargs)
                 if result:
+                        if "Error Message" in result:
+                            raise OpenBBError(result["Error Message"])
                     results.extend(result)
             except Exception as e:
                 if len(urls) == 1 or (len(urls) > 1 and n_urls == len(urls)):

--- a/openbb_platform/providers/fmp/openbb_fmp/models/economic_calendar.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/economic_calendar.py
@@ -125,8 +125,8 @@ class FMPEconomicCalendarFetcher(
             try:
                 result = await amake_request(url, **kwargs)
                 if result:
-                        if "Error Message" in result:
-                            raise OpenBBError(result["Error Message"])
+                    if "Error Message" in result:
+                        raise OpenBBError(result["Error Message"])
                     results.extend(result)
             except Exception as e:
                 if len(urls) == 1 or (len(urls) > 1 and n_urls == len(urls)):


### PR DESCRIPTION
1. **Why**?:

    - Error message that is slipping through from this end point.

2. **What**?:

    - Raises OpenBBError encapsulating the error message from the status 200 response.

3. **Impact**:

    - Better error message.

4. **Testing Done**:

![Screenshot 2024-06-22 at 4 00 09 PM](https://github.com/OpenBB-finance/OpenBBTerminal/assets/85772166/2bacf7dc-dd2a-4f95-a4c6-88798f303d86)
