### PR TITLE
[Bugfix] Uncover cmd len warn

### DIFF
--- a/cli/openbb_cli/config/menu_text.py
+++ b/cli/openbb_cli/config/menu_text.py
@@ -79,8 +79,8 @@ class MenuText:
                 self.warnings.append(
                     {
                         "warning": "Command name too long",
-                        "command": name,
-                        "trimmed_command": new_name,
+                        "actual command": f"`{name}`",
+                        "displayed command": f"`{new_name}`",
                     }
                 )
                 name = new_name

--- a/cli/openbb_cli/controllers/base_platform_controller.py
+++ b/cli/openbb_cli/controllers/base_platform_controller.py
@@ -381,9 +381,7 @@ class PlatformController(BaseController):
 
         session.console.print(text=mt.menu_text, menu=self.PATH)
 
-        settings = session.settings
-        dev_mode = settings.DEBUG_MODE or settings.TEST_MODE
-        if mt.warnings and dev_mode:
+        if mt.warnings:
             session.console.print("")
             for w in mt.warnings:
                 w_str = str(w).replace("{", "").replace("}", "").replace("'", "")

--- a/openbb_platform/providers/oecd/openbb_oecd/models/house_price_index.py
+++ b/openbb_platform/providers/oecd/openbb_oecd/models/house_price_index.py
@@ -130,7 +130,9 @@ class OECDHousePriceIndexFetcher(
                 url.replace(".M.RHPI.", ".Q.RHPI."), headers=headers
             )
         if response.status_code != 200:
-            raise Exception(f"Error with the OECD request: {response.status_code}")
+            raise OpenBBError(
+                f"Error with the OECD request (HTTP {response.status_code}): `{response.text}`"
+            )
         df = read_csv(StringIO(response.text)).get(
             ["REF_AREA", "TIME_PERIOD", "OBS_VALUE"]
         )


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Commands needs to be displayed differently than their original name if it's too big, and the user needs to be aware of this.

2. **What**? (1-3 sentences or a bullet point list):

    - The warning was already there but under dev configuration flags, simply removing.

3. **Impact** (1-2 sentences or a bullet point list):

    - NA

4. **Testing Done**:

    - Navigate to any many where this happens, example `economy` or `economy/survey`

5. **Reviewer Notes** (optional):

    
![image](https://github.com/OpenBB-finance/OpenBBTerminal/assets/48914296/d0e895b0-feb8-43c6-b1eb-9915d166b2ba)
