### PR TITLE
[BugFix] Charting Integration Tests

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/charts/chart.py
+++ b/openbb_platform/core/openbb_core/app/model/charts/chart.py
@@ -6,12 +6,6 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class ChartFormat(str, Enum):
-    """Chart format."""
-
-    plotly = "plotly"
-
-
 class Chart(BaseModel):
     """Model for Chart."""
 
@@ -19,8 +13,8 @@ class Chart(BaseModel):
         default=None,
         description="Raw textual representation of the chart.",
     )
-    format: Optional[ChartFormat] = Field(
-        default=ChartFormat.plotly,
+    format: Optional[str] = Field(
+        default=None,
         description="Complementary attribute to the `content` attribute. It specifies the format of the chart.",
     )
     fig: Optional[Any] = Field(

--- a/openbb_platform/core/openbb_core/app/model/charts/chart.py
+++ b/openbb_platform/core/openbb_core/app/model/charts/chart.py
@@ -1,6 +1,5 @@
 """OpenBB Core Chart model."""
 
-from enum import Enum
 from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/openbb_platform/core/tests/app/model/charts/test_chart.py
+++ b/openbb_platform/core/tests/app/model/charts/test_chart.py
@@ -1,7 +1,7 @@
 """Test the chart model."""
 
 import pytest
-from openbb_core.app.model.charts.chart import Chart, ChartFormat
+from openbb_core.app.model.charts.chart import Chart
 
 
 def test_charting_default_values():
@@ -11,14 +11,14 @@ def test_charting_default_values():
 
     # Assert
     assert chart.content is None
-    assert chart.format == ChartFormat.plotly
+    assert chart.format is None
 
 
 def test_charting_custom_values():
     """Test the charting custom values."""
     # Arrange
     content = {"data": [1, 2, 3]}
-    chart_format = ChartFormat.plotly
+    chart_format = "plotly"
 
     # Act
     chart = Chart(content=content, format=chart_format)
@@ -42,7 +42,7 @@ def test_charting_config_validation():
     """Test the charting config validation."""
     # Arrange
     content = {"data": [1, 2, 3]}
-    chart_format = ChartFormat.plotly
+    chart_format = "plotly"
 
     chart = Chart(content=content, format=chart_format)
 

--- a/openbb_platform/obbject_extensions/charting/integration/test_charting_api.py
+++ b/openbb_platform/obbject_extensions/charting/integration/test_charting_api.py
@@ -799,13 +799,17 @@ def test_charting_derivatives_futures_historical(params, headers):
         (
             {
                 "provider": "yfinance",
-                "symbol": "VX",
+                "symbol": "ES",
+                "date": None,
+                "chart": True,
             }
         ),
         (
             {
                 "provider": "cboe",
                 "symbol": "VX",
+                "date": "2024-06-25",
+                "chart": True,
             }
         ),
     ],

--- a/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
+++ b/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
@@ -654,7 +654,9 @@ def test_charting_derivatives_futures_historical(params, obb):
         (
             {
                 "provider": "yfinance",
-                "symbol": "VX",
+                "symbol": "ES",
+                "date": None,
+                "chart": True,
             }
         ),
         (
@@ -662,6 +664,7 @@ def test_charting_derivatives_futures_historical(params, obb):
                 "provider": "cboe",
                 "symbol": "VX",
                 "date": "2024-06-25",
+                "chart": True,
             }
         ),
     ],

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/charting.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/charting.py
@@ -64,6 +64,7 @@ class Charting:
         entry_point.load()
         for entry_point in entry_points(group="openbb_charting_extension")
     ]
+    _format = "plotly"  # the charts computed by this extension will be in plotly format
 
     def __init__(self, obbject):
         """Initialize Charting extension."""
@@ -361,7 +362,7 @@ class Charting:
             fig, content = charting_function(**kwargs)
             fig = self._set_chart_style(fig)
             content = fig.show(external=True, **kwargs).to_plotly_json()
-            self._obbject.chart = Chart(fig=fig, content=content)
+            self._obbject.chart = Chart(fig=fig, content=content, format=self._format)
             if render:
                 fig.show(**kwargs)
         except Exception:  # pylint: disable=W0718
@@ -369,7 +370,9 @@ class Charting:
                 fig = self.create_line_chart(data=self._obbject.results, render=False, **kwargs)  # type: ignore
                 fig = self._set_chart_style(fig)
                 content = fig.show(external=True, **kwargs).to_plotly_json()  # type: ignore
-                self._obbject.chart = Chart(fig=fig, content=content)
+                self._obbject.chart = Chart(
+                    fig=fig, content=content, format=self._format
+                )
                 if render:
                     return fig.show(**kwargs)  # type: ignore
             except Exception as e:
@@ -480,7 +483,9 @@ class Charting:
                 fig = self.create_line_chart(data=data_as_df, render=False, **kwargs)
                 fig = self._set_chart_style(fig)
                 content = fig.show(external=True, **kwargs).to_plotly_json()  # type: ignore
-                self._obbject.chart = Chart(fig=fig, content=content)
+                self._obbject.chart = Chart(
+                    fig=fig, content=content, format=self._format
+                )
                 if render:
                     return fig.show(**kwargs)  # type: ignore
             except Exception as e:  # pylint: disable=W0718


### PR DESCRIPTION
1. **Why**? (1-3 sentences or a bullet point list):

    - Charting integration tests breaking.

2. **What**? (1-3 sentences or a bullet point list):

    - Remotes the default value for the `Chart.format` and outsource that responsibility for the extension.
    - The extension explicitly says what's the format during chart creating (`obbject.chart = Chart(...)`)

3. **Impact** (1-2 sentences or a bullet point list):

    - NA

4. **Testing Done**:

    - Running integration tests.
    - Running endpoints with and without charting implementation (python + api)
